### PR TITLE
Implement GPT failure parsing and notification

### DIFF
--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,48 @@
+"""Send Slack notification summarizing retry results."""
+
+import os
+import json
+import logging
+import urllib.request
+from dotenv import load_dotenv
+
+load_dotenv()
+REPARSED_OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+def load_result():
+    if not os.path.exists(REPARSED_OUTPUT_PATH):
+        logging.info("결과 파일이 존재하지 않습니다: %s", REPARSED_OUTPUT_PATH)
+        return 0, 0, 0
+    with open(REPARSED_OUTPUT_PATH, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    total = len(data)
+    failed = len([d for d in data if d.get('retry_error')])
+    success = total - failed
+    return total, success, failed
+
+def send_slack(total: int, success: int, failed: int) -> None:
+    if not SLACK_WEBHOOK_URL:
+        logging.warning("SLACK_WEBHOOK_URL가 설정되지 않아 슬랙 알림을 건너뜁니다.")
+        return
+    message = {
+        "text": f"재업로드 결과\n총 시도: {total}\n성공: {success}\n실패: {failed}"
+    }
+    data = json.dumps(message).encode('utf-8')
+    req = urllib.request.Request(SLACK_WEBHOOK_URL, data=data, headers={'Content-Type': 'application/json'})
+    try:
+        with urllib.request.urlopen(req) as response:
+            if response.status != 200:
+                logging.error("슬랙 전송 실패: %s", response.read().decode())
+    except Exception as e:
+        logging.error("슬랙 전송 중 예외 발생: %s", e)
+
+def notify_retry_result():
+    total, success, failed = load_result()
+    send_slack(total, success, failed)
+    logging.info("총 시도: %s, 성공: %s, 실패: %s", total, success, failed)
+
+if __name__ == "__main__":
+    notify_retry_result()

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,40 @@
+"""Parse failed GPT outputs and save reparsed results."""
+
+import os
+import json
+import logging
+from dotenv import load_dotenv
+
+from notion_hook_uploader import parse_generated_text
+
+load_dotenv()
+FAILED_HOOK_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+REPARSED_OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+def parse_failed_gpt():
+    if not os.path.exists(FAILED_HOOK_PATH):
+        logging.info("✅ 실패 파일이 없어 건너뜁니다: %s", FAILED_HOOK_PATH)
+        return
+
+    with open(FAILED_HOOK_PATH, 'r', encoding='utf-8') as f:
+        items = json.load(f)
+
+    reparsed = []
+    for item in items:
+        text = item.get("generated_text")
+        if not text:
+            logging.warning(f"⚠️ generated_text 누락: {item.get('keyword')}")
+            continue
+        parsed = parse_generated_text(text)
+        item["parsed"] = parsed
+        reparsed.append(item)
+
+    os.makedirs(os.path.dirname(REPARSED_OUTPUT_PATH), exist_ok=True)
+    with open(REPARSED_OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        json.dump(reparsed, f, ensure_ascii=False, indent=2)
+    logging.info("✅ 재파싱 결과 저장: %s", REPARSED_OUTPUT_PATH)
+
+if __name__ == "__main__":
+    parse_failed_gpt()

--- a/tests/test_notify_retry_result.py
+++ b/tests/test_notify_retry_result.py
@@ -1,0 +1,43 @@
+import json
+import os
+import sys
+import types
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+dummy_client = types.SimpleNamespace()
+dummy_client.Client = lambda *args, **kwargs: object()
+sys.modules.setdefault('notion_client', dummy_client)
+os.makedirs('logs', exist_ok=True)
+
+
+def test_notify_retry_result(monkeypatch, tmp_path):
+    result_file = tmp_path / "result.json"
+    data = [
+        {"keyword": "a"},
+        {"keyword": "b", "retry_error": "err"}
+    ]
+    result_file.write_text(json.dumps(data, ensure_ascii=False))
+
+    calls = {}
+
+    class DummyResponse:
+        status = 200
+        def read(self):
+            return b"ok"
+
+    def dummy_urlopen(req):
+        calls['req'] = req
+        return DummyResponse()
+
+    monkeypatch.setenv("REPARSED_OUTPUT_PATH", str(result_file))
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "http://example.com")
+    from scripts import notify_retry_result  # import after env setup
+    monkeypatch.setattr(notify_retry_result.urllib.request, 'urlopen', dummy_urlopen)
+
+    notify_retry_result.notify_retry_result()
+
+    assert calls
+    payload = json.loads(calls['req'].data.decode())
+    assert "총 시도: 2" in payload['text']
+    assert "성공: 1" in payload['text']
+    assert "실패: 1" in payload['text']

--- a/tests/test_parse_failed_gpt.py
+++ b/tests/test_parse_failed_gpt.py
@@ -1,0 +1,33 @@
+import json
+import os
+import sys
+import types
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+# Provide a dummy notion_client to satisfy imports
+dummy_client = types.SimpleNamespace()
+dummy_client.Client = lambda *args, **kwargs: object()
+sys.modules.setdefault('notion_client', dummy_client)
+os.makedirs('logs', exist_ok=True)
+
+from notion_hook_uploader import parse_generated_text
+
+
+def test_parse_failed_gpt(tmp_path, monkeypatch):
+    failed = tmp_path / "failed_hooks.json"
+    reparsed = tmp_path / "reparsed.json"
+
+    text = "후킹 문장1: a\n후킹 문장2: b\n블로그 초안: x\ny\nz\n영상 제목: t1\n- t2"
+    data = [{"keyword": "kw1", "generated_text": text}, {"keyword": "kw2"}]
+    failed.write_text(json.dumps(data, ensure_ascii=False))
+
+    monkeypatch.setenv("FAILED_HOOK_PATH", str(failed))
+    monkeypatch.setenv("REPARSED_OUTPUT_PATH", str(reparsed))
+    from scripts import parse_failed_gpt  # import after env setup
+    parse_failed_gpt.parse_failed_gpt()
+
+    output = json.loads(reparsed.read_text())
+    assert len(output) == 1
+    assert output[0]["keyword"] == "kw1"
+    assert output[0]["parsed"] == parse_generated_text(text)


### PR DESCRIPTION
## Summary
- add missing pipeline scripts for GPT retry handling
- send Slack notification of retry results
- cover new scripts with unit tests

## Testing
- `pytest -q`
- `pylint scripts/parse_failed_gpt.py scripts/notify_retry_result.py`
- `mypy scripts/parse_failed_gpt.py scripts/notify_retry_result.py`


------
https://chatgpt.com/codex/tasks/task_e_684e387ac1cc832e93eedfe2b31f133b