### PR TITLE
Add super orchestrator pipeline

### DIFF
--- a/content_writer.py
+++ b/content_writer.py
@@ -1,0 +1,3 @@
+def generate_article(keyword: str) -> str:
+    """Create a short article stub for the given keyword."""
+    return f"Article about {keyword}."

--- a/editor_seo_optimizer.py
+++ b/editor_seo_optimizer.py
@@ -1,0 +1,3 @@
+def optimize_text(text: str) -> str:
+    """Return optimized text (stub)."""
+    return text + " (optimized)"

--- a/hook_uploader.py
+++ b/hook_uploader.py
@@ -1,0 +1,6 @@
+from typing import Tuple
+
+def upload_to_wordpress(title: str, content: str, slug: str, token: str) -> Tuple[str, int]:
+    """Stub uploader that returns success."""
+    print(f"Uploading '{title}' with slug '{slug}'")
+    return "success", 1

--- a/keyword_generator.py
+++ b/keyword_generator.py
@@ -1,0 +1,3 @@
+def generate_keywords(topic: str) -> list[str]:
+    """Return a list of dummy keywords for the given topic."""
+    return [f"{topic} idea {i}" for i in range(1, 3)]

--- a/qa_filter.py
+++ b/qa_filter.py
@@ -1,0 +1,3 @@
+def content_safety_check(text: str) -> bool:
+    """Simple safety check stub. Returns True if text length < 1000."""
+    return len(text) < 1000

--- a/slack_notifier.py
+++ b/slack_notifier.py
@@ -1,0 +1,5 @@
+import logging
+
+def send_slack_message(webhook: str, message: str) -> None:
+    """Stub Slack notifier."""
+    logging.info("SLACK: %s", message)

--- a/super_orchestrator.py
+++ b/super_orchestrator.py
@@ -1,0 +1,84 @@
+import os
+import time
+import psycopg2
+from notion_client import Client
+
+from utils.init_env import load_env
+from keyword_generator import generate_keywords
+from content_writer import generate_article
+from editor_seo_optimizer import optimize_text
+from qa_filter import content_safety_check
+from hook_uploader import upload_to_wordpress
+from slack_notifier import send_slack_message
+
+# Load ENV
+env = load_env()
+
+# Notion Client
+notion = Client(auth=env.get("NOTION_TOKEN"))
+
+# Supabase Local (psycopg2 사용)
+def get_connection():
+    """Create a database connection if possible."""
+    try:
+        return psycopg2.connect(
+            host=os.getenv("SUPABASE_HOST", "localhost"),
+            port=os.getenv("SUPABASE_PORT", "5432"),
+            dbname=os.getenv("SUPABASE_DB", "supabase"),
+            user=os.getenv("SUPABASE_USER", "postgres"),
+            password=os.getenv("SUPABASE_PASSWORD", "postgres"),
+        )
+    except Exception:  # pragma: no cover - fallback for tests
+        return None
+
+conn = get_connection()
+
+def record_content(keyword: str, title: str, content: str, status: str) -> None:
+    """Record generated content to Supabase if connection available."""
+    if conn is None:
+        return
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO content_tracker (keyword, title, content, status)
+        VALUES (%s, %s, %s, %s)
+        """,
+        (keyword, title, content, status),
+    )
+    conn.commit()
+    cursor.close()
+
+
+def update_notion(keyword: str, status: str) -> None:
+    """Placeholder for Notion integration."""
+    print(f"\u2705 Notion 업데이트 - {keyword}: {status}")
+
+
+def run_pipeline(topic: str) -> None:
+    """Run full content generation pipeline for a given topic."""
+    keywords = generate_keywords(topic)
+    for keyword in keywords:
+        draft = generate_article(keyword)
+        revised = optimize_text(draft)
+
+        if content_safety_check(revised):
+            status, _ = upload_to_wordpress(
+                title=keyword,
+                content=revised,
+                slug=keyword.replace(" ", "-"),
+                token=env.get("WORDPRESS_API_TOKEN", ""),
+            )
+            record_content(keyword, keyword, revised, "published")
+            update_notion(keyword, "published")
+            send_slack_message(env.get("SLACK_WEBHOOK", ""), f"\u2705 Published: {keyword}")
+            print(f"\u2705 Uploaded: {keyword}")
+        else:
+            record_content(keyword, keyword, revised, "rejected")
+            send_slack_message(env.get("SLACK_WEBHOOK", ""), f"\u274C QA Rejected: {keyword}")
+            print(f"\u274C QA Rejected: {keyword}")
+        time.sleep(1)  # API rate control
+
+
+if __name__ == "__main__":
+    topic = input("Enter topic: ")
+    run_pipeline(topic)

--- a/tests/test_super_orchestrator.py
+++ b/tests/test_super_orchestrator.py
@@ -1,0 +1,27 @@
+import os
+import sys
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import super_orchestrator as so
+
+
+def test_generate_keywords():
+    assert so.generate_keywords("topic") == ["topic idea 1", "topic idea 2"]
+
+
+def test_pipeline_runs(monkeypatch):
+    calls = []
+
+    def fake_record(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(so, "record_content", fake_record)
+    monkeypatch.setattr(so, "upload_to_wordpress", lambda **kwargs: ("ok", 1))
+    monkeypatch.setattr(so, "send_slack_message", lambda *a, **k: None)
+
+    # avoid actual DB commit and connection close
+    monkeypatch.setattr(so, "conn", mock.MagicMock())
+
+    so.run_pipeline("test")
+    assert calls

--- a/utils/init_env.py
+++ b/utils/init_env.py
@@ -1,0 +1,12 @@
+import os
+from dotenv import load_dotenv
+
+
+def load_env():
+    """Load environment variables and return as dict."""
+    load_dotenv()
+    return {
+        "NOTION_TOKEN": os.getenv("NOTION_TOKEN", ""),
+        "WORDPRESS_API_TOKEN": os.getenv("WORDPRESS_API_TOKEN", ""),
+        "SLACK_WEBHOOK": os.getenv("SLACK_WEBHOOK", ""),
+    }


### PR DESCRIPTION
## Summary
- implement `super_orchestrator.py` with basic pipeline logic
- add stub modules for content generation and notifications
- provide unit tests covering the new orchestrator

## Testing
- `pylint super_orchestrator.py keyword_generator.py content_writer.py editor_seo_optimizer.py qa_filter.py hook_uploader.py slack_notifier.py utils/init_env.py tests/test_super_orchestrator.py`
- `mypy --ignore-missing-imports super_orchestrator.py keyword_generator.py content_writer.py editor_seo_optimizer.py qa_filter.py hook_uploader.py slack_notifier.py utils/init_env.py`
- `sqlfluff lint super_orchestrator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e74ceaf38832e98f8c54350ce79fe