### PR TITLE
Implement TOP_RESULTS_LIMIT selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Example environment configuration for Auto Pipeline
+# Uncomment and set values as needed
+
+# Path to topic channel configuration
+TOPIC_CHANNELS_PATH=config/topic_channels.json
+# Output path for keyword results
+KEYWORD_OUTPUT_PATH=data/keyword_output_with_cpc.json
+# Limit for number of keywords saved
+TOP_RESULTS_LIMIT=20

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Auto Pipeline
+
+자동 키워드 수집 및 후킹 생성 파이프라인 예제입니다.
+
+## 실행 예시
+
+```bash
+export TOP_RESULTS_LIMIT=50
+python keyword_auto_pipeline.py
+```

--- a/tests/test_keyword_pipeline.py
+++ b/tests/test_keyword_pipeline.py
@@ -1,0 +1,36 @@
+"""Tests for keyword selection helpers."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from keyword_auto_pipeline import select_top_keywords, Keyword
+
+
+def test_select_top_keywords_dedup_and_sort():
+    """Ensure deduplication and tie-breaking work."""
+    rows: list[Keyword] = [
+        {"keyword": "a", "cpc": 500.0, "search_volume": 100},
+        {"keyword": "b", "cpc": 1000.0, "search_volume": 50},
+        {"keyword": "a", "cpc": 700.0, "search_volume": 80},
+        {"keyword": "c", "cpc": 700.0, "search_volume": 120},
+    ]
+    result = select_top_keywords(rows, limit=2)
+    assert len(result) == 2
+    # keyword b should come first due to highest cpc
+    assert result[0]["keyword"] == "b"
+    # between a(700) and c(700), c has higher search_volume so should be chosen
+    assert result[1]["keyword"] == "c"
+
+
+def test_select_top_keywords_limit_and_duplicate():
+    """Ensure limit and duplicate handling works."""
+    rows: list[Keyword] = [
+        {"keyword": "x", "cpc": 300.0, "search_volume": 10},
+        {"keyword": "x", "cpc": 400.0, "search_volume": 20},
+        {"keyword": "y", "cpc": 200.0, "search_volume": 30},
+    ]
+    result = select_top_keywords(rows, limit=1)
+    assert len(result) == 1
+    assert result[0]["keyword"] == "x"
+    assert result[0]["cpc"] == 400.0


### PR DESCRIPTION
## Summary
- add README with simple run example
- document env vars in `.env.example`
- implement `TOP_RESULTS_LIMIT` and `select_top_keywords`
- log number of selected keywords
- add unit tests for keyword selection

## Testing
- `pytest -q`
- `mypy keyword_auto_pipeline.py tests/test_keyword_pipeline.py`
- `python3 -m pylint keyword_auto_pipeline.py tests/test_keyword_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684e38622c1c832e8fcb96e2064d332e