### PR TITLE
Add v-Infinity automation module v1.1

### DIFF
--- a/v-Infinity_Codex_Admin_Automation_Module_v1.1/.env.sample
+++ b/v-Infinity_Codex_Admin_Automation_Module_v1.1/.env.sample
@@ -1,0 +1,3 @@
+NOTION_API_SECRET=your_notion_secret_key_here
+NOTION_DATABASE_ID=your_notion_database_id_here
+SLACK_WEBHOOK_URL=your_slack_webhook_url_here

--- a/v-Infinity_Codex_Admin_Automation_Module_v1.1/README.md
+++ b/v-Infinity_Codex_Admin_Automation_Module_v1.1/README.md
@@ -1,0 +1,29 @@
+# v-Infinity Codex Admin Automation Module v1.1
+
+## \ud83d\udce6 \uc8fc\uc694 \uae30\ub2a5
+- Notion \uc6b4\uc601 \ub85c\uae45 \uc790\ub3d9 \ub4f1\ub85d
+- CLI \ud30c\ub77c\ubbf8\ud130 \uae30\ubc18 \ub85c\uae45 \uae30\ub85d
+- \ubc30\ud3ec \uc790\ub3d9 \ub85c\uae45 \uae30\ub85d
+- Slack \uc7a5\uc560/\ub9c1\ub9ac\uc2a4 \uc2e4\uc2dc\uac04 \uc54c\ub9bc
+
+## \u2699\ufe0f \uc124\uce58 \ubc0f \uc2e4\ud589
+1. `.env` \ud30c\uc77c \uc0dd\uc131 \ubc0f \ud658\uacbd\ubcc0\uc218 \uc124\uc815
+2. Notion DB \uc0ac\uc804 \uc0dd\uc131 (v-Infinity Ops Board \uc2a4\ud0a4\ub9c8 \uae30\ubc18)
+
+## \ud83d\ude80 CLI \uc2e4\ud589 \uc608\uc2dc
+```bash
+python log_ops.py \
+  --log_type "DevOps" \
+  --operator "Sunwoo" \
+  --module "ExportScript" \
+  --environment "Local" \
+  --task_summary "Full Export \ud14c\uc2a4\ud2b8" \
+  --action_details "\ud3f4\ub354 \uc0dd\uc131 \ubc0f \uac80\uc99d \uc644\ub8cc"
+```
+
+## \ud83d\ude80 \ubc30\ud3ec \uc2a4\ud06c\ub9bd\ud2b8 \uc790\ub3d9\ub85c\uae45 \uc608\uc2dc
+```python
+from batch_log import auto_deployment_log
+
+auto_deployment_log("Backend API", "Production", "v1.2.3")
+```

--- a/v-Infinity_Codex_Admin_Automation_Module_v1.1/batch_log.py
+++ b/v-Infinity_Codex_Admin_Automation_Module_v1.1/batch_log.py
@@ -1,0 +1,26 @@
+import os
+from notion_client import NotionClient
+from ops_log_model import OpsLogModel
+
+NOTION_TOKEN = os.getenv("NOTION_API_SECRET", "")
+NOTION_DB_ID = os.getenv("NOTION_DATABASE_ID", "")
+
+
+def auto_deployment_log(module: str, env: str, version: str) -> None:
+    notion = NotionClient(NOTION_TOKEN, NOTION_DB_ID)
+    payload = OpsLogModel.build_payload(
+        log_type="Deployment",
+        operator="DeployBot",
+        module=module,
+        environment=env,
+        task_summary="자동 배포 기록",
+        action_details=f"배포 버전 {version} 자동 기록",
+        release_version=version,
+        status="완료",
+    )
+
+    res = notion.create_page(payload)
+    if res.status_code in [200, 201]:
+        print("✅ 배포 로그 자동 기록 성공")
+    else:
+        print("❌ 기록 실패:", res.status_code, res.text)

