### PR TITLE
Add Codex Full Automation Module v1.2

### DIFF
--- a/Codex_Full_Automation_Module_v1.2/.env.sample
+++ b/Codex_Full_Automation_Module_v1.2/.env.sample
@@ -1,0 +1,3 @@
+NOTION_API_SECRET=your_notion_secret_key_here
+NOTION_DATABASE_ID=your_notion_database_id_here
+SLACK_WEBHOOK_URL=your_slack_webhook_url_here

--- a/Codex_Full_Automation_Module_v1.2/README.md
+++ b/Codex_Full_Automation_Module_v1.2/README.md
@@ -1,0 +1,26 @@
+# v-Infinity Codex Full Automation Module v1.2
+
+## \ud1b5\uc2e0 \uae30\ub2a5
+- \uc6b4\uc601 \uc804\uccb4 \uc790\ub3d9\ub85c\uadf8 \uc2dc\uc2a4\ud15c
+- \ubc30\ud3ec \ud30c\uc774\ud504\ub77c\uc778 \uc790\ub3d9 \uae30\ub85d
+- \uc7a5\uc560 \ubc1c\uc0dd\uc2dc SLA \uc790\ub3d9 \ub204\uc802 \uae30\ub85d
+- Slack \uc2e4\uc2dc\uac04 \uc54c\ub9bc
+- Retool \uc5f0\ub3d9 \uc900\ube44\uc644\ub8cc
+
+## \ubc30\ud3ec \ud30c\uc774\ud504\ub77c\uc778 \uc608\uc2dc
+
+```python
+from deploy_pipeline import run_deployment_pipeline
+run_deployment_pipeline("Backend API", "Production", "v1.3.0")
+```
+
+## SLA \uc7a5\uc560 \uae30\ub85d \uc608\uc2dc
+
+```python
+from sla_monitor import record_sla_issue
+record_sla_issue("Backend API", "Production", "DB Connection Timeout", "Critical")
+```
+
+---
+
+\u2705 **\uc774 \uc0c1\ud0dc\ub85c Codex import \u2192 \ubc14\ub85c SaaS \uc6b4\uc601 \uc790\ub3d9\ud654 Full Engine \uac11\ubd80**

--- a/Codex_Full_Automation_Module_v1.2/batch_log.py
+++ b/Codex_Full_Automation_Module_v1.2/batch_log.py
@@ -1,0 +1,25 @@
+import os
+from notion_client import NotionClient
+from ops_log_model import OpsLogModel
+
+NOTION_TOKEN = os.getenv("NOTION_API_SECRET")
+NOTION_DB_ID = os.getenv("NOTION_DATABASE_ID")
+
+def auto_deployment_log(module, env, version):
+    notion = NotionClient(NOTION_TOKEN, NOTION_DB_ID)
+    payload = OpsLogModel.build_payload(
+        log_type="Deployment",
+        operator="DeployBot",
+        module=module,
+        environment=env,
+        task_summary="자동 배포 기록",
+        action_details=f"배포 버전 {version} 자동 기록",
+        release_version=version,
+        status="완료"
+    )
+
+    res = notion.create_page(payload)
+    if res.status_code in [200, 201]:
+        print("✅ 배포 로그 자동 기록 성공")
+    else:
+        print("❌ 기록 실패:", res.status_code, res.text)

--- a/Codex_Full_Automation_Module_v1.2/deploy_pipeline.py
+++ b/Codex_Full_Automation_Module_v1.2/deploy_pipeline.py
@@ -1,0 +1,10 @@
+import os
+from batch_log import auto_deployment_log
+from slack_alert import send_slack_alert
+
+def run_deployment_pipeline(module, env, version):
+    print(f"✅ {module} {env} 배포 시작 - 버전: {version}")
+
+    auto_deployment_log(module, env, version)
+
+    send_slack_alert(f"🚀 {module} {env} 배포 완료 - v{version}")

--- a/Codex_Full_Automation_Module_v1.2/log_ops.py
+++ b/Codex_Full_Automation_Module_v1.2/log_ops.py
@@ -1,0 +1,57 @@
+import os
+import argparse
+from notion_client import NotionClient
+from ops_log_model import OpsLogModel
+from slack_alert import send_slack_alert
+
+NOTION_TOKEN = os.getenv("NOTION_API_SECRET")
+NOTION_DB_ID = os.getenv("NOTION_DATABASE_ID")
+
+def register_log(args):
+    notion = NotionClient(NOTION_TOKEN, NOTION_DB_ID)
+
+    payload = OpsLogModel.build_payload(
+        log_type=args.log_type,
+        operator=args.operator,
+        module=args.module,
+        environment=args.environment,
+        task_summary=args.task_summary,
+        action_details=args.action_details,
+        verification=args.verification,
+        error_summary=args.error_summary,
+        root_cause=args.root_cause,
+        resolution=args.resolution,
+        patch_details=args.patch_details,
+        release_version=args.release_version,
+        release_notes=args.release_notes,
+        post_monitoring=args.post_monitoring,
+        status=args.status
+    )
+
+    res = notion.create_page(payload)
+    if res.status_code in [200, 201]:
+        print("✅ Notion 기록 성공")
+        send_slack_alert(f"[v-Infinity Log] {args.log_type} 등록 완료: {args.task_summary}")
+    else:
+        print("❌ 기록 실패:", res.status_code, res.text)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--log_type", required=True)
+    parser.add_argument("--operator", required=True)
+    parser.add_argument("--module", required=True)
+    parser.add_argument("--environment", required=True)
+    parser.add_argument("--task_summary", required=True)
+    parser.add_argument("--action_details", required=True)
+    parser.add_argument("--verification", default="")
+    parser.add_argument("--error_summary", default="")
+    parser.add_argument("--root_cause", default="")
+    parser.add_argument("--resolution", default="")
+    parser.add_argument("--patch_details", default="")
+    parser.add_argument("--release_version", default="")
+    parser.add_argument("--release_notes", default="")
+    parser.add_argument("--post_monitoring", default="")
+    parser.add_argument("--status", default="진행중")
+
+    args = parser.parse_args()
+    register_log(args)

