### PR TITLE
Add keyword generator utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .env
 logs/
+__pycache__/
+*.log
+tests/__pycache__/

--- a/keyword_content_generator.py
+++ b/keyword_content_generator.py
@@ -1,0 +1,25 @@
+"""Utility to generate SEO-friendly keywords using OpenAI."""
+
+from openai import OpenAI  # pylint: disable=import-error
+
+
+def generate_keywords(topic: str, tone: str = "trendy") -> list[str]:
+    """Generate SEO-friendly keywords using OpenAI."""
+    prompt = f"Generate 10 {tone} SEO-optimized keywords for the topic: '{topic}'"
+    client = OpenAI()
+    response = client.chat.completions.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": prompt}]
+    )
+    # Split lines and filter out any empty strings
+    return [kw.strip() for kw in response.choices[0].message.content.split("\n") if kw.strip()]
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Generate keyword ideas via OpenAI")
+    parser.add_argument("topic", help="Topic to generate keywords for")
+    parser.add_argument("--tone", default="trendy", help="Tone for the keywords")
+    args = parser.parse_args()
+    for kw in generate_keywords(args.topic, args.tone):
+        print(kw)

--- a/tests/test_keyword_content_generator.py
+++ b/tests/test_keyword_content_generator.py
@@ -1,0 +1,15 @@
+from unittest import mock
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import keyword_content_generator as kc
+
+
+def test_generate_keywords_parses_lines():
+    fake_response = mock.Mock()
+    fake_response.choices = [mock.Mock(message=mock.Mock(content="kw1\nkw2\n"))]
+    with mock.patch('keyword_content_generator.OpenAI') as mock_openai:
+        mock_openai.return_value.chat.completions.create.return_value = fake_response
+        result = kc.generate_keywords("test")
+    assert result == ["kw1", "kw2"]


### PR DESCRIPTION
## Summary
- implement `keyword_content_generator.py` script using OpenAI
- ignore logs and cache directories
- add unit test for keyword generator

## Testing
- `pylint keyword_content_generator.py`
- `mypy --ignore-missing-imports keyword_content_generator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e3fc82908832e90793a0bbd4d2619