### PR TITLE
Add parsing and notification scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Auto Pipeline
+
+This repository contains scripts used to generate marketing hooks from keywords and upload them to Notion.  A small pipeline orchestrates several steps.
+
+## Pipeline Stages
+
+1. **hook_generator.py** – Generates hook text using GPT.
+2. **parse_failed_gpt.py** – Parses raw GPT output from failed items for later retries.
+3. **retry_failed_uploads.py** – Attempts to upload the reparsed keywords again.
+4. **notify_retry_result.py** – Sends a Slack notification summarizing retry results.
+5. **retry_dashboard_notifier.py** – Updates KPI metrics in Notion.
+
+Run `python run_pipeline.py` to execute these steps sequentially.

--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,50 @@
+import os
+import json
+import logging
+import urllib.request
+from dotenv import load_dotenv
+
+load_dotenv()
+SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+REPARSED_OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def send_slack_message(text: str):
+    if not SLACK_WEBHOOK_URL:
+        logging.error("❗ SLACK_WEBHOOK_URL 환경 변수가 설정되지 않았습니다.")
+        return
+    data = json.dumps({"text": text}).encode('utf-8')
+    req = urllib.request.Request(SLACK_WEBHOOK_URL, data=data, headers={'Content-Type': 'application/json'})
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            if resp.status != 200:
+                logging.error(f"❌ Slack 전송 실패: HTTP {resp.status}")
+            else:
+                logging.info("✅ Slack 알림 전송 완료")
+    except Exception as e:
+        logging.error(f"❌ Slack 요청 오류: {e}")
+
+
+def notify_retry_result():
+    if not os.path.exists(REPARSED_OUTPUT_PATH):
+        send_slack_message("✅ 모든 키워드가 성공적으로 업로드되었습니다.")
+        return
+
+    try:
+        with open(REPARSED_OUTPUT_PATH, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except Exception as e:
+        logging.error(f"❌ 결과 파일 읽기 오류: {e}")
+        return
+
+    total = len(data)
+    failed = len([d for d in data if d.get("retry_error")])
+    success = total - failed
+    message = f"재시도 결과 - 성공: {success}, 실패: {failed}"
+    send_slack_message(message)
+
+
+if __name__ == "__main__":
+    notify_retry_result()

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,59 @@
+import os
+import json
+import logging
+from dotenv import load_dotenv
+
+load_dotenv()
+FAILED_HOOK_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+REPARSED_OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def parse_gpt_output(text: str):
+    """Parse raw GPT text into structured fields."""
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return {
+        "hook_lines": lines[:2],
+        "blog_paragraphs": lines[2:5],
+        "video_titles": lines[5:],
+    }
+
+
+def reparse_failed_items():
+    if not os.path.exists(FAILED_HOOK_PATH):
+        logging.error(f"❌ 실패 파일이 존재하지 않습니다: {FAILED_HOOK_PATH}")
+        return
+
+    try:
+        with open(FAILED_HOOK_PATH, 'r', encoding='utf-8') as f:
+            failed_items = json.load(f)
+    except Exception as e:
+        logging.error(f"❌ 실패 파일 읽기 오류: {e}")
+        return
+
+    reparsed = []
+    for item in failed_items:
+        keyword = item.get("keyword")
+        text = item.get("generated_text")
+        if not keyword or not text:
+            logging.warning("⛔ keyword 또는 generated_text 누락 항목 건너뜀")
+            continue
+        try:
+            parsed = parse_gpt_output(text)
+            item.update(parsed)
+            reparsed.append(item)
+            logging.info(f"✅ 파싱 성공: {keyword}")
+        except Exception as e:
+            logging.error(f"❌ 파싱 실패: {keyword} - {e}")
+            item["parse_error"] = str(e)
+            reparsed.append(item)
+
+    os.makedirs(os.path.dirname(REPARSED_OUTPUT_PATH), exist_ok=True)
+    with open(REPARSED_OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        json.dump(reparsed, f, ensure_ascii=False, indent=2)
+    logging.info(f"📄 파싱 결과 저장 완료: {REPARSED_OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    reparse_failed_items()


### PR DESCRIPTION
## Summary
- implement `parse_failed_gpt.py` to reparse GPT failures
- implement `notify_retry_result.py` to send Slack summary
- document pipeline stages in new README

## Testing
- `python -m py_compile run_pipeline.py scripts/parse_failed_gpt.py scripts/notify_retry_result.py`


------
https://chatgpt.com/codex/tasks/task_e_684e7af0b598832e87400f4f7e12a737