### PR TITLE
Implement tenacity retries and add retry tests

### DIFF
--- a/retry_dashboard_notifier.py
+++ b/retry_dashboard_notifier.py
@@ -3,6 +3,7 @@ import json
 import logging
 from datetime import datetime
 from notion_client import Client
+from tenacity import retry, stop_after_attempt, wait_fixed
 from dotenv import load_dotenv
 
 # ---------------------- 설정 로딩 ----------------------
@@ -43,6 +44,7 @@ def get_retry_stats():
     }
 
 # ---------------------- Notion KPI 행 추가 ----------------------
+@retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=False)
 def push_kpi_to_notion(kpi):
     try:
         notion.pages.create(
@@ -53,7 +55,7 @@ def push_kpi_to_notion(kpi):
                 "성공": {"number": kpi["success"]},
                 "실패": {"number": kpi["failed"]},
                 "성공률(%)": {"number": kpi["rate"]}
-            }
+            },
         )
         logging.info("📊 Notion KPI 업데이트 완료")
     except Exception as e:

--- a/retry_failed_uploads.py
+++ b/retry_failed_uploads.py
@@ -4,6 +4,8 @@ import time
 import logging
 from datetime import datetime
 from notion_client import Client
+from tenacity import retry, stop_after_attempt, wait_fixed
+from tenacity import retry, stop_after_attempt, wait_fixed
 from dotenv import load_dotenv
 
 # ---------------------- 설정 로딩 ----------------------
@@ -34,6 +36,7 @@ def load_failed_items():
         return json.load(f)
 
 # ---------------------- Notion 페이지 재생성 ----------------------
+@retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
 def create_retry_page(item):
     keyword = item.get('keyword')
     if not keyword:

--- a/scripts/retry_failed_uploads.py
+++ b/scripts/retry_failed_uploads.py
@@ -4,6 +4,7 @@ import time
 import logging
 from datetime import datetime
 from notion_client import Client
+from tenacity import retry, stop_after_attempt, wait_fixed
 from dotenv import load_dotenv
 
 # ---------------------- 설정 로딩 ----------------------
@@ -34,6 +35,7 @@ def load_failed_items():
         return json.load(f)
 
 # ---------------------- Notion 페이지 재생성 ----------------------
+@retry(stop=stop_after_attempt(3), wait=wait_fixed(1), reraise=True)
 def create_retry_page(item):
     keyword = item.get('keyword')
     if not keyword:

--- a/tests/test_retry_behavior.py
+++ b/tests/test_retry_behavior.py
@@ -1,0 +1,41 @@
+from unittest.mock import MagicMock
+import types
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import hook_generator
+import notion_hook_uploader
+
+
+def test_get_gpt_response_retries(monkeypatch):
+    attempts = {"count": 0}
+
+    def fake_create(*args, **kwargs):
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise Exception("temporary failure")
+        mock_resp = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message = {"content": "ok"}
+        mock_resp.choices = [mock_choice]
+        return mock_resp
+
+    monkeypatch.setattr(hook_generator, "openai", types.SimpleNamespace(ChatCompletion=types.SimpleNamespace(create=fake_create)))
+
+    result = hook_generator.get_gpt_response("test")
+    assert result == "ok"
+    assert attempts["count"] == 3
+
+
+def test_page_exists_retries(monkeypatch):
+    attempts = {"count": 0}
+
+    def fake_query(*args, **kwargs):
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise Exception("temporary failure")
+        return {"results": [1]}
+
+    monkeypatch.setattr(notion_hook_uploader.notion.databases, "query", fake_query)
+    assert notion_hook_uploader.page_exists("keyword") is True
+    assert attempts["count"] == 3


### PR DESCRIPTION
## Summary
- add retry logic using tenacity for network calls
- simplify upload loops to rely on retries
- verify retry behavior with new unit tests

## Testing
- `pytest -q`
- `pylint hook_generator.py keyword_auto_pipeline.py notion_hook_uploader.py retry_dashboard_notifier.py retry_failed_uploads.py scripts/notion_uploader.py scripts/retry_failed_uploads.py`
- `mypy --ignore-missing-imports hook_generator.py keyword_auto_pipeline.py notion_hook_uploader.py retry_dashboard_notifier.py retry_failed_uploads.py`

------
https://chatgpt.com/codex/tasks/task_e_684e37fa5c64832ea14f35c1151f1f4d