### PR TITLE
Fix pipeline workflow path

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()


### PR DESCRIPTION
## Summary
- correct daily pipeline workflow to invoke `run_pipeline.py` from repo root

## Testing
- `pylint run_pipeline.py`
- `mypy run_pipeline.py`
- `act -n -j run-pipeline -W .github/workflows/daily-pipeline.yml.txt` *(fails: couldn't get a valid Docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_684e73f8a4c4832eb6ea4475b796f2ad