### PR TITLE
Enable async GPT calls in hook generator

### DIFF
--- a/hook_generator.py
+++ b/hook_generator.py
@@ -1,6 +1,6 @@
 import os
 import json
-import time
+import asyncio
 import logging
 from datetime import datetime
 from dotenv import load_dotenv
@@ -8,18 +8,33 @@ import openai
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
-KEYWORD_JSON_PATH = os.getenv("KEYWORD_OUTPUT_PATH", "data/keyword_output_with_cpc.json")
-HOOK_OUTPUT_PATH = os.getenv("HOOK_OUTPUT_PATH", "data/generated_hooks.json")
-FAILED_HOOK_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+KEYWORD_JSON_PATH = os.getenv(
+    "KEYWORD_OUTPUT_PATH",
+    "data/keyword_output_with_cpc.json",
+)
+HOOK_OUTPUT_PATH = os.getenv(
+    "HOOK_OUTPUT_PATH",
+    "data/generated_hooks.json",
+)
+FAILED_HOOK_PATH = os.getenv(
+    "FAILED_HOOK_PATH",
+    "logs/failed_hooks.json",
+)
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 API_DELAY = float(os.getenv("API_DELAY", "1.0"))
+MAX_CONCURRENCY = int(os.getenv("GPT_MAX_CONCURRENCY", "5"))
 
 openai.api_key = OPENAI_API_KEY
 
 # ---------------------- 로깅 설정 ----------------------
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s %(levelname)s:%(message)s',
+)
 
 # ---------------------- GPT 프롬프트 생성 함수 ----------------------
