### PR TITLE
Add global caching, infra scripts and sampling

### DIFF
--- a/edge/geo_llm_cache.js
+++ b/edge/geo_llm_cache.js
@@ -1,0 +1,13 @@
+export default {
+  async fetch(request, env) {
+    const { continent } = request.cf || {};
+    const key = `llm:${continent}:${btoa(request.url)}`;
+    let cached = await env.LLM_CACHE.get(key);
+    if (!cached) {
+      const resp = await fetch(request);              // Origin → GPT Proxy
+      cached = await resp.text();
+      await env.LLM_CACHE.put(key, cached, { expirationTtl: 60 });
+    }
+    return new Response(cached, { headers: { "Cache-Control": "max-age=60" }});
+  }
+}

--- a/feast_stream_ingest.py
+++ b/feast_stream_ingest.py
@@ -1,0 +1,15 @@
+import aiokafka
+
+KAFKA_BROKERS = "localhost:9092"
+
+producer = aiokafka.AIOKafkaProducer(
+    bootstrap_servers=KAFKA_BROKERS,
+    transactional_id="vinfinity-producer",
+    enable_idempotence=True,
+    acks="all",
+)
+
+async def ingest(msg):
+    await producer.start_transaction()
+    await producer.send_and_wait("vinfinity.events", msg.encode())
+    await producer.commit_transaction()

--- a/infra/dynamo_multi_az.tf
+++ b/infra/dynamo_multi_az.tf
@@ -1,0 +1,18 @@
+resource "aws_dynamodb_table" "feast_online" {
+  name         = "feast-vinfinity"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "entity_id"
+  attribute { name="entity_id" type="S" }
+
+  point_in_time_recovery { enabled=true }
+  replica {
+    region_name = "us-west-2"
+  }
+}
+
+resource "aws_dax_cluster" "feast_dax" {
+  cluster_name = "feast-dax"
+  iam_role_arn = aws_iam_role.dax.arn
+  node_type    = "dax.r5.large"
+  replication_factor = 3
+}

--- a/infra/migrate_state.sh
+++ b/infra/migrate_state.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+TF_STATE="tfstate.json"
+pulumi stack init dev || true
+
+# 1) terraform state export
+terraform show -json > $TF_STATE
+
+# 2) import to pulumi
+pulumi import --file $TF_STATE
+pulumi state copy --from terraform
+echo "✅  Terraform state migrated to Pulumi."

--- a/kafka/config/eos.properties
+++ b/kafka/config/eos.properties
@@ -1,0 +1,4 @@
+transactional.id=vinfinity-producer
+enable.idempotence=true
+acks=all
+max.in.flight.requests.per.connection=5

--- a/llm_monitor/phoenix_sampling.py
+++ b/llm_monitor/phoenix_sampling.py
@@ -1,0 +1,7 @@
+import random
+from phoenix.trace import set_trace_config
+
+def sample_trace(trace):
+    return random.random() < 0.01   # 1% 샘플
+
+set_trace_config(should_trace=sample_trace)

--- a/phoenix_init.py
+++ b/phoenix_init.py
@@ -1,0 +1,1 @@
+from llm_monitor.phoenix_sampling import sample_trace

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,4 @@
+kv_namespaces = [{ binding="LLM_CACHE", id="kv_llm_cache" }]
+routes = [
+  { pattern="https://api.vinfinity.ai/*", script="geo_llm_cache" }
+]


### PR DESCRIPTION
## Summary
- add Geo LLM cache worker and wrangler config
- enable Phoenix trace sampling
- script and terraform for infra migrations
- configure Kafka EOS producer

## Testing
- `pytest -q`
- `pylint *.py scripts/*.py llm_monitor/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684e852c562c832eb3b3c55276d9b582