### PR TITLE
Add logging helper

### DIFF
--- a/hook_generator.py
+++ b/hook_generator.py
@@ -2,6 +2,7 @@ import os
 import json
 import time
 import logging
+from utils import setup_logging
 from datetime import datetime
 from dotenv import load_dotenv
 import openai
@@ -17,7 +18,7 @@ API_DELAY = float(os.getenv("API_DELAY", "1.0"))
 openai.api_key = OPENAI_API_KEY
 
 # ---------------------- 로깅 설정 ----------------------
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+setup_logging("logs/hook_generator.log")
 
 # ---------------------- GPT 프롬프트 생성 함수 ----------------------
 def generate_hook_prompt(keyword, topic, source, score, growth, mentions):

--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -2,6 +2,7 @@ import os
 import json
 import time
 import logging
+from utils import setup_logging
 import re
 from datetime import datetime
 from notion_client import Client
@@ -15,15 +16,8 @@ HOOK_JSON_PATH = os.getenv("HOOK_OUTPUT_PATH", "data/generated_hooks.json")
 FAILED_OUTPUT_PATH = "data/upload_failed_hooks.json"
 UPLOAD_DELAY = float(os.getenv("UPLOAD_DELAY", "0.5"))
 
+setup_logging("logs/notion_upload.log")
 notion = Client(auth=NOTION_TOKEN)
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s %(levelname)s:%(message)s',
-    handlers=[
-        logging.FileHandler("logs/notion_upload.log"),
-        logging.StreamHandler()
-    ]
-)
 
 # ---------------------- 유틸: Notion rich_text 제한 처리 ----------------------
 def truncate_text(text, max_length=2000):

--- a/retry_dashboard_notifier.py
+++ b/retry_dashboard_notifier.py
@@ -1,6 +1,7 @@
 import os
 import json
 import logging
+from utils import setup_logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
@@ -11,7 +12,7 @@ NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_KPI_DB_ID = os.getenv("NOTION_KPI_DB_ID")
 SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+setup_logging("logs/retry_dashboard_notifier.log")
 
 # ---------------------- Notion 클라이언트 ----------------------
 if not NOTION_TOKEN or not NOTION_KPI_DB_ID:

--- a/retry_failed_uploads.py
+++ b/retry_failed_uploads.py
@@ -2,6 +2,7 @@ import os
 import json
 import time
 import logging
+from utils import setup_logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
@@ -13,7 +14,7 @@ NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
 FAILED_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
 RETRY_DELAY = float(os.getenv("RETRY_DELAY", "0.5"))
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+setup_logging("logs/retry_failed_uploads.log")
 
 # ---------------------- Notion 클라이언트 ----------------------
 if not NOTION_TOKEN or not NOTION_HOOK_DB_ID:

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,15 @@
+import logging
+import os
+
+
+def setup_logging(log_file: str) -> None:
+    """Configure logging for console and file output."""
+    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s %(levelname)s:%(message)s',
+        handlers=[
+            logging.FileHandler(log_file),
+            logging.StreamHandler()
+        ],
+    )


### PR DESCRIPTION
## Summary
- create `utils.setup_logging` for console and file logging
- use `setup_logging` in hook and retry scripts

## Testing
- `pylint $(git ls-files '*.py')`
- `mypy --ignore-missing-imports --exclude 'scripts/' $(git ls-files '*.py' | grep -v '^scripts/')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e3116d768832e8ee128a4b1145991