### PR TITLE
Add Feast feature store skeleton

### DIFF
--- a/.github/workflows/feast.yml
+++ b/.github/workflows/feast.yml
@@ -1,0 +1,20 @@
+name: Feast Update
+on:
+  push:
+    paths: ["feature_store/**"]
+jobs:
+  registry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Feast
+        run: pip install feast[redis,kafka]
+      - name: Build registry
+        run: |
+          cd feature_store/feature_repo
+          feast apply
+      - name: Deploy ingest worker
+        uses: render-examples/action-render-deploy@v1
+        with:
+          api-key: ${{ secrets.RENDER_API_KEY }}
+          service-id: ${{ secrets.RENDER_FEAST_INGEST_ID }}

--- a/feast_stream_ingest.py
+++ b/feast_stream_ingest.py
@@ -1,0 +1,22 @@
+import json, os, asyncio, aiokafka, redis
+
+KAFKA_BROKERS = os.getenv("KAFKA_BROKERS", "kafka:9092").split(",")
+r = redis.Redis(host="redis", port=6379)
+
+async def stream():
+    consumer = aiokafka.AIOKafkaConsumer(
+        "vinfinity.events",
+        bootstrap_servers=KAFKA_BROKERS,
+        value_deserializer=lambda v: json.loads(v.decode())
+    )
+    await consumer.start()
+    async for msg in consumer:
+        evt = msg.value
+        uid = evt["user_id"]
+        key = f"user:{uid}:5m"
+        if evt["event"] == "view":   r.hincrby(key, "views_5m", 1)
+        if evt["event"] == "click":  r.hincrby(key, "clicks_5m", 1)
+        r.expire(key, 3600)
+    await consumer.stop()
+
+asyncio.run(stream())

--- a/feature_store/docker-compose.feast.yml
+++ b/feature_store/docker-compose.feast.yml
@@ -1,0 +1,21 @@
+version: "3.9"
+services:
+  redis:
+    image: redis:7
+    ports: ["6379:6379"]
+
+  kafka:
+    image: bitnami/kafka:3
+    environment:
+      - KAFKA_LISTENERS=INTERNAL://:9092,EXTERNAL://:29092
+      - KAFKA_ADVERTISED_LISTENERS=INTERNAL://kafka:9092,EXTERNAL://localhost:29092
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - ALLOW_PLAINTEXT_LISTENER=yes
+    ports: ["29092:29092"]
+
+  feast-ingest:
+    build: .
+    command: python feast_stream_ingest.py
+    depends_on: [kafka, redis]
+    environment:
+      - KAFKA_BROKERS=kafka:9092

--- a/feature_store/feature_repo/data_sources.py
+++ b/feature_store/feature_repo/data_sources.py
@@ -1,0 +1,16 @@
+from feast import KafkaSource, PushSource, FileSource
+from feast.data_format import JsonFormat
+from datetime import timedelta
+
+event_kafka = KafkaSource(
+    name="event_kafka",
+    bootstrap_servers="${KAFKA_BROKERS}",
+    topic="vinfinity.events",
+    timestamp_field="occurred_at",
+    message_format=JsonFormat(),
+)
+
+conversion_file = FileSource(
+    path="file:///app/data/conversions.parquet",
+    timestamp_field="occurred_at",
+)

--- a/feature_store/feature_repo/event_features.py
+++ b/feature_store/feature_repo/event_features.py
@@ -1,0 +1,18 @@
+from feast import Entity, FeatureView, Field, ValueType
+from feast.types import Float32, Int64
+from data_sources import event_kafka
+from datetime import timedelta
+
+user = Entity(name="user_id", join_keys=["user_id"])
+
+event_features = FeatureView(
+    name="user_events_5m",
+    entities=[user],
+    ttl=timedelta(hours=1),
+    schema=[
+        Field(name="views_5m", dtype=Int64),
+        Field(name="clicks_5m", dtype=Int64),
+    ],
+    source=event_kafka,
+    timestamp_field="occurred_at",
+)

--- a/feature_store/feature_repo/feature_store.yaml
+++ b/feature_store/feature_repo/feature_store.yaml
@@ -1,0 +1,9 @@
+project: vinfinity
+registry: feast_registry.db
+provider: local
+online_store:
+  type: redis
+  connection_string: "redis://redis:6379"
+offline_store:
+  type: file
+entity_key_serialization_version: 2

--- a/feature_store/feature_repo/user_features.py
+++ b/feature_store/feature_repo/user_features.py
@@ -1,0 +1,18 @@
+from feast import Entity, FeatureView, Field, FileSource
+from feast.types import Int64, Float32
+from data_sources import conversion_file
+from datetime import timedelta
+
+user = Entity(name="user_id", join_keys=["user_id"])
+
+conversion_features = FeatureView(
+    name="user_conversion_stats",
+    entities=[user],
+    ttl=timedelta(days=90),
+    schema=[
+        Field(name="total_revenue", dtype=Float32),
+        Field(name="purchases", dtype=Int64),
+    ],
+    source=conversion_file,
+    timestamp_field="occurred_at",
+)

--- a/personalization_service.py
+++ b/personalization_service.py
@@ -1,0 +1,14 @@
+from feast import FeatureStore
+
+store = FeatureStore(repo_path="feature_store/feature_repo")
+
+def feature_row(user_id):
+    feats = store.get_online_features(
+        features=[
+            "user_events_5m:views_5m",
+            "user_events_5m:clicks_5m",
+            "user_conversion_stats:total_revenue",
+        ],
+        entity_rows=[{"user_id": user_id}]
+    ).to_dict()
+    return {k: v[0] for k, v in feats.items()}


### PR DESCRIPTION
## Summary
- implement Feast feature store skeleton with Kafka & Redis
- add ingestion worker
- create personalization service feature lookup
- include Docker Compose and GitHub Action for registry updates

## Testing
- `pytest -q`
- `pylint *.py scripts/*.py feature_store/feature_repo/*.py personalization_service.py`

------
https://chatgpt.com/codex/tasks/task_e_684e83dc79f4832ea7e0bff179157d9d