### PR TITLE
Add CLI and docs for Content Automation Pipeline

### DIFF
--- a/.github/workflows/auto_pipeline.yml
+++ b/.github/workflows/auto_pipeline.yml
@@ -1,0 +1,28 @@
+name: Run Content Pipeline
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 10 * * *"
+
+jobs:
+  run-pipeline:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+
+      - name: Run CLI pipeline
+        run: |
+          python cli.py --topic "future of ecommerce" --token ${{ secrets.WORDPRESS_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
+
+CMD ["streamlit", "run", "dashboard.py"]

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,15 @@
+import argparse
+from pipeline_orchestrator import run_pipeline
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Content Automation Pipeline CLI")
+    parser.add_argument("--topic", required=True, help="Enter the main topic to generate content")
+    parser.add_argument("--token", required=True, help="WordPress or platform API token")
+
+    args = parser.parse_args()
+    run_pipeline(topic=args.topic, token=args.token)
+
+
+if __name__ == "__main__":
+    main()

--- a/content_writer.py
+++ b/content_writer.py
@@ -1,0 +1,8 @@
+from textwrap import fill
+
+
+def generate_article(keyword: str, word_count: int = 300) -> str:
+    """Generate a dummy article containing the keyword."""
+    sentence = f"This article discusses {keyword} in depth. "
+    content = (sentence * (word_count // len(sentence.split()))).strip()
+    return fill(content, 80)

--- a/pipeline_flow.md
+++ b/pipeline_flow.md
@@ -1,0 +1,13 @@
+```mermaid
+graph TD
+    A[Keyword Generator] --> B[Content Writer]
+    B --> C[Editor & SEO Optimizer]
+    C --> D[QA Filter]
+    D --> E{Is Content Safe?}
+    E -- Yes --> F[Hook Uploader (WP, Medium, etc)]
+    E -- No --> G[Log & Skip]
+    F --> H[Notion Sync - Content Tracker]
+    H --> I[Schedule Next Upload]
+    I --> J[Slack Notification]
+    J --> K[Done]
+```

--- a/pipeline_orchestrator.py
+++ b/pipeline_orchestrator.py
@@ -1,0 +1,6 @@
+import run_pipeline as rp
+
+
+def run_pipeline(topic: str, token: str) -> None:
+    """Execute the main pipeline. Topic and token are reserved for future use."""
+    rp.run_pipeline()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+openai
+requests
+notion-client
+schedule
+streamlit
+pytest

--- a/tests/test_content_writer.py
+++ b/tests/test_content_writer.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from content_writer import generate_article
+
+
+def test_generate_article_output():
+    keyword = "AI Marketing Trends"
+    result = generate_article(keyword, word_count=300)
+    assert isinstance(result, str)
+    assert len(result.split()) >= 250
+    assert keyword.lower() in result.lower()


### PR DESCRIPTION
## Summary
- add mermaid flow chart for Content Automation Pipeline
- implement argparse CLI entrypoint
- provide orchestrator shim
- add Dockerfile and requirements
- set up GitHub Actions workflow
- add dummy content writer and pytest

## Testing
- `mypy --ignore-missing-imports --exclude scripts .`
- `pylint $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e73b927a0832e8dcdc8482359d446