### PR TITLE
Add OpenAI content safety checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .env
 logs/
+__pycache__/
+.pytest_cache/
+.mypy_cache/

--- a/qa_filter.py
+++ b/qa_filter.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""Utility for checking content safety using OpenAI's moderation models."""
+from openai import OpenAI
+
+
+def content_safety_check(text: str) -> bool:
+    """Return ``True`` if the given text passes the safety check.
+
+    The function queries OpenAI's ChatCompletion endpoint with a prompt asking
+    whether the provided ``text`` violates community guidelines. Only "YES" or
+    "NO" is expected as a response. Any variant of "YES" indicates the text is
+    unsafe.
+    """
+    prompt = (
+        "Does this content violate any community guidelines, ethical standards, "
+        "or include offensive terms?\n\n"
+        f"{text}\n\nReply only 'YES' or 'NO'."
+    )
+    response = OpenAI().chat.completions.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    text_response = response.choices[0].message.content or ""
+    return "YES" not in text_response.upper()

--- a/tests/test_qa_filter.py
+++ b/tests/test_qa_filter.py
@@ -1,0 +1,29 @@
+"""Tests for the qa_filter module."""
+
+from types import SimpleNamespace
+import qa_filter
+
+
+class DummyClient:  # pylint: disable=too-few-public-methods
+    """Simple stand-in for the OpenAI client used in tests."""
+
+    def __init__(self, response: str) -> None:
+        message = SimpleNamespace(content=response)
+        choice = SimpleNamespace(message=message)
+        self.chat = SimpleNamespace(
+            completions=SimpleNamespace(
+                create=lambda model, messages: SimpleNamespace(choices=[choice])
+            )
+        )
+
+
+def test_content_safety_check_safe(monkeypatch):
+    """The function should return True when the API responds with 'NO'."""
+    monkeypatch.setattr(qa_filter, "OpenAI", lambda: DummyClient("NO"))
+    assert qa_filter.content_safety_check("hello") is True
+
+
+def test_content_safety_check_unsafe(monkeypatch):
+    """The function should return False when the API responds with 'YES'."""
+    monkeypatch.setattr(qa_filter, "OpenAI", lambda: DummyClient("YES"))
+    assert qa_filter.content_safety_check("bad stuff") is False


### PR DESCRIPTION
## Summary
- introduce `qa_filter.py` with helper `content_safety_check`
- add unit tests for the safety check utility
- ignore caches in `.gitignore`

## Testing
- `mypy qa_filter.py tests/test_qa_filter.py`
- `pylint qa_filter.py tests/test_qa_filter.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e3fdb89e0832eaec8f910b3db6e9e