### PR TITLE
Fix workflow YAML naming

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -1,6 +1,6 @@
 name: Daily Notion Hook Pipeline
 
-on:
+'on':
   schedule:
     - cron: '0 0 * * *'  # 매일 오전 9시 (KST 기준)
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- rename daily pipeline config so GitHub will run it
- quote the `on` key to keep the YAML valid

## Testing
- `pytest -q`
- `pylint *.py scripts/*.py`
- `mypy *.py scripts/*.py`
- `yamllint .github/workflows/daily-pipeline.yml.txt`

------
https://chatgpt.com/codex/tasks/task_e_684e7bc49418832eb1022b3560768c9e