### PR TITLE
Add asynchronous blog pipeline modules

### DIFF
--- a/blog_automation_pipeline.py
+++ b/blog_automation_pipeline.py
@@ -1,0 +1,55 @@
+import logging
+import asyncio
+from data_sources import (
+    fetch_google_analytics,
+    fetch_search_console,
+    fetch_social_insights,
+    fetch_email_marketing,
+    fetch_industry_reports,
+)
+from feedback_loop import (
+    analyze_comment_sentiment,
+    monitor_social_mentions,
+    analyze_user_behavior,
+    apply_feedback,
+)
+from cross_platform_integrator import integrate_data
+
+# ---------------------- 로깅 설정 ----------------------
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+# ---------------------- 전체 파이프라인 ----------------------
+
+async def run_pipeline() -> None:
+    logging.info("블로그 자동화 파이프라인 시작")
+
+    # 1차 데이터 수집 병렬 실행
+    ga_task = asyncio.create_task(fetch_google_analytics())
+    sc_task = asyncio.create_task(fetch_search_console())
+    social_task = asyncio.create_task(fetch_social_insights())
+    email_task = asyncio.create_task(fetch_email_marketing())
+
+    # 2차 데이터 수집
+    industry_task = asyncio.create_task(fetch_industry_reports())
+
+    ga, sc, social, email, industry = await asyncio.gather(
+        ga_task, sc_task, social_task, email_task, industry_task
+    )
+
+    # 실시간 피드백 수집 병렬 실행
+    comments_fb = asyncio.create_task(analyze_comment_sentiment([]))
+    mentions_fb = asyncio.create_task(monitor_social_mentions("brand"))
+    behavior_fb = asyncio.create_task(analyze_user_behavior(ga))
+
+    feedback_results = await asyncio.gather(comments_fb, mentions_fb, behavior_fb)
+    feedback = {k: v for result in feedback_results for k, v in result.items()}
+    await apply_feedback(feedback)
+
+    # 데이터 통합
+    integrated = integrate_data(ga, sc, social, email, industry)
+    logging.info(f"통합 결과: {integrated}")
+    logging.info("파이프라인 종료")
+
+if __name__ == "__main__":
+    asyncio.run(run_pipeline())
+

--- a/cross_platform_integrator.py
+++ b/cross_platform_integrator.py
@@ -1,0 +1,26 @@
+import logging
+from typing import Dict, List
+
+# ---------------------- 로깅 설정 ----------------------
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+# ---------------------- 데이터 통합 ----------------------
+
+def integrate_data(*datasets: Dict) -> Dict:
+    """여러 플랫폼의 데이터를 통합"""
+    logging.info("데이터 통합 시작")
+
+    integrated: Dict[str, float | int | List] = {}
+    for data in datasets:
+        for key, value in data.items():
+            # 기존 키가 존재하면 값 합산 또는 업데이트
+            if isinstance(value, (int, float)):
+                integrated[key] = integrated.get(key, 0) + value
+            elif isinstance(value, list):
+                integrated.setdefault(key, []).extend(value)
+            else:
+                integrated[key] = value
+
+    logging.info("데이터 통합 완료")
+    return integrated
+

--- a/data_sources.py
+++ b/data_sources.py
@@ -1,0 +1,50 @@
+import logging
+import asyncio
+from typing import Dict
+
+import aiohttp
+
+# ---------------------- 로깅 설정 ----------------------
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+# ---------------------- 1차 데이터 소스 ----------------------
+
+async def fetch_google_analytics() -> Dict:
+    """Google Analytics에서 데이터 수집 (비동기)"""
+    logging.info("Google Analytics 데이터 수집 시작")
+    # TODO: 실제 Google Analytics API 호출 구현
+    await asyncio.sleep(0.1)
+    data = {"visits": 0, "conversions": 0}
+    logging.info("Google Analytics 데이터 수집 완료")
+    return data
+
+async def fetch_search_console() -> Dict:
+    """Search Console에서 데이터 수집 (비동기)"""
+    logging.info("Search Console 데이터 수집 시작")
+    await asyncio.sleep(0.1)
+    data = {"keywords": [], "impressions": 0}
+    logging.info("Search Console 데이터 수집 완료")
+    return data
+
+async def fetch_social_insights() -> Dict:
+    """소셜미디어 인사이트 수집 (비동기)"""
+    logging.info("소셜미디어 인사이트 수집 시작")
+    await asyncio.sleep(0.1)
+    return {"likes": 0, "shares": 0}
+
+async def fetch_email_marketing() -> Dict:
+    """이메일 마케팅 성과 데이터 수집 (비동기)"""
+    logging.info("이메일 성과 데이터 수집 시작")
+    await asyncio.sleep(0.1)
+    return {"open_rate": 0.0, "click_rate": 0.0}
+
+# ---------------------- 2차 데이터 소스 ----------------------
+
+async def fetch_industry_reports() -> Dict:
+    """외부 리포트나 통계 API 수집 (비동기)"""
+    logging.info("산업 리포트 데이터 수집 시작")
+    await asyncio.sleep(0.1)
+    data = {"market_growth": 0.0}
+    logging.info("산업 리포트 데이터 수집 완료")
+    return data
+

--- a/feedback_loop.py
+++ b/feedback_loop.py
@@ -1,0 +1,46 @@
+import logging
+import asyncio
+from typing import Dict, List
+
+import aiohttp
+
+# ---------------------- 로깅 설정 ----------------------
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+# ---------------------- 피드백 수집 ----------------------
+
+async def analyze_comment_sentiment(comments: List[str]) -> Dict:
+    """댓글 감정 분석 (비동기)"""
+    logging.info("댓글 감정 분석 시작")
+    await asyncio.sleep(0.05)
+    # TODO: 실제 감정 분석 로직 구현
+    result = {"positive": 0, "negative": 0}
+    logging.info("댓글 감정 분석 완료")
+    return result
+
+async def monitor_social_mentions(keyword: str) -> Dict:
+    """소셜 미디어 언급 모니터링 (비동기)"""
+    logging.info("소셜 언급 모니터링 시작")
+    await asyncio.sleep(0.05)
+    # TODO: SNS API 호출 로직 추가
+    result = {"mentions": 0}
+    logging.info("소셜 언급 모니터링 완료")
+    return result
+
+async def analyze_user_behavior(analytics_data: Dict) -> Dict:
+    """사용자 행동 분석 (비동기)"""
+    logging.info("사용자 행동 분석 시작")
+    await asyncio.sleep(0.05)
+    # TODO: 실제 분석 로직 구현
+    return {"bounce_rate": 0.0}
+
+# ---------------------- 피드백 루프 적용 ----------------------
+
+async def apply_feedback(feedback: Dict) -> bool:
+    """분석 결과를 컨텐츠 전략에 반영 (비동기)"""
+    logging.info("피드백 반영 시작")
+    await asyncio.sleep(0.05)
+    # TODO: DB 업데이트 또는 전략 수정 로직 구현
+    logging.info("피드백 반영 완료")
+    return True
+


### PR DESCRIPTION
## Summary
- refactor `data_sources` with async fetch functions
- enhance `feedback_loop` with async feedback collectors
- improve `cross_platform_integrator` to merge numeric and list data
- update `blog_automation_pipeline` to run async tasks concurrently

## Testing
- `python -m py_compile data_sources.py feedback_loop.py cross_platform_integrator.py blog_automation_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_684bc530d0c8832e8e9bab677b6ab13e