### PR TITLE
Add Slack notifier with test

### DIFF
--- a/slack_notifier.py
+++ b/slack_notifier.py
@@ -1,0 +1,27 @@
+"""Utility for sending Slack notifications."""
+
+import os
+import sys
+import requests
+
+
+def send_slack_message(webhook_url: str, message: str) -> int:
+    """Send a message to Slack via an incoming webhook."""
+    payload = {"text": message}
+    response = requests.post(webhook_url, json=payload, timeout=10)
+    return response.status_code
+
+
+def main() -> None:
+    """Send a message provided via command line arguments."""
+    url = os.getenv("SLACK_WEBHOOK_URL")
+    if not url:
+        raise SystemExit("SLACK_WEBHOOK_URL environment variable is not set")
+
+    message = " ".join(sys.argv[1:]) or "Pipeline notification"
+    status = send_slack_message(url, message)
+    print(f"Slack response status: {status}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_slack_notifier.py
+++ b/tests/test_slack_notifier.py
@@ -1,0 +1,14 @@
+"""Tests for the Slack notifier utility."""
+from unittest.mock import patch, MagicMock
+
+import slack_notifier
+
+
+def test_send_slack_message_success():
+    """send_slack_message should post message payload and return status code."""
+    with patch('requests.post') as mock_post:
+        mock_resp = MagicMock(status_code=200)
+        mock_post.return_value = mock_resp
+        status = slack_notifier.send_slack_message('http://example.com', 'hello')
+        mock_post.assert_called_once_with('http://example.com', json={'text': 'hello'}, timeout=10)
+        assert status == 200


### PR DESCRIPTION
## Summary
- add `slack_notifier.py` utility
- add unit test for Slack notifier

## Testing
- `python -m pytest -q`
- `pylint slack_notifier.py tests/test_slack_notifier.py`
- `mypy slack_notifier.py tests/test_slack_notifier.py`


------
https://chatgpt.com/codex/tasks/task_e_684e3ff279c0832eb683d7b0b83ec38b