### PR TITLE
Add AB test and performance rewrite modules

### DIFF
--- a/.github/workflows/ab_analytics.yml
+++ b/.github/workflows/ab_analytics.yml
@@ -1,0 +1,16 @@
+name: Deploy AB + Analytics Workers
+on:
+  push:
+    paths:
+      - 'ab_test_*'
+      - 'analytics_worker.py'
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Render Deploy
+        uses: render-examples/action-render-deploy@v1
+        with:
+          api-key: ${{ secrets.RENDER_API_KEY }}
+          service-id: ${{ secrets.RENDER_AB_ANALYTICS_ID }}

--- a/ab_test_generator.py
+++ b/ab_test_generator.py
@@ -1,0 +1,14 @@
+"""Generate alternative text variants for A/B testing."""
+from openai import OpenAI
+
+client = OpenAI()
+
+
+def generate_variants(text: str, k: int = 2) -> list[str]:
+    """Return k alternative variants that may improve CTR."""
+    prompt = f"Generate {k} alternative variants that may achieve higher CTR:\n\n«{text}»"
+    resp = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return [v.strip("- ").strip() for v in resp.choices[0].message.content.split("\n") if v]

--- a/ab_test_worker.py
+++ b/ab_test_worker.py
@@ -1,0 +1,31 @@
+"""Worker that enqueues A/B test variants for published content."""
+import time
+from db_utils import get_conn
+from ab_test_generator import generate_variants
+
+
+while True:
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+          SELECT id, title, user_id
+          FROM content_tracker
+          WHERE status='published' AND ab_test_done IS NOT TRUE
+          LIMIT 1
+        """
+        )
+        row = cur.fetchone()
+        if row:
+            cid, title, user = row
+            variants = generate_variants(title, 2)
+            for label, text in zip(["A", "B"], variants):
+                cur.execute(
+                    """
+                  INSERT INTO ab_test_queue (content_id, variant, field, original, variant_text)
+                  VALUES (%s,%s,'title',%s,%s)
+                """,
+                    (cid, label, title, text),
+                )
+            cur.execute("UPDATE content_tracker SET ab_test_done=TRUE WHERE id=%s", (cid,))
+            conn.commit()
+    time.sleep(300)

--- a/analytics_worker.py
+++ b/analytics_worker.py
@@ -1,0 +1,23 @@
+"""Simple analytics worker that records metrics and triggers rewriting."""
+from typing import Dict
+from db_utils import get_conn
+from performance_rewriter import rewrite_for_performance
+
+
+def save_metrics(content_id: str, metrics: Dict[str, int], title: str) -> None:
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO analytics (content_id, views) VALUES (%s, %s)",
+            (content_id, metrics.get("views", 0)),
+        )
+        if metrics.get("views", 0) < 100:
+            new_title = rewrite_for_performance(title, "low views")
+            cur.execute(
+                """
+      UPDATE ab_test_queue
+      SET variant='R', field='title', original=%s, variant_text=%s
+      WHERE content_id=%s
+                """,
+                (title, new_title, content_id),
+            )
+        conn.commit()

--- a/campaign_calendar.sql
+++ b/campaign_calendar.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS campaign_calendar (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id),
+  campaign_name TEXT,
+  start_date DATE,
+  end_date DATE,
+  goal_views BIGINT,
+  goal_signups BIGINT,
+  notes TEXT
+);

--- a/performance_rewriter.py
+++ b/performance_rewriter.py
@@ -1,0 +1,18 @@
+"""Rewrite underperforming titles or text to improve CTR."""
+from openai import OpenAI
+
+client = OpenAI()
+
+
+def rewrite_for_performance(title: str, fail_reason: str) -> str:
+    """Return a rewritten title addressing the given failure reason."""
+    prompt = (
+        f"The following title under-performed ({fail_reason}). "
+        "Rewrite it to be more eye-catching, max 60 chars:\n\n"
+        f"Original: {title}"
+    )
+    resp = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return resp.choices[0].message.content.strip()

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS ab_test_queue (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  content_id UUID REFERENCES content_tracker(id),
+  variant TEXT,
+  field TEXT,
+  original TEXT,
+  variant_text TEXT,
+  status TEXT DEFAULT 'queued',
+  created_at TIMESTAMP DEFAULT now()
+);

--- a/vinfinity_flow_v3.md
+++ b/vinfinity_flow_v3.md
@@ -1,0 +1,9 @@
+```mermaid
+flowchart LR
+    A[Published Content] --> B[Analytics Worker]
+    B --> C{Under-perform?}
+    C -- Yes --> D[Performance Rewriter]
+    D --> E[AB Test Queue]
+    E --> F[AB Test Worker] --> G[OSMU/Upload]
+    B -- No --> H[Success Tag]
+```


### PR DESCRIPTION
## Summary
- add SQL schema for A/B test queue and campaign calendar
- implement `ab_test_generator` and `ab_test_worker`
- add performance rewriter and analytics worker modules
- deploy workflow for A/B and analytics workers
- document new data flow

## Testing
- `python -m py_compile ab_test_generator.py ab_test_worker.py performance_rewriter.py analytics_worker.py`

------
https://chatgpt.com/codex/tasks/task_e_684e7abef550832ea193c27e4258532d