### PR TITLE
Fix pipeline references

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Auto Pipeline
+
+This repository contains a collection of Python scripts used to generate hook text from keywords and upload the results to Notion. The pipeline is executed via `run_pipeline.py` and consists of the following steps:
+
+1. `hook_generator.py` – generates hook sentences using GPT and stores them.
+2. `retry_failed_uploads.py` – retries any uploads that previously failed.
+3. `retry_dashboard_notifier.py` – updates the KPI dashboard in Notion.
+
+Earlier versions referenced `parse_failed_gpt.py` and `notify_retry_result.py`, but these scripts are no longer part of the process.
+
+## Running locally
+
+Install the required dependencies and execute the pipeline:
+
+```bash
+python run_pipeline.py
+```

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -11,12 +11,12 @@ logging.basicConfig(
 )
 
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
+# parse_failed_gpt.py 와 notify_retry_result.py 스크립트는 더 이상 사용하지 않
+# 습니다. 현재 파이프라인은 세 단계로 구성됩니다.
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    "retry_dashboard_notifier.py",
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------


### PR DESCRIPTION
## Summary
- prune unused `parse_failed_gpt.py` and `notify_retry_result.py` from the pipeline
- correct workflow to run the pipeline from repo root
- document pipeline steps in a new README

## Testing
- `python -m py_compile run_pipeline.py hook_generator.py notion_hook_uploader.py retry_dashboard_notifier.py retry_failed_uploads.py scripts/notion_uploader.py scripts/retry_failed_uploads.py keyword_auto_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_684ac1444e2c832e8dfadfe9197b9406