### PR TITLE
Add scheduler module with daily trigger

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,29 @@
+"""Simple scheduler to trigger the content pipeline."""
+
+import time
+import schedule
+
+from run_pipeline import run_pipeline
+
+
+def job() -> None:
+    """Trigger the content pipeline."""
+    print("🚀 Content Pipeline Triggered")
+    run_pipeline()
+
+
+def setup_scheduler() -> None:
+    """Configure the daily schedule."""
+    schedule.every().day.at("10:00").do(job)
+
+
+def start_scheduler() -> None:
+    """Start the scheduler loop."""
+    setup_scheduler()
+    while True:
+        schedule.run_pending()
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    start_scheduler()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,27 @@
+"""Tests for the scheduler module."""
+
+from unittest.mock import patch
+import schedule
+
+import scheduler
+
+
+def test_job_triggers_pipeline_and_prints(capsys):
+    """Ensure job prints the trigger message and calls the pipeline."""
+    with patch('scheduler.run_pipeline') as run_mock:
+        scheduler.job()
+        captured = capsys.readouterr()
+        assert "Content Pipeline Triggered" in captured.out
+        run_mock.assert_called_once()
+
+
+def test_setup_scheduler_adds_daily_job():
+    """Verify that a job is scheduled for 10:00 every day."""
+    schedule.clear()
+    scheduler.setup_scheduler()
+    jobs = schedule.get_jobs()
+    assert len(jobs) == 1
+    job = jobs[0]
+    assert job.at_time.hour == 10
+    assert job.at_time.minute == 0
+    schedule.clear()


### PR DESCRIPTION
## Summary
- add `scheduler.py` to run the pipeline daily at 10:00
- include unit tests for scheduler behavior

## Testing
- `mypy scheduler.py tests/test_scheduler.py`
- `pylint scheduler.py tests/test_scheduler.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e3fed1874832e9a3f941ab464ca92