### PR TITLE
Add personalization and compliance modules

### DIFF
--- a/vinfinity_saas_production_bundle_v1.0/.github/workflows/sentry_release.yml
+++ b/vinfinity_saas_production_bundle_v1.0/.github/workflows/sentry_release.yml
@@ -1,0 +1,9 @@
+name: Sentry Release
+on: push
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/action-release@v1
+        with:
+          environment: production

--- a/vinfinity_saas_production_bundle_v1.0/ARCHITECTURE_V6.md
+++ b/vinfinity_saas_production_bundle_v1.0/ARCHITECTURE_V6.md
@@ -1,0 +1,15 @@
+```mermaid
+flowchart TD
+    subgraph Data&ML
+      BigQuery--dbt-->Snowflake
+      Kafka --> Personalize
+      Personalize --> Frontend
+    end
+    subgraph Ops
+      PromExporter-->Prometheus-->Grafana
+      Prometheus-->GPUCostGovernor
+      Sentry-->Slack
+    end
+    FeatureFlags-->Pipeline
+    PrivacyAPI-->DB
+```

--- a/vinfinity_saas_production_bundle_v1.0/Dockerfile-personalize
+++ b/vinfinity_saas_production_bundle_v1.0/Dockerfile-personalize
@@ -1,0 +1,5 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY ./ ./
+RUN pip install fastapi uvicorn redis joblib pandas scikit-learn
+CMD ["python", "personalization_service.py"]

--- a/vinfinity_saas_production_bundle_v1.0/dbt_project/models/fct_conversion.sql
+++ b/vinfinity_saas_production_bundle_v1.0/dbt_project/models/fct_conversion.sql
@@ -1,0 +1,2 @@
+-- fact conversions
+SELECT * FROM raw.conversion_log;

--- a/vinfinity_saas_production_bundle_v1.0/dbt_project/models/mart_roi.sql
+++ b/vinfinity_saas_production_bundle_v1.0/dbt_project/models/mart_roi.sql
@@ -1,0 +1,16 @@
+WITH conv AS (
+  SELECT date_trunc('day', occurred_at) AS d,
+         SUM(revenue_cents)/100 AS revenue
+  FROM {{ ref('fct_conversion') }}
+  GROUP BY 1
+), spend AS (
+  SELECT d, SUM(cost_usd) AS ad_spend
+  FROM marketing_spend
+  GROUP BY 1
+)
+SELECT conv.d,
+       revenue,
+       ad_spend,
+       revenue / NULLIF(ad_spend,0) AS ROAS
+FROM conv
+LEFT JOIN spend USING (d);

--- a/vinfinity_saas_production_bundle_v1.0/dbt_project/models/stg_event_log.sql
+++ b/vinfinity_saas_production_bundle_v1.0/dbt_project/models/stg_event_log.sql
@@ -1,0 +1,2 @@
+-- staging events
+SELECT * FROM raw.event_log;

--- a/vinfinity_saas_production_bundle_v1.0/event_log_pseudonymize.sql
+++ b/vinfinity_saas_production_bundle_v1.0/event_log_pseudonymize.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE FUNCTION anon_event() RETURNS trigger AS $$
+BEGIN
+  NEW.meta = jsonb_set(NEW.meta, '{email}', '"***"');
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_anon
+BEFORE INSERT ON event_log
+FOR EACH ROW EXECUTE PROCEDURE anon_event();

--- a/vinfinity_saas_production_bundle_v1.0/feature_flag.py
+++ b/vinfinity_saas_production_bundle_v1.0/feature_flag.py
@@ -1,0 +1,7 @@
+from ldclient import LDClient, Context
+
+ld = LDClient("LAUNCHDARKLY_SDK_KEY")
+
+def flag_on(user_id: str, flag_key: str) -> bool:
+    ctx = Context.builder(user_id).build()
+    return ld.variation(flag_key, ctx, False)

