### PR TITLE
Add content writer module

### DIFF
--- a/content_writer.py
+++ b/content_writer.py
@@ -1,0 +1,26 @@
+"""SEO content generator module."""
+from typing import Any
+# ✅ SEO 기반 원고 자동 생성기
+from openai import OpenAI
+
+
+def generate_article(keyword: str, word_count: int = 600, tone: str = "neutral") -> str:
+    """Generate an SEO-friendly article using OpenAI's chat completion API.
+
+    Args:
+        keyword: The topic keyword for the article.
+        word_count: Approximate number of words for the post.
+        tone: Desired tone of the article.
+
+    Returns:
+        Generated article text.
+    """
+    prompt = (
+        f"Write a {tone} tone SEO blog post about '{keyword}' "
+        f"in approximately {word_count} words."
+    )
+    response: Any = OpenAI().chat.completions.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message.content.strip()

--- a/tests/test_content_writer.py
+++ b/tests/test_content_writer.py
@@ -1,0 +1,36 @@
+"""Tests for content_writer module."""
+# pylint: disable=too-few-public-methods
+# pylint: disable=wrong-import-position
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from content_writer import generate_article
+
+
+class DummyChoice:
+    """A dummy choice object for mocking."""
+
+    def __init__(self, content: str):
+        self.message = MagicMock(content=content)
+
+
+class DummyResponse:
+    """A dummy response object for mocking."""
+
+    def __init__(self, content: str):
+        self.choices = [DummyChoice(content)]
+
+
+def test_generate_article_returns_text():
+    """Test generate_article returns expected text."""
+    dummy_response = DummyResponse("Generated text")
+    with patch("content_writer.OpenAI") as mock_openai:
+        instance = mock_openai.return_value
+        instance.chat.completions.create.return_value = dummy_response
+        result = generate_article("test keyword", word_count=100, tone="friendly")
+
+    assert result == "Generated text"
+    instance.chat.completions.create.assert_called_once()


### PR DESCRIPTION
## Summary
- implement `content_writer` to generate SEO articles
- add unit test for new module

## Testing
- `pytest -q`
- `pylint content_writer.py tests/test_content_writer.py`
- `mypy content_writer.py tests/test_content_writer.py`


------
https://chatgpt.com/codex/tasks/task_e_684e3fd00eec832ebade601f29c0ee75