--- a/Codex_Full_Automation_Module_v1.2/notion_client.py
+++ b/Codex_Full_Automation_Module_v1.2/notion_client.py
@@ -1,0 +1,15 @@
+import requests
+
+class NotionClient:
+    def __init__(self, notion_token, database_id):
+        self.api_url = "https://api.notion.com/v1/pages"
+        self.database_id = database_id
+        self.headers = {
+            "Authorization": f"Bearer {notion_token}",
+            "Content-Type": "application/json",
+            "Notion-Version": "2022-06-28"
+        }
+
+    def create_page(self, payload):
+        response = requests.post(self.api_url, headers=self.headers, json=payload)
+        return response

--- a/Codex_Full_Automation_Module_v1.2/ops_log_model.py
+++ b/Codex_Full_Automation_Module_v1.2/ops_log_model.py
@@ -1,0 +1,32 @@
+import datetime
+
+class OpsLogModel:
+    @staticmethod
+    def build_payload(
+        log_type, operator, module, environment, task_summary,
+        action_details, verification="", error_summary="", root_cause="",
+        resolution="", patch_details="", release_version="", release_notes="",
+        post_monitoring="", status="진행중"
+    ):
+        payload = {
+            "parent": {"database_id": "YOUR_NOTION_DATABASE_ID"},
+            "properties": {
+                "Log Type": {"select": {"name": log_type}},
+                "Date": {"date": {"start": datetime.datetime.now().isoformat()}},
+                "Operator": {"title": [{"text": {"content": operator}}]},
+                "Module": {"rich_text": [{"text": {"content": module}}]},
+                "Environment": {"select": {"name": environment}},
+                "Task Summary": {"rich_text": [{"text": {"content": task_summary}}]},
+                "Action Details": {"rich_text": [{"text": {"content": action_details}}]},
+                "Verification": {"rich_text": [{"text": {"content": verification}}]},
+                "Error Summary": {"rich_text": [{"text": {"content": error_summary}}]},
+                "Root Cause": {"rich_text": [{"text": {"content": root_cause}}]},
+                "Resolution": {"rich_text": [{"text": {"content": resolution}}]},
+                "Patch Details": {"rich_text": [{"text": {"content": patch_details}}]},
+                "Release Version": {"rich_text": [{"text": {"content": release_version}}]},
+                "Release Notes": {"rich_text": [{"text": {"content": release_notes}}]},
+                "Post Monitoring": {"rich_text": [{"text": {"content": post_monitoring}}]},
+                "Status": {"select": {"name": status}}
+            }
+        }
+        return payload

--- a/Codex_Full_Automation_Module_v1.2/sla_monitor.py
+++ b/Codex_Full_Automation_Module_v1.2/sla_monitor.py
@@ -1,0 +1,26 @@
+import os
+from notion_client import NotionClient
+from ops_log_model import OpsLogModel
+from slack_alert import send_slack_alert
+
+NOTION_TOKEN = os.getenv("NOTION_API_SECRET")
+NOTION_DB_ID = os.getenv("NOTION_DATABASE_ID")
+
+def record_sla_issue(module, environment, error_summary, severity="Major"):
+    notion = NotionClient(NOTION_TOKEN, NOTION_DB_ID)
+    payload = OpsLogModel.build_payload(
+        log_type="Error",
+        operator="AutoSLA",
+        module=module,
+        environment=environment,
+        task_summary="SLA 장애 발생",
+        action_details="자동 SLA 이슈 기록",
+        error_summary=error_summary,
+        status="오류 발생"
+    )
+    res = notion.create_page(payload)
+    if res.status_code in [200, 201]:
+        print("✅ SLA 장애 기록 완료")
+        send_slack_alert(f"🚨 SLA 장애 발생 [{severity}] - {module}: {error_summary}")
+    else:
+        print("❌ SLA 기록 실패:", res.status_code, res.text)

--- a/Codex_Full_Automation_Module_v1.2/slack_alert.py
+++ b/Codex_Full_Automation_Module_v1.2/slack_alert.py
@@ -1,0 +1,15 @@
+import requests
+import os
+
+SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+
+def send_slack_alert(message):
+    if not SLACK_WEBHOOK_URL:
+        print("❌ Slack Webhook URL 미설정")
+        return
+    payload = {"text": message}
+    res = requests.post(SLACK_WEBHOOK_URL, json=payload)
+    if res.status_code == 200:
+        print("✅ Slack 알림 전송 완료")
+    else:
+        print(f"❌ Slack 전송 실패: {res.status_code}, {res.text}")


### PR DESCRIPTION
## Summary
- introduce `Codex_Full_Automation_Module_v1.2` package
- includes Notion logging, Slack alerting, SLA monitoring, and deployment helpers

## Testing
- `pylint Codex_Full_Automation_Module_v1.2/*.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684e7c7284d4832e9ce4037991cfb93a