--- a/vinfinity_saas_production_bundle_v1.0/gpu_cost_governor.py
+++ b/vinfinity_saas_production_bundle_v1.0/gpu_cost_governor.py
@@ -1,0 +1,18 @@
+import os, time
+from slack_notifier import send_slack_message
+from utils.init_env import load_env
+
+env = load_env()
+
+HARD_BUDGET_HOURS = float(os.getenv("GPU_MONTHLY_HRS", "100"))
+SENT = False
+
+def gpu_hours_consumed() -> float:
+    return float(open("/var/log/gpu_usage.txt").read().strip())
+
+while True:
+    used = gpu_hours_consumed()
+    if used > HARD_BUDGET_HOURS and not SENT:
+        send_slack_message(env["SLACK_WEBHOOK"], f"\ud83d\udea8 GPU budget exceeded: {used}h")
+        SENT = True
+    time.sleep(3600)

--- a/vinfinity_saas_production_bundle_v1.0/infra/flags.tf
+++ b/vinfinity_saas_production_bundle_v1.0/infra/flags.tf
@@ -1,0 +1,4 @@
+module "launchdarkly" {
+  source  = "launchdarkly/terraform-provider-launchdarkly"
+  token   = var.ld_token
+}

--- a/vinfinity_saas_production_bundle_v1.0/infra/prometheus_gpu_rule.yml
+++ b/vinfinity_saas_production_bundle_v1.0/infra/prometheus_gpu_rule.yml
@@ -1,0 +1,6 @@
+- alert: GPUQuotaExceeded
+  expr: gpu_usage_hours_month > 100
+  for: 5m
+  labels: { severity: critical }
+  annotations:
+    summary: "GPU \uc608\uc790\ubc88 \ucd08\uacfc"

--- a/vinfinity_saas_production_bundle_v1.0/infra/snowflake.tf
+++ b/vinfinity_saas_production_bundle_v1.0/infra/snowflake.tf
@@ -1,0 +1,9 @@
+provider "snowflake" {
+  account  = var.snow_account
+  username = var.snow_user
+  password = var.snow_pass
+}
+
+resource "snowflake_database" "vinfinity" {
+  name = "VINFINITY"
+}

--- a/vinfinity_saas_production_bundle_v1.0/personalization_service.py
+++ b/vinfinity_saas_production_bundle_v1.0/personalization_service.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+import redis, joblib, json, uvicorn
+from ml.predict import top_users
+
+app = FastAPI()
+r = redis.Redis(host="redis", port=6379, decode_responses=True)
+model = joblib.load("ml/propensity.pkl")
+
+@app.get("/next/{user_id}")
+def next_content(user_id: str):
+    if cached := r.get(user_id):
+        return json.loads(cached)
+    recs = top_users(100)
+    choice = recs.sample(1).iloc[0].to_dict()
+    r.setex(user_id, 300, json.dumps(choice))
+    return choice
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=9000)

--- a/vinfinity_saas_production_bundle_v1.0/privacy_api.py
+++ b/vinfinity_saas_production_bundle_v1.0/privacy_api.py
@@ -1,0 +1,12 @@
+from fastapi import FastAPI, HTTPException
+from db_utils import get_conn
+
+app = FastAPI()
+
+@app.delete("/user/{user_id}")
+def delete_user(user_id: str):
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute("DELETE FROM event_log WHERE user_id=%s", (user_id,))
+        cur.execute("DELETE FROM conversion_log WHERE user_id=%s", (user_id,))
+        conn.commit()
+    return {"status":"deleted"}

--- a/vinfinity_saas_production_bundle_v1.0/sentry_init.py
+++ b/vinfinity_saas_production_bundle_v1.0/sentry_init.py
@@ -1,0 +1,6 @@
+import sentry_sdk, os
+sentry_sdk.init(
+    dsn=os.getenv("SENTRY_DSN"),
+    traces_sample_rate=0.25,
+    release=os.getenv("GIT_SHA","dev")
+)


### PR DESCRIPTION
## Summary
- integrate enterprise personalization and compliance bundle
- add feature flag helper
- add FastAPI personalization service with Redis cache
- enforce GPU budget monitoring and alerting
- initialize Sentry for error tracking
- provide privacy API and dbt models

## Testing
- `pytest -q`
- `pylint vinfinity_saas_production_bundle_v1.0/*.py` *(fails: Missing module docstring, import errors)*
- `mypy vinfinity_saas_production_bundle_v1.0/*.py` *(fails: missing stubs, import-not-found)*
- `sqlfluff lint vinfinity_saas_production_bundle_v1.0/dbt_project/models/*.sql` *(failed: dialect not specified)*


------
https://chatgpt.com/codex/tasks/task_e_684e7c499ee0832e8bb19f1e5746aff7