### PR TITLE
Add Notion sync utility

### DIFF
--- a/notion_sync.py
+++ b/notion_sync.py
@@ -1,0 +1,17 @@
+"""Utility to update Notion page status."""
+
+from notion_client import Client  # type: ignore  # pylint: disable=import-error
+
+notion = Client(auth="your_notion_token")
+
+
+def update_notion_status(page_id: str, status: str) -> None:
+    """Update the given Notion page's status property."""
+    notion.pages.update(
+        page_id=page_id,
+        properties={
+            "Status": {
+                "select": {"name": status}
+            }
+        }
+    )


### PR DESCRIPTION
## Summary
- add `notion_sync.py` helper for updating Notion page status

## Testing
- `pytest -q`
- `mypy notion_sync.py --ignore-missing-imports`
- `pylint notion_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_684e3feb21dc832e8294ef1a04ef67d8