### PR TITLE
Add missing pipeline scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Auto Pipeline
+
+This repository contains a small set of scripts for generating marketing hooks and uploading them to Notion.  The pipeline is orchestrated by `run_pipeline.py` and executes a sequence of helper scripts located in `scripts/`.
+
+## Pipeline Steps
+
+1. **hook_generator.py** – Generates hook text for each keyword using GPT and saves both successful and failed results.
+2. **parse_failed_gpt.py** – Parses the raw GPT output from `logs/failed_hooks.json` and stores a structured version in `logs/failed_keywords_reparsed.json`.
+3. **retry_failed_uploads.py** – Attempts to upload any items that previously failed, using the parsed results.
+4. **notify_retry_result.py** – Sends a short summary of the retry outcome to Slack (or prints the message if no webhook is configured).
+5. **retry_dashboard_notifier.py** – Records aggregated retry statistics in a Notion KPI database.
+
+Run the pipeline with:
+
+```bash
+python run_pipeline.py
+```
+
+Each script relies on environment variables for API tokens and paths. See the individual files for details.

--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,42 @@
+import os
+import json
+import logging
+from dotenv import load_dotenv
+import requests
+
+load_dotenv()
+REPARSED_OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+def build_summary():
+    if not os.path.exists(REPARSED_OUTPUT_PATH):
+        logging.warning(f"재시도 결과 파일이 없습니다: {REPARSED_OUTPUT_PATH}")
+        return "재시도 결과 파일이 존재하지 않습니다."
+
+    with open(REPARSED_OUTPUT_PATH, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    total = len(data)
+    failed = len([d for d in data if d.get("retry_error")])
+    success = total - failed
+    return f"총 시도: {total}\n성공: {success}\n실패: {failed}"
+
+def send_slack(message: str):
+    if not SLACK_WEBHOOK_URL:
+        logging.info("SLACK_WEBHOOK_URL이 설정되지 않아 출력만 진행합니다.")
+        print(message)
+        return
+    try:
+        response = requests.post(SLACK_WEBHOOK_URL, json={"text": message})
+        if response.status_code == 200:
+            logging.info("슬랙 알림 전송 성공")
+        else:
+            logging.error(f"슬랙 전송 실패: {response.status_code} {response.text}")
+    except Exception as e:
+        logging.error(f"슬랙 요청 실패: {e}")
+
+if __name__ == "__main__":
+    summary = build_summary()
+    send_slack(summary)

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,43 @@
+import os
+import json
+import logging
+import re
+from dotenv import load_dotenv
+
+load_dotenv()
+FAILED_HOOK_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+REPARSED_OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+def parse_generated_text(text: str):
+    hook_lines = re.findall(r"후킹 ?문장[0-9]?[\s:：\-\)]*([^\n]+)", text)
+    blog_match = re.search(r"블로그(?:\s*초안)?[\s:：\-\)]*(.*?)\n+\s*(.*?\n+.*?\n+.*?)(?:\n|$)", text, re.DOTALL)
+    video_titles = re.findall(r"(?:영상 제목|YouTube 제목)[\s:：\-\)]*[^\n]*\n?-\s*(.+)", text)
+    blog_paragraphs = [p.strip() for p in blog_match[1].strip().split('\n')[:3]] if blog_match else ["", "", ""]
+    return {
+        "hook_lines": hook_lines[:2] if len(hook_lines) >= 2 else ["", ""],
+        "blog_paragraphs": blog_paragraphs,
+        "video_titles": video_titles[:2] if video_titles else ["", ""]
+    }
+
+def parse_failed_items():
+    if not os.path.exists(FAILED_HOOK_PATH):
+        logging.error(f"❌ 실패 로그 파일이 없습니다: {FAILED_HOOK_PATH}")
+        return
+
+    with open(FAILED_HOOK_PATH, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    for item in data:
+        text = item.get("generated_text", "")
+        item["parsed"] = parse_generated_text(text)
+
+    os.makedirs(os.path.dirname(REPARSED_OUTPUT_PATH), exist_ok=True)
+    with open(REPARSED_OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+    logging.info(f"✅ 파싱 결과 저장: {REPARSED_OUTPUT_PATH}")
+
+if __name__ == "__main__":
+    parse_failed_items()


### PR DESCRIPTION
## Summary
- implement missing pipeline steps `parse_failed_gpt.py` and `notify_retry_result.py`
- add README with overall pipeline explanation

## Testing
- `pytest -q`
- `pylint $(git ls-files '*.py')`
- `mypy $(git ls-files '*.py')` *(fails: duplicate module name)*

------
https://chatgpt.com/codex/tasks/task_e_684e73f2945c832e8e0c5904a5ad1161