### PR TITLE
Add deployment scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Application settings
+OPENAI_API_KEY=
+NOTION_API_TOKEN=
+NOTION_HOOK_DB_ID=
+NOTION_KPI_DB_ID=
+SLACK_WEBHOOK_URL=
+KEYWORD_OUTPUT_PATH=data/keyword_output_with_cpc.json
+HOOK_OUTPUT_PATH=data/generated_hooks.json
+FAILED_HOOK_PATH=logs/failed_hooks.json
+UPLOAD_DELAY=0.5
+API_DELAY=1.0
+
+# Database credentials
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=postgres
+PGADMIN_DEFAULT_EMAIL=admin@example.com
+PGADMIN_DEFAULT_PASSWORD=admin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "run_pipeline.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.9'
+services:
+  supabase:
+    image: supabase/postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-postgres}
+    volumes:
+      - supabase-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  pgadmin:
+    image: dpage/pgadmin4
+    restart: unless-stopped
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-admin@example.com}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
+    ports:
+      - "8080:80"
+    depends_on:
+      - supabase
+
+  app:
+    build: .
+    env_file:
+      - .env
+    depends_on:
+      - supabase
+    command: python run_pipeline.py
+
+volumes:
+  supabase-data:

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,10 @@
+{
+  "services": [
+    {
+      "name": "codex-pipeline",
+      "dockerfile": "Dockerfile",
+      "startCommand": "python run_pipeline.py"
+    }
+  ],
+  "plugins": ["postgresql"]
+}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,15 @@
+services:
+  - type: web
+    name: codex-pipeline
+    env: docker
+    plan: starter
+    dockerfilePath: ./Dockerfile
+    autoDeploy: false
+    envVars:
+      - key: OPENAI_API_KEY
+        sync: false
+      - key: NOTION_API_TOKEN
+        sync: false
+      - key: POSTGRES_PASSWORD
+        sync: false
+    startCommand: python run_pipeline.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+openai
+python-dotenv
+notion-client

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,41 @@
+-- Supabase initial schema
+
+CREATE TABLE IF NOT EXISTS content_tracker (
+    id SERIAL PRIMARY KEY,
+    content_id TEXT NOT NULL UNIQUE,
+    generated_at TIMESTAMPTZ DEFAULT NOW(),
+    status TEXT NOT NULL,
+    metadata JSONB
+);
+
+CREATE TABLE IF NOT EXISTS performance_tracker (
+    id SERIAL PRIMARY KEY,
+    content_id TEXT NOT NULL REFERENCES content_tracker(content_id),
+    metric TEXT NOT NULL,
+    value NUMERIC,
+    recorded_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS scheduler_queue (
+    id SERIAL PRIMARY KEY,
+    job_name TEXT NOT NULL,
+    payload JSONB,
+    scheduled_for TIMESTAMPTZ,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS pipeline_runs (
+    id SERIAL PRIMARY KEY,
+    started_at TIMESTAMPTZ DEFAULT NOW(),
+    finished_at TIMESTAMPTZ,
+    status TEXT NOT NULL,
+    details JSONB
+);
+
+CREATE TABLE IF NOT EXISTS error_logs (
+    id SERIAL PRIMARY KEY,
+    run_id INTEGER REFERENCES pipeline_runs(id),
+    message TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- add container build with Dockerfile and requirements
- compose supabase, pgadmin, and pipeline app
- provide Supabase schema
- supply env template and SaaS deploy configs for Render and Railway

## Testing
- `pytest -q`
- `pylint $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e7453449c832eaff38bdce066e909