### PR TITLE
Add pipeline orchestrator and tests

### DIFF
--- a/content_writer.py
+++ b/content_writer.py
@@ -1,0 +1,3 @@
+def generate_article(keyword: str) -> str:
+    """Return a simple article draft for the given keyword."""
+    return f"Draft content about {keyword}."

--- a/editor_seo_optimizer.py
+++ b/editor_seo_optimizer.py
@@ -1,0 +1,3 @@
+def optimize_text(text: str) -> str:
+    """Dummy SEO optimization step."""
+    return text + " (SEO optimized)"

--- a/hook_uploader.py
+++ b/hook_uploader.py
@@ -1,0 +1,3 @@
+def upload_to_wordpress(title: str, content: str, slug: str, token: str):
+    """Return a fake upload status and response."""
+    return 201, {"title": title, "slug": slug}

--- a/keyword_generator.py
+++ b/keyword_generator.py
@@ -1,0 +1,3 @@
+def generate_keywords(topic: str) -> list[str]:
+    """Return a list of example keywords for the given topic."""
+    return [f"{topic} example1", f"{topic} example2"]

--- a/pipeline_orchestrator.py
+++ b/pipeline_orchestrator.py
@@ -1,0 +1,23 @@
+from keyword_generator import generate_keywords
+from content_writer import generate_article
+from editor_seo_optimizer import optimize_text
+from qa_filter import content_safety_check
+from hook_uploader import upload_to_wordpress
+
+
+def run_pipeline(topic: str, token: str) -> None:
+    """Run the content generation pipeline for a given topic."""
+    keywords = generate_keywords(topic)
+    for keyword in keywords:
+        draft = generate_article(keyword)
+        revised = optimize_text(draft)
+        if content_safety_check(revised):
+            status, _ = upload_to_wordpress(
+                title=keyword,
+                content=revised,
+                slug=keyword.replace(" ", "-"),
+                token=token,
+            )
+            print(f"✅ Uploaded '{keyword}' with status {status}")
+        else:
+            print(f"⚠️ Content rejected for: {keyword}")

--- a/qa_filter.py
+++ b/qa_filter.py
@@ -1,0 +1,3 @@
+def content_safety_check(text: str) -> bool:
+    """Always approve content in this stub."""
+    return True

--- a/tests/test_pipeline_orchestrator.py
+++ b/tests/test_pipeline_orchestrator.py
@@ -1,0 +1,44 @@
+import unittest
+from unittest.mock import patch
+import pipeline_orchestrator
+
+
+class PipelineOrchestratorTests(unittest.TestCase):
+    @patch('pipeline_orchestrator.upload_to_wordpress')
+    @patch('pipeline_orchestrator.content_safety_check')
+    @patch('pipeline_orchestrator.optimize_text')
+    @patch('pipeline_orchestrator.generate_article')
+    @patch('pipeline_orchestrator.generate_keywords')
+    def test_run_pipeline_uploads_when_safe(self, mock_keywords, mock_article, mock_optimize, mock_check, mock_upload):
+        mock_keywords.return_value = ['kw']
+        mock_article.return_value = 'draft'
+        mock_optimize.return_value = 'revised'
+        mock_check.return_value = True
+        mock_upload.return_value = (200, {})
+
+        pipeline_orchestrator.run_pipeline('topic', 'token')
+
+        mock_keywords.assert_called_once_with('topic')
+        mock_article.assert_called_once_with('kw')
+        mock_optimize.assert_called_once_with('draft')
+        mock_check.assert_called_once_with('revised')
+        mock_upload.assert_called_once_with(title='kw', content='revised', slug='kw', token='token')
+
+    @patch('pipeline_orchestrator.upload_to_wordpress')
+    @patch('pipeline_orchestrator.content_safety_check')
+    @patch('pipeline_orchestrator.optimize_text')
+    @patch('pipeline_orchestrator.generate_article')
+    @patch('pipeline_orchestrator.generate_keywords')
+    def test_run_pipeline_skips_when_unsafe(self, mock_keywords, mock_article, mock_optimize, mock_check, mock_upload):
+        mock_keywords.return_value = ['kw']
+        mock_article.return_value = 'draft'
+        mock_optimize.return_value = 'revised'
+        mock_check.return_value = False
+
+        pipeline_orchestrator.run_pipeline('topic', 'token')
+
+        mock_upload.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new `pipeline_orchestrator` module for full content workflow
- stub out helper modules used by orchestrator
- create unit tests covering safe and unsafe scenarios

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pylint pipeline_orchestrator.py` *(fails: command not found)*
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_684e3ff80098832ea7ceb3f34b79213c