### PR TITLE
Add requirements file and setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Auto Pipeline
+
+This repository contains scripts for running the Notion hook generation pipeline.
+
+## Setup
+
+1. Ensure Python 3.10 or higher is installed.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Running
+
+Execute the pipeline using:
+```bash
+python run_pipeline.py
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+openai==1.86.0
+pytrends==4.9.2
+snscrape==0.7.0.20230622
+notion-client==2.3.0
+python-dotenv==1.1.0


### PR DESCRIPTION
## Summary
- add a requirements.txt listing core packages with pinned versions
- document how to install dependencies in README
- workflow already installs from requirements.txt

## Testing
- `pip install openai pytrends snscrape notion-client python-dotenv`

------
https://chatgpt.com/codex/tasks/task_e_684e73f87250832ea83f9e159354bb07