### PR TITLE
Add modular Notion logging utilities

### DIFF
--- a/log_ops.py
+++ b/log_ops.py
@@ -1,0 +1,35 @@
+"""Command-line entry point for logging operational events to Notion."""
+
+import os
+
+from notion_client import NotionClient
+from ops_log_model import OpsLogModel
+
+
+NOTION_TOKEN = os.getenv("NOTION_API_SECRET", "")
+NOTION_DB_ID = os.getenv("NOTION_DATABASE_ID", "")
+
+
+def register_log() -> None:
+    """Example function to register an operations log."""
+    notion = NotionClient(NOTION_TOKEN, NOTION_DB_ID)
+
+    payload = OpsLogModel.build_payload(
+        log_type="DevOps",
+        operator="Sunwoo",
+        module="ExportScript",
+        environment="Local",
+        task_summary="Full Export 테스트",
+        action_details="폴더 생성 및 검증 완료",
+        database_id=NOTION_DB_ID,
+    )
+
+    res = notion.create_page(payload)
+    if res.status_code in (200, 201):
+        print("✅ 성공적으로 기록됨")
+    else:
+        print("❌ 기록 실패:", res.status_code, res.text)
+
+
+if __name__ == "__main__":
+    register_log()

--- a/notion_client.py
+++ b/notion_client.py
@@ -1,0 +1,22 @@
+"""Lightweight Notion API wrapper used for logging to Notion databases."""
+
+import requests
+
+
+class NotionClient:
+    """Simple wrapper for the Notion API"""
+
+    def __init__(self, notion_token: str, database_id: str):
+        self.api_url = "https://api.notion.com/v1/pages"
+        self.database_id = database_id
+        self.headers = {
+            "Authorization": f"Bearer {notion_token}",
+            "Content-Type": "application/json",
+            "Notion-Version": "2022-06-28",
+        }
+
+    def create_page(self, payload: dict) -> requests.Response:
+        """Send a request to create a new page."""
+        return requests.post(
+            self.api_url, headers=self.headers, json=payload, timeout=10
+        )

--- a/ops_log_model.py
+++ b/ops_log_model.py
@@ -1,0 +1,57 @@
+"""Model helpers for constructing operation log payloads."""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any, Dict
+
+
+class OpsLogModel:
+    """Utility for building standardized Notion payloads."""
+
+    @staticmethod
+    def build_payload(
+        log_type: str,
+        operator: str,
+        module: str,
+        environment: str,
+        task_summary: str,
+        action_details: str,
+        verification: str = "",
+        error_summary: str = "",
+        root_cause: str = "",
+        resolution: str = "",
+        patch_details: str = "",
+        release_version: str = "",
+        release_notes: str = "",
+        post_monitoring: str = "",
+        status: str = "진행중",
+        database_id: str | None = None,
+    ) -> Dict[str, Any]:
+        """Construct a Notion page creation payload."""
+
+        if not database_id:
+            database_id = "YOUR_NOTION_DATABASE_ID"
+
+        payload: Dict[str, Any] = {
+            "parent": {"database_id": database_id},
+            "properties": {
+                "Log Type": {"select": {"name": log_type}},
+                "Date": {"date": {"start": datetime.datetime.now().isoformat()}},
+                "Operator": {"title": [{"text": {"content": operator}}]},
+                "Module": {"rich_text": [{"text": {"content": module}}]},
+                "Environment": {"select": {"name": environment}},
+                "Task Summary": {"rich_text": [{"text": {"content": task_summary}}]},
+                "Action Details": {"rich_text": [{"text": {"content": action_details}}]},
+                "Verification": {"rich_text": [{"text": {"content": verification}}]},
+                "Error Summary": {"rich_text": [{"text": {"content": error_summary}}]},
+                "Root Cause": {"rich_text": [{"text": {"content": root_cause}}]},
+                "Resolution": {"rich_text": [{"text": {"content": resolution}}]},
+                "Patch Details": {"rich_text": [{"text": {"content": patch_details}}]},
+                "Release Version": {"rich_text": [{"text": {"content": release_version}}]},
+                "Release Notes": {"rich_text": [{"text": {"content": release_notes}}]},
+                "Post Monitoring": {"rich_text": [{"text": {"content": post_monitoring}}]},
+                "Status": {"select": {"name": status}},
+            },
+        }
+        return payload

--- a/tests/test_notion_client.py
+++ b/tests/test_notion_client.py
@@ -1,0 +1,20 @@
+import unittest
+from unittest import mock
+from notion_client import NotionClient
+
+
+class TestNotionClient(unittest.TestCase):
+    @mock.patch("notion_client.requests.post")
+    def test_create_page(self, mock_post):
+        mock_response = mock.Mock(status_code=200)
+        mock_post.return_value = mock_response
+
+        client = NotionClient("token", "db")
+        res = client.create_page({"key": "value"})
+
+        mock_post.assert_called_once()
+        self.assertIs(res, mock_response)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ops_log_model.py
+++ b/tests/test_ops_log_model.py
@@ -1,0 +1,23 @@
+import unittest
+from ops_log_model import OpsLogModel
+
+
+class TestOpsLogModel(unittest.TestCase):
+    def test_build_payload_basic(self):
+        payload = OpsLogModel.build_payload(
+            log_type="DevOps",
+            operator="tester",
+            module="module",
+            environment="Local",
+            task_summary="summary",
+            action_details="details",
+            database_id="db",
+        )
+        self.assertEqual(payload["parent"]["database_id"], "db")
+        props = payload["properties"]
+        self.assertEqual(props["Log Type"]["select"]["name"], "DevOps")
+        self.assertEqual(props["Operator"]["title"][0]["text"]["content"], "tester")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement NotionClient for simple Notion API requests
- create OpsLogModel to build standardized payloads
- add log_ops CLI example
- include unit tests for new modules

## Testing
- `python -m unittest discover -v`
- `pylint notion_client.py ops_log_model.py log_ops.py`
- `mypy notion_client.py ops_log_model.py log_ops.py`


------
https://chatgpt.com/codex/tasks/task_e_684e7ab3e9f8832eb831f5712f73152e