### PR TITLE
Add GitOps IaC v2.4 example

### DIFF
--- a/vinfinity_gitops_v2.4/.github/workflows/argo-sync.yml
+++ b/vinfinity_gitops_v2.4/.github/workflows/argo-sync.yml
@@ -1,0 +1,22 @@
+name: ArgoCD Sync
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "k8s/**"
+      - "argo/**"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Trigger ArgoCD Refresh
+        run: |
+          curl -X POST \
+          -H "Authorization: Bearer $ARGOCD_TOKEN" \
+          "$ARGOCD_SERVER/api/v1/applications/vinfinity-api/refresh"
+        env:
+          ARGOCD_SERVER: ${{ secrets.ARGOCD_SERVER }}
+          ARGOCD_TOKEN:  ${{ secrets.ARGOCD_TOKEN }}

--- a/vinfinity_gitops_v2.4/.github/workflows/terraform.yml
+++ b/vinfinity_gitops_v2.4/.github/workflows/terraform.yml
@@ -1,0 +1,30 @@
+name: Terraform
+
+on:
+  pull_request:
+    paths: ["infra/**"]
+  push:
+    branches: [main]
+    paths: ["infra/**"]
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    env:
+      TF_VAR_render_api_key: ${{ secrets.RENDER_API_KEY }}
+      TF_VAR_notion_key: ${{ secrets.NOTION_API_SECRET }}
+      TF_VAR_supabase_url: ${{ secrets.SUPABASE_URL }}
+      TF_VAR_supabase_key: ${{ secrets.SUPABASE_KEY }}
+    steps:
+      - uses: hashicorp/setup-terraform@v3
+      - uses: actions/checkout@v4
+
+      - name: Terraform Init
+        run: terraform -chdir=infra init
+
+      - name: Terraform Plan
+        run: terraform -chdir=infra plan -no-color
+
+      - name: Terraform Apply (main만)
+        if: github.ref == 'refs/heads/main'
+        run: terraform -chdir=infra apply -auto-approve -no-color

--- a/vinfinity_gitops_v2.4/argo/vinfinity-api-app.yaml
+++ b/vinfinity_gitops_v2.4/argo/vinfinity-api-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vinfinity-api
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: vinfinity-prod
+  source:
+    repoURL: 'https://github.com/your/repo.git'
+    targetRevision: HEAD
+    path: k8s/api
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions: [CreateNamespace=true]

--- a/vinfinity_gitops_v2.4/infra/main.tf
+++ b/vinfinity_gitops_v2.4/infra/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    render = { source = "renderinc/render" version = "~> 0.6" }
+  }
+  cloud {
+    organization = "vinfinity-lab"
+    workspaces { name = "prod" }
+  }
+}
+
+provider "render" {
+  api_key = var.render_api_key
+}
+
+resource "render_service" "api" {
+  name           = "vinfinity-api"
+  type           = "web_service"
+  repo           = var.github_repo
+  branch         = "main"
+  env            = "docker"
+  region         = var.render_region
+  plan           = "standard"
+  env_vars = {
+    NOTION_API_SECRET = var.notion_key
+    SUPABASE_URL      = var.supabase_url
+    SUPABASE_KEY      = var.supabase_key
+  }
+}

--- a/vinfinity_gitops_v2.4/infra/outputs.tf
+++ b/vinfinity_gitops_v2.4/infra/outputs.tf
@@ -1,0 +1,4 @@
+# Example output placeholder
+output "service_id" {
+  value = render_service.api.id
+}

--- a/vinfinity_gitops_v2.4/infra/terraform.tfvars.example
+++ b/vinfinity_gitops_v2.4/infra/terraform.tfvars.example
@@ -1,0 +1,5 @@
+render_api_key = "RENDER_API_KEY_HERE"
+github_repo    = "https://github.com/your/repo.git"
+notion_key     = "secret_xxx"
+supabase_url   = "https://xxx.supabase.co"
+supabase_key   = "anonkey"

--- a/vinfinity_gitops_v2.4/infra/variables.tf
+++ b/vinfinity_gitops_v2.4/infra/variables.tf
@@ -1,0 +1,6 @@
+variable "render_api_key"  { type = string }
+variable "github_repo"     { type = string }
+variable "render_region"   { type = string  default = "oregon" }
+variable "notion_key"      { type = string }
+variable "supabase_url"    { type = string }
+variable "supabase_key"    { type = string }

--- a/vinfinity_gitops_v2.4/k8s/api/deployment.yaml
+++ b/vinfinity_gitops_v2.4/k8s/api/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vinfinity-api
+spec:
+  replicas: 2
+  selector:
+    matchLabels: {app: vinfinity-api}
+  template:
+    metadata:
+      labels: {app: vinfinity-api}
+    spec:
+      containers:
+        - name: api
+          image: ghcr.io/your/repo:${GIT_SHA}
+          ports: [{containerPort: 8000}]
+          env:
+            - name: NOTION_API_SECRET
+              valueFrom: {secretKeyRef: {name: notion, key: api_key}}

--- a/vinfinity_gitops_v2.4/k8s/api/kustomization.yaml
+++ b/vinfinity_gitops_v2.4/k8s/api/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+  - deployment.yaml
+  - service.yaml
+images:
+  - name: ghcr.io/your/repo
+    newTag: ${GIT_SHA}

--- a/vinfinity_gitops_v2.4/k8s/api/service.yaml
+++ b/vinfinity_gitops_v2.4/k8s/api/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: vinfinity-api
+spec:
+  selector:
+    app: vinfinity-api
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000


### PR DESCRIPTION
## Summary
- add GitOps & IaC (Argo CD + Terraform) example as `vinfinity_gitops_v2.4`
- includes Render Terraform config, K8s manifests, Argo CD application, and GitHub Actions workflows

## Testing
- `pytest -q`
- `pylint *.py scripts/*.py`
- `mypy --ignore-missing-imports hook_generator.py keyword_auto_pipeline.py notion_hook_uploader.py retry_dashboard_notifier.py run_pipeline.py scripts/notion_uploader.py`

------
https://chatgpt.com/codex/tasks/task_e_684e862e1654832e9a3902d99f608c3a