### PR TITLE
Add operational automation modules

### DIFF
--- a/batch_log.py
+++ b/batch_log.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+from notion_client_wrapper import NotionClient
+from ops_log_model import OpsLogModel
+
+NOTION_TOKEN = os.getenv("NOTION_API_SECRET", "")
+NOTION_DB_ID = os.getenv("NOTION_DATABASE_ID", "")
+
+
+def auto_deployment_log(module: str, environment: str, version: str) -> object:
+    """Record deployment information to Notion."""
+    notion = NotionClient(NOTION_TOKEN, NOTION_DB_ID)
+    payload = OpsLogModel.build_payload(
+        log_type="Deploy",
+        operator="AutoDeploy",
+        module=module,
+        environment=environment,
+        task_summary="배포 기록",
+        action_details=f"버전 {version} 배포",
+        status="성공",
+        version=version,
+    )
+    return notion.create_page(payload)

--- a/deploy_pipeline.py
+++ b/deploy_pipeline.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import os
+from batch_log import auto_deployment_log
+from slack_alert import send_slack_alert
+
+
+def run_deployment_pipeline(module: str, env: str, version: str) -> None:
+    """Run deployment steps and record results."""
+    print(f"✅ {module} {env} 배포 시작 - 버전: {version}")
+
+    auto_deployment_log(module, env, version)
+    send_slack_alert(f"🚀 {module} {env} 배포 완료 - v{version}")
+
+
+# Example invocation
+if __name__ == "__main__":
+    MODULE = os.getenv("DEPLOY_MODULE", "Backend API")
+    ENV = os.getenv("DEPLOY_ENV", "Production")
+    VERSION = os.getenv("DEPLOY_VERSION", "v1.0.0")
+    run_deployment_pipeline(MODULE, ENV, VERSION)

--- a/notion_client_wrapper.py
+++ b/notion_client_wrapper.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from notion_client import Client
+
+
+class NotionClient:
+    """Simple wrapper around the official Notion Client."""
+
+    def __init__(self, token: str, database_id: str) -> None:
+        self.client = Client(auth=token)
+        self.database_id = database_id
+
+    def create_page(self, properties: dict) -> object:
+        """Create a page in the configured database."""
+        return self.client.pages.create(
+            parent={"database_id": self.database_id},
+            properties=properties["properties"] if "properties" in properties else properties,
+        )