--- a/v-Infinity_Codex_Admin_Automation_Module_v1.1/log_ops.py
+++ b/v-Infinity_Codex_Admin_Automation_Module_v1.1/log_ops.py
@@ -1,0 +1,59 @@
+import os
+import argparse
+from notion_client import NotionClient
+from ops_log_model import OpsLogModel
+from slack_alert import send_slack_alert
+
+NOTION_TOKEN = os.getenv("NOTION_API_SECRET", "")
+NOTION_DB_ID = os.getenv("NOTION_DATABASE_ID", "")
+
+
+def register_log(args: argparse.Namespace) -> None:
+    notion = NotionClient(NOTION_TOKEN, NOTION_DB_ID)
+
+    payload = OpsLogModel.build_payload(
+        log_type=args.log_type,
+        operator=args.operator,
+        module=args.module,
+        environment=args.environment,
+        task_summary=args.task_summary,
+        action_details=args.action_details,
+        verification=args.verification,
+        error_summary=args.error_summary,
+        root_cause=args.root_cause,
+        resolution=args.resolution,
+        patch_details=args.patch_details,
+        release_version=args.release_version,
+        release_notes=args.release_notes,
+        post_monitoring=args.post_monitoring,
+        status=args.status,
+    )
+
+    res = notion.create_page(payload)
+    if res.status_code in [200, 201]:
+        print("✅ Notion 기록 성공")
+        send_slack_alert(f"[v-Infinity Log] {args.log_type} 등록 완료: {args.task_summary}")
+    else:
+        print("❌ 기록 실패:", res.status_code, res.text)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--log_type", required=True)
+    parser.add_argument("--operator", required=True)
+    parser.add_argument("--module", required=True)
+    parser.add_argument("--environment", required=True)
+    parser.add_argument("--task_summary", required=True)
+    parser.add_argument("--action_details", required=True)
+    parser.add_argument("--verification", default="")
+    parser.add_argument("--error_summary", default="")
+    parser.add_argument("--root_cause", default="")
+    parser.add_argument("--resolution", default="")
+    parser.add_argument("--patch_details", default="")
+    parser.add_argument("--release_version", default="")
+    parser.add_argument("--release_notes", default="")
+    parser.add_argument("--post_monitoring", default="")
+    parser.add_argument("--status", default="진행중")
+
+    args = parser.parse_args()
+    register_log(args)

--- a/v-Infinity_Codex_Admin_Automation_Module_v1.1/notion_client.py
+++ b/v-Infinity_Codex_Admin_Automation_Module_v1.1/notion_client.py
@@ -1,0 +1,21 @@
+import requests
+
+class NotionClient:
+    def __init__(self, token: str, database_id: str):
+        self.token = token
+        self.database_id = database_id
+        self.session = requests.Session()
+        self.session.headers.update({
+            "Authorization": f"Bearer {self.token}",
+            "Notion-Version": "2022-06-28",
+            "Content-Type": "application/json",
+        })
+
+    def create_page(self, properties: dict):
+        url = "https://api.notion.com/v1/pages"
+        payload = {
+            "parent": {"database_id": self.database_id},
+            "properties": properties,
+        }
+        response = self.session.post(url, json=payload)
+        return response

--- a/v-Infinity_Codex_Admin_Automation_Module_v1.1/ops_log_model.py
+++ b/v-Infinity_Codex_Admin_Automation_Module_v1.1/ops_log_model.py
@@ -1,0 +1,43 @@
+class OpsLogModel:
+    @staticmethod
+    def build_payload(
+        log_type: str,
+        operator: str,
+        module: str,
+        environment: str,
+        task_summary: str,
+        action_details: str,
+        verification: str = "",
+        error_summary: str = "",
+        root_cause: str = "",
+        resolution: str = "",
+        patch_details: str = "",
+        release_version: str = "",
+        release_notes: str = "",
+        post_monitoring: str = "",
+        status: str = "진행중",
+    ) -> dict:
+        def title(value: str) -> dict:
+            return {"title": [{"text": {"content": value}}]}
+
+        def rich(value: str) -> dict:
+            return {"rich_text": [{"text": {"content": value}}]}
+
+        properties = {
+            "Log Type": title(log_type),
+            "Operator": rich(operator),
+            "Module": rich(module),
+            "Environment": rich(environment),
+            "Task Summary": rich(task_summary),
+            "Action Details": rich(action_details),
+            "Verification": rich(verification),
+            "Error Summary": rich(error_summary),
+            "Root Cause": rich(root_cause),
+            "Resolution": rich(resolution),
+            "Patch Details": rich(patch_details),
+            "Release Version": rich(release_version),
+            "Release Notes": rich(release_notes),
+            "Post Monitoring": rich(post_monitoring),
+            "Status": rich(status),
+        }
+        return properties

--- a/v-Infinity_Codex_Admin_Automation_Module_v1.1/slack_alert.py
+++ b/v-Infinity_Codex_Admin_Automation_Module_v1.1/slack_alert.py
@@ -1,0 +1,16 @@
+import requests
+import os
+
+SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL", "")
+
+
+def send_slack_alert(message: str) -> None:
+    if not SLACK_WEBHOOK_URL:
+        print("❌ Slack Webhook URL 미설정")
+        return
+    payload = {"text": message}
+    res = requests.post(SLACK_WEBHOOK_URL, json=payload)
+    if res.status_code == 200:
+        print("✅ Slack 알림 전송 완료")
+    else:
+        print(f"❌ Slack 전송 실패: {res.status_code}, {res.text}")


### PR DESCRIPTION
## Summary
- add automation scripts for v-Infinity admin module
- support Slack alerts, CLI logging and batch deployment logs
- provide example `.env` and documentation

## Testing
- `pytest -q`
- `mypy --ignore-missing-imports v-Infinity_Codex_Admin_Automation_Module_v1.1`

------
https://chatgpt.com/codex/tasks/task_e_684e7be24300832e8bc3da8393106675