### PR TITLE
Add analytics worker and FFmpeg renderer

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,28 @@
+# API Credentials
+OPENAI_API_KEY=
+NOTION_API_TOKEN=
+NOTION_DB_ID=
+NOTION_HOOK_DB_ID=
+NOTION_KPI_DB_ID=
+
+# Paths and delays
+TOPIC_CHANNELS_PATH=config/topic_channels.json
+KEYWORD_OUTPUT_PATH=data/keyword_output_with_cpc.json
+HOOK_OUTPUT_PATH=data/generated_hooks.json
+FAILED_HOOK_PATH=logs/failed_hooks.json
+UPLOAD_DELAY=0.5
+UPLOADED_CACHE_PATH=data/uploaded_keywords_cache.json
+FAILED_UPLOADS_PATH=logs/failed_uploads.json
+REPARSED_OUTPUT_PATH=logs/failed_keywords_reparsed.json
+RETRY_DELAY=0.5
+
+# Database
+DATABASE_URL=postgresql://user:pass@localhost:5432/dbname
+
+# Analytics and uploaders
+ANALYTICS_INTERVAL_SEC=1800
+YT_CLIENT_SECRET_FILE=client_secret.json
+TIKTOK_ACCESS_TOKEN=your_tiktok_token
+TIKTOK_OPEN_ID=your_open_id
+TISTORY_BLOG=your_blog_name
+WORDPRESS_API_TOKEN=your_wp_token

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -1,0 +1,17 @@
+name: Deploy Analytics Worker
+
+on:
+  push:
+    paths:
+      - 'analytics_worker.py'
+      - 'ffmpeg_renderer.py'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: render-examples/action-render-deploy@v1
+        with:
+          api-key: ${{ secrets.RENDER_API_KEY }}
+          service-id: ${{ secrets.RENDER_ANALYTICS_ID }}

--- a/analytics_worker.py
+++ b/analytics_worker.py
@@ -1,0 +1,49 @@
+import os
+import time
+import requests
+import psycopg2
+from dotenv import load_dotenv
+from db_utils import get_conn
+
+load_dotenv()
+
+INTERVAL = int(os.getenv("ANALYTICS_INTERVAL_SEC", "1800"))
+
+
+def fetch_wp_stats(post_id: str, token: str) -> dict:
+    url = f"https://public-api.wordpress.com/rest/v1.1/sites/$YOUR_SITE_ID/posts/{post_id}"
+    resp = requests.get(url, headers={"Authorization": f"Bearer {token}"})
+    j = resp.json()
+    return {"views": j.get("views", 0), "likes": j.get("likes", 0)}
+
+
+def save_metrics(content_id: str, platform: str, metrics: dict) -> None:
+    with get_conn() as conn, conn.cursor() as cur:
+        for k, v in metrics.items():
+            cur.execute(
+                """
+              INSERT INTO analytics_log (content_id, platform, metric, value)
+              VALUES (%s,%s,%s,%s)
+            """,
+                (content_id, platform, k, v),
+            )
+        conn.commit()
+
+
+while True:
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+          SELECT id, title->>'rendered' AS title, meta->>'wordpress_id' AS wp_id
+          FROM content_tracker
+          WHERE status='published'
+        """
+        )
+        for content_id, title, wp_id in cur.fetchall():
+            if not wp_id:
+                continue
+            token = os.getenv("WORDPRESS_API_TOKEN", "")
+            metrics = fetch_wp_stats(wp_id, token)
+            save_metrics(content_id, "wordpress", metrics)
+            print(f"\U0001F4CA {title} → {metrics}")
+    time.sleep(INTERVAL)

--- a/db_utils.py
+++ b/db_utils.py
@@ -1,0 +1,15 @@
+import os
+import psycopg2
+from contextlib import contextmanager
+
+
+@contextmanager
+def get_conn():
+    dsn = os.getenv("DATABASE_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL not set")
+    conn = psycopg2.connect(dsn)
+    try:
+        yield conn
+    finally:
+        conn.close()

--- a/ffmpeg_renderer.py
+++ b/ffmpeg_renderer.py
@@ -1,0 +1,27 @@
+import subprocess
+import textwrap
+import os
+import uuid
+import pathlib
+
+FONT = "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"
+
+
+def render_short(text: str, output_dir: str = "media") -> str:
+    pathlib.Path(output_dir).mkdir(exist_ok=True)
+    video_id = str(uuid.uuid4())
+    outfile = f"{output_dir}/{video_id}.mp4"
+    wrapped = textwrap.fill(text, 40)
+    cmd = [
+        "ffmpeg",
+        "-f",
+        "lavfi",
+        "-i",
+        "color=c=black:s=720x1280:d=20",
+        "-vf",
+        f"drawtext=fontsize=40:fontfile={FONT}:fontcolor=white:text='{wrapped}':x=(w-text_w)/2:y=(h-text_h)/2",
+        "-y",
+        outfile,
+    ]
+    subprocess.run(cmd, stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
+    return outfile

--- a/osmu_dispatcher.py
+++ b/osmu_dispatcher.py
@@ -1,0 +1,18 @@
+from ffmpeg_renderer import render_short
+
+
+def upload_youtube_shorts(title: str, description: str, video_path: str) -> None:
+    """Placeholder for YouTube Shorts upload logic."""
+    pass
+
+
+def upload_tiktok_video(title: str, video_path: str) -> None:
+    """Placeholder for TikTok upload logic."""
+    pass
+
+
+def dispatch(title: str, full_text: str) -> None:
+    # Shorts용 비디오 생성
+    video_path = render_short(full_text[:200])
+    upload_youtube_shorts(title, full_text[:1000], video_path)
+    upload_tiktok_video(title, video_path)

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,9 @@
+-- 퍼포먼스 수집 로그
+CREATE TABLE IF NOT EXISTS analytics_log (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    content_id UUID REFERENCES content_tracker (id),
+    platform TEXT,
+    metric TEXT,
+    value BIGINT,
+    collected_at TIMESTAMP DEFAULT now()
+);

--- a/vinfinity_flow_v2.md
+++ b/vinfinity_flow_v2.md
@@ -1,0 +1,10 @@
+```mermaid
+flowchart TD
+    A[Super Orchestrator] --> B[OSMU Dispatcher]
+    B --> C[FFmpeg Renderer] --> D[Shorts Uploaders]
+    B --> E[Social Uploaders]
+    A -->|WP ID| F[Performance Tracker]
+    D & E & F --> G[Analytics Worker]
+    G --> H[analytics_log]
+    H --> I[Retool KPI Dashboard]
+```


### PR DESCRIPTION
## Summary
- extend database schema with `analytics_log`
- create `analytics_worker` for KPI collection
- add FFmpeg-based short video renderer
- introduce simple dispatcher stub for uploading shorts
- provide workflow to deploy analytics worker
- document updated data flow and environment variables

## Testing
- `pytest -q`
- `mypy --ignore-missing-imports analytics_worker.py ffmpeg_renderer.py osmu_dispatcher.py db_utils.py`
- `pylint analytics_worker.py ffmpeg_renderer.py osmu_dispatcher.py db_utils.py`
- `sqlfluff lint --dialect postgres schema.sql`


------
https://chatgpt.com/codex/tasks/task_e_684e7a7935a4832ea203ae4d35cf6011