### PR TITLE
Fix pipeline script search path

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,17 +13,25 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    "retry_dashboard_notifier.py",
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
+REPO_ROOT = os.path.dirname(os.path.abspath(__file__))
+
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    possible_paths = [
+        os.path.join(REPO_ROOT, script),
+        os.path.join(REPO_ROOT, "scripts", script),
+    ]
+    full_path = None
+    for path in possible_paths:
+        if os.path.exists(path):
+            full_path = path
+            break
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- ensure run_pipeline searches scripts at repo root
- drop missing entries from PIPELINE_SEQUENCE

## Testing
- `python -m py_compile run_pipeline.py`
- `python -m py_compile hook_generator.py retry_failed_uploads.py retry_dashboard_notifier.py notion_hook_uploader.py keyword_auto_pipeline.py scripts/notion_uploader.py scripts/retry_failed_uploads.py`


------
https://chatgpt.com/codex/tasks/task_e_684b8326936c832e8d558396f0b6bd85