--- a/ops_log_model.py
+++ b/ops_log_model.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional, Dict, Any
+
+
+@dataclass
+class OpsLogModel:
+    """Utility for building Notion payloads for operational logs."""
+
+    log_type: str
+    operator: str
+    module: str
+    environment: str
+    task_summary: str
+    action_details: str
+    status: str
+    error_summary: Optional[str] = None
+    version: Optional[str] = None
+
+    @classmethod
+    def build_payload(
+        cls,
+        log_type: str,
+        operator: str,
+        module: str,
+        environment: str,
+        task_summary: str,
+        action_details: str,
+        status: str,
+        error_summary: Optional[str] = None,
+        version: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        timestamp = datetime.utcnow().isoformat() + "Z"
+        return {
+            "properties": {
+                "로그유형": {"select": {"name": log_type}},
+                "운영자": {"rich_text": [{"text": {"content": operator}}]},
+                "모듈": {"title": [{"text": {"content": module}}]},
+                "환경": {"select": {"name": environment}},
+                "작업요약": {"rich_text": [{"text": {"content": task_summary}}]},
+                "상세내역": {"rich_text": [{"text": {"content": action_details}}]},
+                "상태": {"select": {"name": status}},
+                "오류": {"rich_text": [{"text": {"content": error_summary or ""}}]},
+                "버전": {"rich_text": [{"text": {"content": version or ""}}]},
+                "발생일시": {"date": {"start": timestamp}},
+            }
+        }

--- a/retool_api.py
+++ b/retool_api.py
@@ -1,0 +1,8 @@
+"""Placeholder module for Retool integration."""
+
+
+def push_update(payload: dict) -> bool:
+    """Push updates to Retool if integration is enabled."""
+    # In actual usage this would POST to a Retool endpoint.
+    _ = payload
+    return True

--- a/sla_monitor.py
+++ b/sla_monitor.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import os
+from notion_client_wrapper import NotionClient
+from ops_log_model import OpsLogModel
+from slack_alert import send_slack_alert
+
+NOTION_TOKEN = os.getenv("NOTION_API_SECRET", "")
+NOTION_DB_ID = os.getenv("NOTION_DATABASE_ID", "")
+
+
+def record_sla_issue(
+    module: str, environment: str, error_summary: str, severity: str = "Major"
+) -> None:
+    """Record SLA issue to Notion and send Slack alert."""
+    notion = NotionClient(NOTION_TOKEN, NOTION_DB_ID)
+    payload = OpsLogModel.build_payload(
+        log_type="Error",
+        operator="AutoSLA",
+        module=module,
+        environment=environment,
+        task_summary="SLA 장애 발생",
+        action_details="자동 SLA 이슈 기록",
+        error_summary=error_summary,
+        status="오류 발생",
+    )
+    res = notion.create_page(payload)
+    status_code = getattr(res, "status_code", 200)
+    if status_code in (200, 201):
+        print("✅ SLA 장애 기록 완료")
+        send_slack_alert(f"🚨 SLA 장애 발생 [{severity}] - {module}: {error_summary}")
+    else:
+        print("❌ SLA 기록 실패:", status_code)

--- a/slack_alert.py
+++ b/slack_alert.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import os
+import requests
+
+SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+
+
+def send_slack_alert(message: str) -> object:
+    """Send a message to Slack via an incoming webhook."""
+    if not SLACK_WEBHOOK_URL:
+        print("⚠️ Slack webhook URL not configured")
+        return None
+
+    try:
+        response = requests.post(SLACK_WEBHOOK_URL, json={"text": message}, timeout=5)
+        return response
+    except Exception as exc:  # pylint: disable=broad-except
+        print(f"❌ Slack alert failed: {exc}")
+        return None

--- a/tests/test_deploy_pipeline.py
+++ b/tests/test_deploy_pipeline.py
@@ -1,0 +1,12 @@
+from unittest.mock import patch
+
+from deploy_pipeline import run_deployment_pipeline
+
+
+def test_run_deployment_pipeline():
+    with patch("deploy_pipeline.auto_deployment_log") as mock_log, patch(
+        "deploy_pipeline.send_slack_alert"
+    ) as mock_slack:
+        run_deployment_pipeline("mod", "prod", "v1")
+        mock_log.assert_called_once()
+        mock_slack.assert_called_once()

--- a/tests/test_ops_log_model.py
+++ b/tests/test_ops_log_model.py
@@ -1,0 +1,16 @@
+from ops_log_model import OpsLogModel
+
+
+def test_build_payload_contains_properties():
+    payload = OpsLogModel.build_payload(
+        log_type="Deploy",
+        operator="tester",
+        module="mod",
+        environment="prod",
+        task_summary="summary",
+        action_details="details",
+        status="성공",
+    )
+    assert "properties" in payload
+    props = payload["properties"]
+    assert props["모듈"]["title"][0]["text"]["content"] == "mod"

--- a/tests/test_sla_monitor.py
+++ b/tests/test_sla_monitor.py
@@ -1,0 +1,14 @@
+from unittest.mock import patch
+
+from sla_monitor import record_sla_issue
+
+
+def test_record_sla_issue_calls_clients():
+    with patch("sla_monitor.NotionClient") as mock_notion, patch(
+        "sla_monitor.send_slack_alert"
+    ) as mock_slack:
+        mock_instance = mock_notion.return_value
+        mock_instance.create_page.return_value.status_code = 200
+        record_sla_issue("mod", "prod", "err")
+        mock_instance.create_page.assert_called_once()
+        mock_slack.assert_called_once()


### PR DESCRIPTION
## Summary
- implement `sla_monitor`, `deploy_pipeline`, and logging helpers
- add `OpsLogModel` data model
- add Slack and Notion client wrappers
- provide unit tests for new modules

## Testing
- `ruff check .`
- `pylint deploy_pipeline.py sla_monitor.py batch_log.py slack_alert.py ops_log_model.py notion_client_wrapper.py retool_api.py`
- `mypy --ignore-missing-imports --exclude scripts/ .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e7c3a8b60832ebf40f9314ba9a479