+
+
 def generate_hook_prompt(keyword, topic, source, score, growth, mentions):
     base = f"""
     주제: {keyword}
@@ -34,10 +49,12 @@ def generate_hook_prompt(keyword, topic, source, score, growth, mentions):
     return base.strip()
 
 # ---------------------- GPT 호출 함수 (재시도 포함) ----------------------
-def get_gpt_response(prompt, retries=3):
+
+
+async def get_gpt_response(prompt, retries=3):
     for attempt in range(retries):
         try:
-            response = openai.ChatCompletion.create(
+            response = await openai.ChatCompletion.acreate(
                 model="gpt-4",
                 messages=[{"role": "user", "content": prompt}],
                 temperature=0.7
@@ -45,11 +62,54 @@ def get_gpt_response(prompt, retries=3):
             return response.choices[0].message['content']
         except Exception as e:
             logging.warning(f"GPT 호출 실패 {attempt + 1}/{retries}: {e}")
-            time.sleep(2)
+            await asyncio.sleep(2)
     return None
 
 # ---------------------- 메인 실행 함수 ----------------------
-def generate_hooks():
+
+
+async def process_keyword(item, semaphore):
+    keyword = item.get('keyword')
+    if not keyword:
+        logging.warning("⛔ 빈 키워드 항목, 건너뜁니다.")
+        return None, 'skipped'
+
+    prompt = generate_hook_prompt(
+        keyword=keyword,
+        topic=keyword.split()[0],
+        source=item.get('source'),
+        score=item.get('score', 0),
+        growth=item.get('growth', 0),
+        mentions=item.get('mentions', 0)
+    )
+
+    async with semaphore:
+        response = await get_gpt_response(prompt)
+        await asyncio.sleep(API_DELAY)
+
+    result = {
+        "keyword": keyword,
+        "hook_prompt": prompt,
+        "timestamp": datetime.utcnow().isoformat() + 'Z'
+    }
+
+    if response:
+        lines = response.split('\n')
+        result.update({
+            "hook_lines": lines[0:2],
+            "blog_paragraphs": lines[2:5],
+            "video_titles": lines[5:],
+            "generated_text": response
+        })
+        logging.info(f"✅ 생성 완료: {keyword}")
+        return result, 'success'
+    result["generated_text"] = None
+    result["error"] = "GPT 응답 실패"
+    logging.error(f"❌ 생성 실패: {keyword}")
+    return result, 'failed'
+
+
+async def generate_hooks():
     if not OPENAI_API_KEY:
         logging.error("❗ OpenAI API 키가 누락되었습니다. .env 파일 확인 필요")
         return
@@ -74,54 +134,33 @@ def generate_hooks():
 
     new_output = []
     failed_output = []
-    skipped, success, failed = 0, 0, 0
+    skipped = 0
+
+    semaphore = asyncio.Semaphore(MAX_CONCURRENCY)
+    tasks = []
 
     for item in keywords:
         keyword = item.get('keyword')
         if not keyword:
             logging.warning("⛔ 빈 키워드 항목, 건너뜁니다.")
             continue
-
         if keyword in existing:
             logging.info(f"⏭️ 중복 스킵: {keyword}")
             skipped += 1
             continue
+        tasks.append(process_keyword(item, semaphore))
 
-        prompt = generate_hook_prompt(
-            keyword=keyword,
-            topic=keyword.split()[0],
-            source=item.get('source'),
-            score=item.get('score', 0),
-            growth=item.get('growth', 0),
-            mentions=item.get('mentions', 0)
-        )
-        response = get_gpt_response(prompt)
+    results = await asyncio.gather(*tasks)
 
-        result = {
-            "keyword": keyword,
-            "hook_prompt": prompt,
-            "timestamp": datetime.utcnow().isoformat() + 'Z'
-        }
-
-        if response:
-            lines = response.split('\n')
-            result.update({
-                "hook_lines": lines[0:2],
-                "blog_paragraphs": lines[2:5],
-                "video_titles": lines[5:],
-                "generated_text": response
-            })
+    success = 0
+    failed = 0
+    for result, status in results:
+        if status == 'success':
             new_output.append(result)
-            logging.info(f"✅ 생성 완료: {keyword}")
             success += 1
-        else:
-            result["generated_text"] = None
-            result["error"] = "GPT 응답 실패"
+        elif status == 'failed':
             failed_output.append(result)
-            logging.error(f"❌ 생성 실패: {keyword}")
             failed += 1
-
-        time.sleep(API_DELAY)
 
     full_output = list(existing.values()) + new_output
     os.makedirs(os.path.dirname(HOOK_OUTPUT_PATH), exist_ok=True)
@@ -132,11 +171,17 @@ def generate_hooks():
         os.makedirs(os.path.dirname(FAILED_HOOK_PATH), exist_ok=True)
         with open(FAILED_HOOK_PATH, 'w', encoding='utf-8') as f:
             json.dump(failed_output, f, ensure_ascii=False, indent=2)
-        logging.warning(f"⚠️ 실패 후킹 저장 완료: {FAILED_HOOK_PATH}")
+        logging.warning(
+            f"⚠️ 실패 후킹 저장 완료: {FAILED_HOOK_PATH}"
+        )
 
     logging.info("📊 생성 작업 요약")
-    logging.info(f"총 키워드: {len(keywords)} | 성공: {success} | 중복스킵: {skipped} | 실패: {failed}")
+    summary = (
+        f"총 키워드: {len(keywords)} | 성공: {success} "
+        f"| 중복스킵: {skipped} | 실패: {failed}"
+    )
+    logging.info(summary)
     logging.info(f"🎉 후킹 문장 저장 완료: {HOOK_OUTPUT_PATH}")
 
 if __name__ == "__main__":
-    generate_hooks()
+    asyncio.run(generate_hooks())


### PR DESCRIPTION
## Summary
- refactor `hook_generator.py` to use `asyncio` for parallel GPT requests
- add configurable concurrency level and adjust retry delays
- keep output and logging logic intact under async execution

## Testing
- `flake8 hook_generator.py`
- `pylint hook_generator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e387e0304832e953b2f3b8a93ced8