### PR TITLE
Fix pipeline script paths and update docs

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Auto Pipeline
+
+This repository contains scripts for generating marketing hooks, retrying failed uploads, and notifying dashboards.
+
+## Running the pipeline
+
+Use the `run_pipeline.py` script located in the project root. It will automatically
+look for scripts in the `scripts/` directory first and then fall back to
+root-level scripts.
+
+```bash
+python run_pipeline.py
+```
+
+The GitHub workflow `.github/workflows/daily-pipeline.yml.txt` uses the same
+entrypoint.

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -20,10 +20,20 @@ PIPELINE_SEQUENCE = [
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
-def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+def run_script(script: str) -> bool:
+    """Run a single pipeline script.
+
+    The function first looks for the script inside the ``scripts/`` directory.
+    If not found there, it falls back to a root-level path so legacy layouts
+    continue to work.
+    """
+    candidates = [os.path.join("scripts", script), script]
+    for path in candidates:
+        if os.path.exists(path):
+            full_path = path
+            break
+    else:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {candidates}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- allow `run_pipeline.py` to locate scripts in either `scripts/` or repo root
- update GitHub workflow to use the root `run_pipeline.py`
- add README with basic usage instructions

## Testing
- `pylint run_pipeline.py hook_generator.py keyword_auto_pipeline.py retry_failed_uploads.py retry_dashboard_notifier.py notion_hook_uploader.py`
- `mypy run_pipeline.py hook_generator.py keyword_auto_pipeline.py retry_failed_uploads.py retry_dashboard_notifier.py notion_hook_uploader.py` *(fails: missing stubs)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684e7af3c810832ea367ca006e174f38