### PR TITLE
Integrate Hyper-Scale v10 modules

### DIFF
--- a/edge/kv_to_r2.js
+++ b/edge/kv_to_r2.js
@@ -1,0 +1,13 @@
+export default {
+  async fetch(req, env) {
+    const key = new URL(req.url).pathname;
+    let val = await env.KV_CACHE.get(key);
+    if (!val) {
+      val = await env.R2_BUCKET.get(key);             // ❶ R2 cold fetch
+      if (val) await env.KV_CACHE.put(key, val.body, { expirationTtl: 60 });
+    }
+    // PUT 키(60초 넘은 값) → R2
+    req.cf?.cacheTtl === 0 && env.R2_BUCKET.put(key, val, { httpMetadata: req.headers });
+    return new Response(val);
+  }
+}

--- a/grafana/bandit_panel.sql
+++ b/grafana/bandit_panel.sql
@@ -1,0 +1,3 @@
+SELECT variant, SUM(conversions)::float / NULLIF(SUM(views),0) AS ctr
+FROM ab_test_queue
+GROUP BY variant ORDER BY ctr DESC;

--- a/k8s/gpu_quota.yml
+++ b/k8s/gpu_quota.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: gpu-quota-teamA
+  namespace: team-a
+spec:
+  hard:
+    nvidia.com/gpu: "40"          # 팀당 GPU 최대 40
+---
+apiVersion: scheduling.x-k8s.io/v1
+kind: ElasticQuota
+metadata: { name: team-a-elastic }
+spec:
+  max:
+    nvidia.com/gpu: "40"
+  min:
+    nvidia.com/gpu: "4"

--- a/kafka/connect/iceberg_sink.json
+++ b/kafka/connect/iceberg_sink.json
@@ -1,0 +1,10 @@
+{
+  "name": "iceberg-sink",
+  "connector.class": "org.apache.iceberg.kafka.ConnectSink",
+  "topics": "vinfinity.events",
+  "iceberg.catalog": "aws",
+  "iceberg.table": "vinfinity.event_log",
+  "s3.path": "s3a://vinfinity-lake/",
+  "tasks.max": "4",
+  "exactly.once.support": "required"
+}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1,0 +1,7 @@
+global:
+  prometheus:
+    enabled: false          # 외부 Prometheus 사용
+kubecostProductConfigs:
+  productKeySecretName: KUBECOST_KEY
+  gpuUsageMetrics: true
+  networkCosts: true

--- a/ml/bandit_optimizer.py
+++ b/ml/bandit_optimizer.py
@@ -1,0 +1,29 @@
+"""Thompson-sampling based variant selection utilities."""
+
+try:
+    from db_utils import get_conn
+except ImportError:  # pragma: no cover - optional dependency
+    get_conn = None
+import numpy as np
+import pandas as pd
+
+
+def choose_variant(content_id: int) -> str:
+    """Return the best variant using Thompson Sampling."""
+    if get_conn is None:
+        raise ImportError("db_utils is required for choose_variant")
+
+    with get_conn() as conn:
+        df = pd.read_sql(
+            """
+          SELECT variant, views, conversions
+          FROM ab_test_queue
+          WHERE content_id=%s
+        """,
+            conn,
+            params=(content_id,),
+        )
+    alpha = 1 + df["conversions"]
+    beta = 1 + df["views"] - df["conversions"]
+    theta = np.random.beta(alpha, beta)
+    return df.loc[theta.idxmax(), "variant"]

--- a/trino/catalog/iceberg.properties
+++ b/trino/catalog/iceberg.properties
@@ -1,0 +1,3 @@
+connector.name=iceberg
+catalog.warehouse=s3a://vinfinity-lake/
+hive.metastore.uri=thrift://hive-metastore:9083

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,2 @@
+kv_namespaces = [{ binding="KV_CACHE", id="kv_llm_cache" }]
+r2_buckets = [{ binding="R2_BUCKET", bucket_name="vinfinity-cache" }]


### PR DESCRIPTION
## Summary
- add GPU quota and Kubecost configs
- implement KV→R2 tiering worker script
- introduce RL bandit optimizer module and Grafana query
- include Iceberg sink and Trino catalog for Zero‑ETL lakehouse

## Testing
- `pytest -q`
- `pylint ml/bandit_optimizer.py`
- `mypy ml/bandit_optimizer.py` *(fails: Cannot find implementation or library stub for module named "db_utils")*
- `sqlfluff lint grafana/bandit_panel.sql --dialect postgres` *(fails: layout violations)*

------
https://chatgpt.com/codex/tasks/task_e_684e8633ab18832e883b0179d7c79533