### PR TITLE
Add pipeline rate limiting and dashboard

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -1,0 +1,60 @@
+name: Main Pipeline
+
+env:
+  PYTHON_VERSION: "3.12"
+  # ↓ Token only needed for private repos
+  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  run-pipeline:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env: [prod]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y build-essential python3.12-dev
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.env }}-${{ hashFiles('requirements.txt', 'scripts/**.py', '*.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.env }}-
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          # avoid network-restricted hosts if mirror set
+          pip config set global.index-url https://pypi.python.org/simple || \
+          pip config set global.index-url https://pypi.kr/simple
+      - name: Pre-commit (lint/format/static)
+        uses: pre-commit/action@v3.0.1
+      - name: Pytest + coverage
+        run: |
+          pytest -q --cov=./ --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ env.CODECOV_TOKEN }}
+      - name: Datadog metric (fail)
+        if: failure()
+        run: |
+          curl -X POST -H "DD-API-KEY:${{ secrets.DD_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d '{"series":[{"metric":"pipeline.run","points":[['$(date +%s)',0]],"type":"count","tags":["env:${{ matrix.env }}","status:fail"]}]}' \
+            https://api.datadoghq.com/api/v1/series
+        timeout-minutes: 1

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,25 @@
+name: Release Docker Image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/auto_pipeline:${{ github.ref_name }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+default_language_version:
+  python: python3.12
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/pylint
+    rev: v3.2.2
+    hooks:
+      - id: pylint
+        language_version: python3.12
+        additional_dependencies:
+          - astroid==3.2.2
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.6.1
+    hooks:
+      - id: mypy
+        additional_dependencies: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+## [0.3.0] - 2025-06-15
+### Added
+- Dynamic import fallback 루트→scripts
+- Duplicate module detection & structured error log
+- Datadog 실패 태그(status:fail) 전송
+### Fixed
+- 캐시 restore-keys: 환경별 부분 캐시 재사용
+- pre-commit pylint 환경 문제 해결

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+### 스크립트 배치 규칙
+- **run_pipeline.py** 는 `PIPELINE_SEQUENCE`에 명시된 스크립트를 로드합니다.
+- 각 스크립트 파일은 **루트 또는 `scripts/` 중 하나에만** 존재해야 하며, 두 위치에 중복되면 CI가 실패합니다.
+
+### 개발 환경
+- Python 3.12 사용을 권장합니다.
+- 네트워크 제한이 있는 환경에서는 `pip config set global.index-url https://pypi.python.org/simple` 또는 사내 미러 주소를 설정해 주세요.

--- a/datadog/dashboard_pipeline.json
+++ b/datadog/dashboard_pipeline.json
@@ -1,0 +1,83 @@
+{
+  "title": "Auto_Pipeline Overview",
+  "widgets": [
+    {
+      "definition": {
+        "type": "timeseries",
+        "title": "Pipeline Run Success / Fail",
+        "requests": [
+          {
+            "q": "sum:pipeline.run{status:success} by {env}",
+            "display_type": "line",
+            "style": {"palette": "cool"}
+          },
+          {
+            "q": "sum:pipeline.run{status:fail} by {env}",
+            "display_type": "line",
+            "style": {"palette": "warm"}
+          }
+        ]
+      },
+      "layout": {"x": 0, "y": 0, "w": 47, "h": 15}
+    },
+    {
+      "definition": {
+        "type": "timeseries",
+        "title": "GPT Cost (USD)",
+        "requests": [
+          {
+            "q": "avg:gpt.usage.cost{*} by {env}",
+            "aggregator": "sum",
+            "display_type": "area"
+          }
+        ]
+      },
+      "layout": {"x": 0, "y": 16, "w": 23, "h": 15}
+    },
+    {
+      "definition": {
+        "type": "timeseries",
+        "title": "Notion Latency (ms)",
+        "requests": [
+          {
+            "q": "avg:notion.request.latency{*}.rollup(avg, 60)",
+            "display_type": "line"
+          }
+        ]
+      },
+      "layout": {"x": 24, "y": 16, "w": 23, "h": 15}
+    },
+    {
+      "definition": {
+        "type": "timeseries",
+        "title": "Twitter Fetch Duration (s)",
+        "requests": [
+          {
+            "q": "avg:twitter.fetch.time{*}.rollup(avg,60)",
+            "display_type": "line"
+          }
+        ]
+      },
+      "layout": {"x": 0, "y": 32, "w": 47, "h": 15}
+    },
+    {
+      "definition": {
+        "type": "timeseries",
+        "title": "HTTP 5xx Rate (%)",
+        "requests": [
+          {
+            "q": "100 * sum:service.http.errors{status:5xx} / sum:service.http.requests{*}",
+            "display_type": "line"
+          }
+        ]
+      },
+      "layout": {"x": 0, "y": 48, "w": 47, "h": 15}
+    }
+  ],
+  "template_variables": [
+    {"name": "env", "prefix": "env", "default": "prod"}
+  ],
+  "notify_list": ["slack-channel"],
+  "layout_type": "ordered",
+  "description": "Auto_Pipeline key metrics dashboard"
+}

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+disallow_untyped_defs = True
+ignore_missing_imports = True

--- a/scripts/logger.py
+++ b/scripts/logger.py
@@ -1,0 +1,32 @@
+"""Utility for JSON-formatted logging."""
+
+import json
+import logging
+from logging import Logger
+from typing import Any, Dict
+
+
+class JsonFormatter(logging.Formatter):
+    """Simple formatter that outputs log records as JSON strings."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        base: Dict[str, Any] = {
+            "level": record.levelname,
+            "message": record.getMessage(),
+            "name": record.name,
+        }
+        extra = getattr(record, "extra", None)
+        if isinstance(extra, dict):
+            base.update(extra)
+        return json.dumps(base)
+
+
+def setup_logger(name: str) -> Logger:
+    """Return a logger emitting JSON-formatted records."""
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
+    return logger

--- a/scripts/utils_rate.py
+++ b/scripts/utils_rate.py
@@ -1,0 +1,117 @@
+"""Async rate limiting utilities with retry support."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import TracebackType
+from typing import Any, Awaitable, Callable, TypeVar
+
+from aiolimiter import AsyncLimiter
+from tenacity import (RetryCallState, retry, retry_if_exception_type,
+                      stop_after_attempt, wait_exponential, wait_random)
+
+
+class CombinedLimiter:
+    """Combine multiple AsyncLimiters into one context manager."""
+
+    def __init__(self, *limiters: AsyncLimiter) -> None:
+        self.limiters = limiters
+
+    async def __aenter__(self) -> "CombinedLimiter":
+        for limiter in self.limiters:
+            await limiter.acquire()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        # aiolimiter does not expose a release method; tokens recover over time.
+        return None
+
+
+T = TypeVar("T")
+
+
+# ---------------------- Retry Helper ----------------------
+
+
+def _after_retry(retry_state: RetryCallState) -> None:
+    if retry_state.outcome is not None:  # type: ignore[truthy-bool]
+        err = retry_state.outcome.exception()  # type: ignore[union-attr]
+    else:
+        err = None
+    logging.warning("retry", extra={"error": str(err)})
+
+
+# ---------- Notion RateLimiter ----------
+NOTION_LIMITER = CombinedLimiter(AsyncLimiter(3, 1), AsyncLimiter(60, 60))
+
+
+def notion_rate_limited(
+    func: Callable[..., Awaitable[T]],
+) -> Callable[..., Awaitable[T]]:
+    """Wrap a coroutine with Notion-specific rate limits and retries."""
+
+    @retry(
+        wait=wait_exponential(multiplier=1, min=2, max=10) + wait_random(0, 1),
+        stop=stop_after_attempt(3),
+        after=_after_retry,
+    )
+    async def wrapper(
+        *args: Any, **kwargs: Any
+    ) -> T:  # pylint: disable=missing-function-docstring
+        # type: ignore[override]
+        async with NOTION_LIMITER:
+            return await func(*args, **kwargs)
+
+    return wrapper
+
+
+# ---------- Twitter RateLimiter ----------
+TWITTER_LIMITER = CombinedLimiter(
+    AsyncLimiter(5, 1),
+    AsyncLimiter(250, 60),
+    AsyncLimiter(50, 15),
+)
+
+
+def _maybe_retry_after(exc: BaseException) -> float:
+    """Return delay from Retry-After header when available."""
+    resp = getattr(exc, "response", None)
+    if resp is not None and getattr(resp, "status", None) == 429:
+        try:
+            return float(resp.headers.get("Retry-After", 0))
+        except (ValueError, TypeError, AttributeError):
+            return 0
+    return 0
+
+
+def twitter_rate_limited(
+    func: Callable[..., Awaitable[T]],
+) -> Callable[..., Awaitable[T]]:
+    """Twitter 스크레이퍼 전용 데코레이터."""
+
+    @retry(
+        wait=wait_exponential(multiplier=1, min=2, max=10) + wait_random(0, 1),
+        stop=stop_after_attempt(4),
+        retry=retry_if_exception_type(Exception),
+        after=_after_retry,
+    )
+    async def wrapper(
+        *args: Any, **kwargs: Any
+    ) -> T:  # pylint: disable=missing-function-docstring
+        # type: ignore[override]
+        async with TWITTER_LIMITER:
+            try:
+                return await func(*args, **kwargs)
+            except Exception as exc:  # pylint: disable=broad-except
+                delay = _maybe_retry_after(exc)
+                if delay:
+                    await asyncio.sleep(delay)
+                raise
+
+    return wrapper

--- a/tests/test_pipeline_load.py
+++ b/tests/test_pipeline_load.py
@@ -1,0 +1,17 @@
+"""Smoke test for the pipeline loader."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_pipeline_dry_run_smoke() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        ["python", str(repo_root / "run_pipeline.py"), "--dry-run"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -1,0 +1,104 @@
+"""Tests for run_pipeline module."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from shutil import copyfile
+
+from pytest import MonkeyPatch  # pylint: disable=import-error
+
+
+def test_run_pipeline_normal() -> None:
+    """Pipeline should exit with code 0 in dry-run mode."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        ["python", str(repo_root / "run_pipeline.py"), "--dry-run"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+
+
+def test_run_pipeline_duplicate_detection(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Duplicate module files should trigger ImportError and exit code 1."""
+
+    dup = tmp_path / "dup_step.py"
+    dup.write_text("def main(): pass")
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "dup_step.py").write_text("def main(): pass")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    copyfile(repo_root / "run_pipeline.py", tmp_path / "run_pipeline.py")
+    (tmp_path / "scripts").mkdir(exist_ok=True)
+    copyfile(repo_root / "scripts" / "logger.py", tmp_path / "scripts" / "logger.py")
+    copyfile(
+        repo_root / "scripts" / "__init__.py", tmp_path / "scripts" / "__init__.py"
+    )
+    monkeypatch.chdir(tmp_path)
+    result = subprocess.run(
+        ["python", "run_pipeline.py", "--only", "dup_step.py"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1
+    assert "duplicate_module" in result.stderr
+
+
+def test_run_pipeline_failure_exit_code(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """A failing step should cause the pipeline to exit with code 1."""
+
+    (tmp_path / "fail_step.py").write_text(
+        "def main():\n    raise RuntimeError('boom')\n"
+    )
+
+    repo_root = Path(__file__).resolve().parents[1]
+    copyfile(repo_root / "run_pipeline.py", tmp_path / "run_pipeline.py")
+    (tmp_path / "scripts").mkdir(exist_ok=True)
+    copyfile(repo_root / "scripts" / "logger.py", tmp_path / "scripts" / "logger.py")
+    copyfile(
+        repo_root / "scripts" / "__init__.py", tmp_path / "scripts" / "__init__.py"
+    )
+
+    monkeypatch.chdir(tmp_path)
+    result = subprocess.run(
+        ["python", "run_pipeline.py", "--only", "fail_step.py"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "step_failed" in result.stderr
+
+
+def test_run_pipeline_root_step(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Steps located at the repository root should load and execute."""
+
+    (tmp_path / "simple_step.py").write_text("def main():\n    print('ok')\n")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    copyfile(repo_root / "run_pipeline.py", tmp_path / "run_pipeline.py")
+    (tmp_path / "scripts").mkdir(exist_ok=True)
+    copyfile(repo_root / "scripts" / "logger.py", tmp_path / "scripts" / "logger.py")
+    copyfile(
+        repo_root / "scripts" / "__init__.py", tmp_path / "scripts" / "__init__.py"
+    )
+
+    monkeypatch.chdir(tmp_path)
+    result = subprocess.run(
+        ["python", "run_pipeline.py", "--only", "simple_step.py"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "step_completed" in result.stderr

--- a/tests/test_twitter_rate.py
+++ b/tests/test_twitter_rate.py
@@ -1,0 +1,66 @@
+"""Tests for Twitter rate limiter utilities."""
+
+import asyncio
+import sys
+import time
+from pathlib import Path
+from typing import Any, Coroutine, cast
+
+import pytest
+from tenacity import RetryError
+
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[1])
+)  # pylint: disable=wrong-import-position
+
+from scripts.utils_rate import (  # pylint: disable=wrong-import-position
+    TWITTER_LIMITER, twitter_rate_limited)
+
+
+async def dummy_twitter_call() -> None:
+    """Acquire the limiter once."""
+    async with TWITTER_LIMITER:
+        return
+
+
+def test_twitter_rate_limiter() -> None:
+    """Ensure rate limiter throttles bursts."""
+
+    async def _run() -> float:
+        start = time.perf_counter()
+        await asyncio.gather(*(dummy_twitter_call() for _ in range(20)))
+        return time.perf_counter() - start
+
+    duration = asyncio.run(_run())
+    assert duration >= 3
+
+
+class DummyHTTPError(Exception):
+    """Simulate httpx.HTTPStatusError with Retry-After header."""
+
+    def __init__(self, retry_after: int) -> None:
+        self.response = type(
+            "Resp",
+            (),
+            {"status": 429, "headers": {"Retry-After": str(retry_after)}},
+        )
+
+
+def test_retry_after_respected() -> None:
+    """Wrapper should sleep based on Retry-After header."""
+    calls: list[int] = []
+
+    async def failing() -> None:
+        """Always raise HTTP 429."""
+        calls.append(1)
+        raise DummyHTTPError(1)
+
+    wrapped = twitter_rate_limited(failing)
+
+    start = time.perf_counter()
+    coro = wrapped()
+    with pytest.raises(RetryError):
+        asyncio.run(cast(Coroutine[Any, Any, None], coro))
+    duration = time.perf_counter() - start
+    assert len(calls) == 4
+    assert duration >= 1


### PR DESCRIPTION
## Summary
- implement Twitter API rate limiter with async wrapper
- add Datadog dashboard template JSON
- call Twitter scraper via asyncio in keyword pipeline
- include rate limiter test
- fix lint setup and add retries with jitter
- strengthen run_pipeline tests and fix import bug

## Testing
- `pre-commit run --files run_pipeline.py tests/test_run_pipeline.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684dcfe9fe40832e8bf5ec281cad3626