### PR TITLE
Fix pipeline script path resolution

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,15 +13,20 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    "retry_dashboard_notifier.py",
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
-def run_script(script):
-    full_path = os.path.join("scripts", script)
+def run_script(script: str) -> bool:
+    """Run a python script located either in the repository root or the scripts directory."""
+    if os.path.isabs(script) and os.path.exists(script):
+        full_path = script
+    elif os.path.exists(script):
+        full_path = script
+    else:
+        full_path = os.path.join("scripts", script)
+
     if not os.path.exists(full_path):
         logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
         return False


### PR DESCRIPTION
## Summary
- only run scripts that actually exist
- resolve script paths from either the repo root or `scripts/`

## Testing
- `pylint run_pipeline.py`
- `mypy run_pipeline.py`
- `pytest`
- `python run_pipeline.py` *(fails: ModuleNotFoundError: dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_684e7bc32108832eb1ca3259bc5ac201