### PR TITLE
Improve keyword pipeline revenue targeting

### DIFF
--- a/tests/test_keyword_pipeline.py
+++ b/tests/test_keyword_pipeline.py
@@ -1,0 +1,19 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from keyword_auto_pipeline import select_top_keywords
+
+class TestSelectTopKeywords(unittest.TestCase):
+    def test_select_top_keywords(self):
+        sample = [
+            {'keyword': 'A', 'cpc': 1500},
+            {'keyword': 'B', 'cpc': 2000},
+            {'keyword': 'A', 'cpc': 1800},  # duplicate with higher CPC
+            {'keyword': 'C', 'cpc': 500},
+        ]
+        result = select_top_keywords(sample, top_n=2)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]['keyword'], 'B')
+        self.assertEqual(result[1]['keyword'], 'A')


### PR DESCRIPTION
## Summary
- limit output to high CPC keywords
- add helper to sort and deduplicate keywords
- unit test for top-keyword selection

## Testing
- `pytest -q`
- `pylint keyword_auto_pipeline.py`
- `mypy --ignore-missing-imports keyword_auto_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_684dfcde5380832e9fd2a8236c18323d