### PR TITLE
Add monitoring and automation modules

### DIFF
--- a/.github/workflows/wandb_cycle.yml
+++ b/.github/workflows/wandb_cycle.yml
@@ -1,0 +1,18 @@
+name: W\&B Finetune Cycle
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  finetune:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: |
+          python -m pip install --upgrade pip
+          pip install wandb openai
+      - run: python ml/wandb_schedule.py

--- a/edge/log_ab_result.js
+++ b/edge/log_ab_result.js
@@ -1,0 +1,15 @@
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const uid = request.headers.get("CF-Connecting-IP");
+    const variant = await env.KV_AB.get(uid) || "A";
+    // Supabase Edge Log
+    await fetch(env.SUPABASE_EDGE_URL + "/log", {
+      method: "POST",
+      headers: { "apikey": env.SUPABASE_EDGE_KEY },
+      body: JSON.stringify({ uid, variant, path: url.pathname })
+    });
+    url.pathname = variant === "A" ? "/index-a.html" : "/index-b.html";
+    return fetch(url, request);
+  }
+}

--- a/feature_store/cleanup.py
+++ b/feature_store/cleanup.py
@@ -1,0 +1,13 @@
+import os
+import time
+
+import boto3
+
+ddb = boto3.client("dynamodb", region_name="ap-northeast-2")
+TABLE = os.getenv("FEAST_TABLE", "feast-vinfinity")
+
+def cleanup():
+    paginator = ddb.scan(TableName=TABLE, ProjectionExpression="entity_id, ttl")
+    for item in paginator.get("Items", []):
+        if int(item["ttl"]["N"]) < time.time():
+            ddb.delete_item(TableName=TABLE, Key={"entity_id": item["entity_id"]})

--- a/infra/lambda_warm.tf
+++ b/infra/lambda_warm.tf
@@ -1,0 +1,17 @@
+resource "aws_lambda_function" "warm_feast" {
+  function_name = "warm_feast_store"
+  runtime       = "python3.10"
+  handler       = "cleanup.lambda_handler"
+  filename      = "feature_store/cleanup.zip"
+  timeout       = 10
+}
+
+resource "aws_cloudwatch_event_rule" "every_5min" {
+  schedule_expression = "rate(5 minutes)"
+}
+
+resource "aws_cloudwatch_event_target" "warm_target" {
+  rule      = aws_cloudwatch_event_rule.every_5min.name
+  target_id = "lambda"
+  arn       = aws_lambda_function.warm_feast.arn
+}

--- a/llm_monitor/phoenix_alert.py
+++ b/llm_monitor/phoenix_alert.py
@@ -1,0 +1,10 @@
+import os
+import json
+import requests
+
+SLACK = os.getenv("SLACK_WEBHOOK")
+
+def alert(rule, evt):
+    msg = f"\ud83d\udea8 *{rule['id']}* - {evt['trace_id']}\n{rule['description']}"
+    if SLACK:
+        requests.post(SLACK, json={"text": msg})

--- a/llm_monitor/phoenix_rules.yaml
+++ b/llm_monitor/phoenix_rules.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: high_toxicity
+    description: "Toxicity > 0.7"
+    filter: "event_type == 'completion'"
+    condition: "metrics.toxicity > 0.7"
+    severity: warning
+
+  - id: semantic_drift
+    description: "Cosine drift > 0.25"
+    filter: "event_type == 'completion'"
+    condition: "metrics.embedding_cosine_drift > 0.25"
+    severity: critical

--- a/ml/wandb_schedule.py
+++ b/ml/wandb_schedule.py
@@ -1,0 +1,28 @@
+import os
+import subprocess
+import datetime
+import json
+
+import wandb
+import openai
+
+wandb.login()
+
+def launch_finetune():
+    run = wandb.init(project="vinfinity-ft", job_type="train")
+    job = openai.FineTuningJob.create(
+        training_file=os.getenv("FT_TRAIN_FILE"),
+        model="gpt-3.5-turbo",
+        hyperparameters={"n_epochs": 1}
+    )
+    run.log({"job_id": job.id})
+    run.finish()
+
+def canary_deploy(model_id):
+    subprocess.run([
+        "wrangler", "kv:key", "put",
+        "MODEL_CANARY", model_id, "--namespace", os.getenv("KV_AB")
+    ])
+
+if __name__ == "__main__":
+    launch_finetune()

--- a/phoenix_init.py
+++ b/phoenix_init.py
@@ -1,0 +1,5 @@
+from phoenix.alerting import AlertManager
+from llm_monitor.phoenix_alert import alert
+
+# Register alerting rules for LLM monitoring
+AlertManager.add_yaml("llm_monitor/phoenix_rules.yaml", callback=alert)


### PR DESCRIPTION
## Summary
- monitor LLM output with Phoenix rules and Slack alerts
- log Cloudflare Worker A/B test data to Supabase
- schedule W&B finetuning and optional canary deploy
- clean Feast features with DynamoDB TTL and keep lambda warm

## Testing
- `pylint llm_monitor/phoenix_alert.py ml/wandb_schedule.py feature_store/cleanup.py phoenix_init.py` *(fails: missing docstrings, import errors)*
- `mypy llm_monitor/phoenix_alert.py ml/wandb_schedule.py feature_store/cleanup.py phoenix_init.py` *(fails: missing stubs)*
- `pytest` *(no tests ran)*
- `sqlfluff lint`

------
https://chatgpt.com/codex/tasks/task_e_684e84b2d0bc832eb225e0d149b6b66a