### PR TITLE
Add Supabase insight uploader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .env
 logs/
+
+__pycache__/
+*.pyc

--- a/auto_insight.py
+++ b/auto_insight.py
@@ -1,0 +1,95 @@
+import os
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, List
+
+from dotenv import load_dotenv
+from notion_client import Client as NotionClient
+from supabase import create_client, Client as SupabaseClient
+
+load_dotenv()
+
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_KEY = os.getenv("SUPABASE_KEY")
+INSIGHT_TABLE = os.getenv("INSIGHT_TABLE", "performance_summary")
+
+NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
+NOTION_INSIGHT_DB_ID = os.getenv("NOTION_INSIGHT_DB_ID")
+UPLOAD_DELAY = float(os.getenv("UPLOAD_DELAY", "0.5"))
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+supabase: SupabaseClient | None = None
+notion: NotionClient | None = None
+
+if SUPABASE_URL and SUPABASE_KEY:
+    supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
+else:
+    logging.warning("Supabase credentials missing. fetch_insights will return []")
+
+if NOTION_TOKEN:
+    notion = NotionClient(auth=NOTION_TOKEN)
+
+@dataclass
+class InsightRecord:
+    id: Any
+    summary: str
+    created_at: str | None = None
+
+
+def fetch_insights(client: SupabaseClient | None = None) -> List[dict]:
+    """Fetch insight rows from Supabase."""
+    client = client or supabase
+    if client is None:
+        return []
+    try:
+        response = client.table(INSIGHT_TABLE).select("*").execute()
+        data = getattr(response, "data", [])
+        logging.info("Fetched %d rows from Supabase", len(data))
+        return data
+    except Exception as exc:  # pylint: disable=broad-except
+        logging.error("Supabase fetch error: %s", exc)
+        return []
+
+
+def create_notion_page(record: dict, client: NotionClient | None = None) -> None:
+    """Upload a single record to Notion."""
+    client = client or notion
+    if client is None or NOTION_INSIGHT_DB_ID is None:
+        logging.error("Notion credentials missing")
+        return
+    props = {
+        "요약": {"title": [{"text": {"content": str(record.get("summary", ""))}}]},
+        "SupabaseID": {"rich_text": [{"text": {"content": str(record.get("id", ""))}}]},
+        "등록일": {"date": {"start": datetime.utcnow().isoformat() + "Z"}},
+    }
+    try:
+        client.pages.create(parent={"database_id": NOTION_INSIGHT_DB_ID}, properties=props)
+        logging.info("Uploaded record %s to Notion", record.get("id"))
+    except Exception as exc:  # pylint: disable=broad-except
+        logging.error("Failed to upload record %s: %s", record.get("id"), exc)
+
+
+def upload_insights(records: List[dict], client: NotionClient | None = None) -> None:
+    """Upload multiple records to Notion."""
+    for rec in records:
+        create_notion_page(rec, client)
+        if UPLOAD_DELAY:
+            try:
+                import time
+                time.sleep(UPLOAD_DELAY)
+            except Exception:  # pragma: no cover - sleep errors not expected
+                pass
+
+
+def run() -> None:
+    data = fetch_insights()
+    if not data:
+        logging.info("No insight data fetched")
+        return
+    upload_insights(data)
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_auto_insight.py
+++ b/tests/test_auto_insight.py
@@ -1,0 +1,48 @@
+import types
+from unittest.mock import MagicMock
+
+import auto_insight as ai
+
+class DummyResponse:
+    def __init__(self, data):
+        self.data = data
+
+class DummyTable:
+    def __init__(self, data):
+        self._data = data
+    def select(self, *args, **kwargs):
+        return self
+    def execute(self):
+        return DummyResponse(self._data)
+
+class DummySupabase:
+    def __init__(self, data):
+        self._data = data
+    def table(self, name):
+        assert name == ai.INSIGHT_TABLE
+        return DummyTable(self._data)
+
+class DummyNotion:
+    def __init__(self):
+        self.pages = MagicMock()
+
+def test_fetch_insights():
+    data = [{"id": 1, "summary": "a"}]
+    client = DummySupabase(data)
+    result = ai.fetch_insights(client)
+    assert result == data
+
+def test_create_notion_page(monkeypatch):
+    notion = DummyNotion()
+    monkeypatch.setattr(ai, "NOTION_INSIGHT_DB_ID", "db")
+    ai.create_notion_page({"id": 1, "summary": "hello"}, notion)
+    notion.pages.create.assert_called_once()
+    props = notion.pages.create.call_args[1]["properties"]
+    assert props["요약"]["title"][0]["text"]["content"] == "hello"
+
+def test_upload_insights(monkeypatch):
+    notion = DummyNotion()
+    monkeypatch.setattr(ai, "NOTION_INSIGHT_DB_ID", "db")
+    records = [{"id": 1, "summary": "x"}, {"id": 2, "summary": "y"}]
+    ai.upload_insights(records, notion)
+    assert notion.pages.create.call_count == 2


### PR DESCRIPTION
## Summary
- add `auto_insight.py` for pushing Supabase records to a Notion DB
- unit tests for the new module
- ignore `__pycache__` and pyc files

## Testing
- `python -m pytest -q`
- `PYTHONPATH=. pytest -q`
- `pylint auto_insight.py tests/test_auto_insight.py` *(fails: code rating 7.94/10)*
- `mypy auto_insight.py tests/test_auto_insight.py`


------
https://chatgpt.com/codex/tasks/task_e_684e3f7a4894832e8b4db8031cc4f080