### PR TITLE
Add SaaS infra extensions

### DIFF
--- a/hook_generator.py
+++ b/hook_generator.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from dotenv import load_dotenv
 import openai
+from llm_monitor.phoenix_init import instrument_openai  # auto-imports & patches
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()

--- a/vinfinity_saas_production_bundle_v1.0/.github/workflows/wandb_sweep.yml
+++ b/vinfinity_saas_production_bundle_v1.0/.github/workflows/wandb_sweep.yml
@@ -1,0 +1,12 @@
+on:
+  workflow_dispatch:
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: pip install wandb openai
+      - env:
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: python ml/fine_tune_wandb.py

--- a/vinfinity_saas_production_bundle_v1.0/docker-compose.yml
+++ b/vinfinity_saas_production_bundle_v1.0/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  phoenix:
+    image: arizephoenix/phoenix:latest
+    ports:
+      - "6006:6006"

--- a/vinfinity_saas_production_bundle_v1.0/edge/ab_router.js
+++ b/vinfinity_saas_production_bundle_v1.0/edge/ab_router.js
@@ -1,0 +1,12 @@
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const uid = request.headers.get("CF-Connecting-IP");
+    const variant = await env.KV_AB.get(uid) ||
+      (Math.random() < 0.5 ? "A" : "B");
+    await env.KV_AB.put(uid, variant, { expirationTtl: 86400 });
+
+    url.pathname = variant === "A" ? "/index-a.html" : "/index-b.html";
+    return fetch(url, request);
+  }
+}

--- a/vinfinity_saas_production_bundle_v1.0/feature_repo/feature_store.yaml
+++ b/vinfinity_saas_production_bundle_v1.0/feature_repo/feature_store.yaml
@@ -1,0 +1,5 @@
+online_store:
+  type: dynamodb
+  region: ap-northeast-2
+  aws_access_key_id: ${AWS_KEY}
+  aws_secret_access_key: ${AWS_SECRET}

--- a/vinfinity_saas_production_bundle_v1.0/llm_monitor/phoenix_init.py
+++ b/vinfinity_saas_production_bundle_v1.0/llm_monitor/phoenix_init.py
@@ -1,0 +1,5 @@
+from phoenix.trace.openai import instrument_openai
+import os
+
+phoenix_server = os.getenv("PHOENIX_HOST", "http://phoenix:6006")
+instrument_openai(server_url=phoenix_server)

--- a/vinfinity_saas_production_bundle_v1.0/ml/fine_tune_wandb.py
+++ b/vinfinity_saas_production_bundle_v1.0/ml/fine_tune_wandb.py
@@ -1,0 +1,13 @@
+import wandb, openai, os, json
+wandb.init(project="vInfinity-ft")
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+train_file = openai.File.create(
+    file=open("data/fine_tune.jsonl", "rb"), purpose="fine-tune"
+)
+job = openai.FineTuningJob.create(
+    training_file=train_file.id,
+    model="gpt-3.5-turbo",
+    hyperparameters={"n_epochs": 3}
+)
+wandb.log({"job_id": job.id})

--- a/vinfinity_saas_production_bundle_v1.0/prometheus/phoenix_rules.yml
+++ b/vinfinity_saas_production_bundle_v1.0/prometheus/phoenix_rules.yml
@@ -1,0 +1,3 @@
+- alert: LLMHighLatency
+  expr: phoenix_llm_latency_seconds_mean > 2
+  for: 2m

--- a/vinfinity_saas_production_bundle_v1.0/terraform/dynamodb.tf
+++ b/vinfinity_saas_production_bundle_v1.0/terraform/dynamodb.tf
@@ -1,0 +1,9 @@
+resource "aws_dynamodb_table" "feast_online" {
+  name         = "feast-vinfinity"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "entity_id"
+  attribute {
+    name = "entity_id"
+    type = "S"
+  }
+}

--- a/vinfinity_saas_production_bundle_v1.0/vinfinity_flow_v7.md
+++ b/vinfinity_saas_production_bundle_v1.0/vinfinity_flow_v7.md
@@ -1,0 +1,9 @@
+```mermaid
+flowchart TD
+    GPT-->Phoenix
+    User-->CloudflareWorker-->A/B_Page
+    Phoenix-->Prometheus-->Grafana
+    BigQuery--train-->WandB
+    FeastRedis-->DynamoDB
+    DynamoDB-->PersonalizationService
+```

--- a/vinfinity_saas_production_bundle_v1.0/wrangler.toml
+++ b/vinfinity_saas_production_bundle_v1.0/wrangler.toml
@@ -1,0 +1,3 @@
+name = "vinfinity-ab-router"
+main = "edge/ab_router.js"
+kv_namespaces = [{ binding = "KV_AB", id = "xxxx" }]


### PR DESCRIPTION
## Summary
- integrate Phoenix monitoring via `phoenix_init.py`
- add Cloudflare Workers A/B router and wrangler config
- include WandB fine-tuning script and workflow
- configure Feast online store for DynamoDB with Terraform
- document updated flow

## Testing
- `pylint hook_generator.py`
- `mypy hook_generator.py` *(fails: missing stubs)*
- `pytest -q` *(no tests discovered)*

------
https://chatgpt.com/codex/tasks/task_e_684e841edd08832e814fc3c25d800cc6