### PR TITLE
Add JSON schema validation

### DIFF
--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -6,6 +6,8 @@ import re
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from jsonschema import ValidationError, validate
+from schemas import HOOK_OUTPUT_SCHEMA
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -83,8 +85,9 @@ def upload_all_hooks():
     try:
         with open(HOOK_JSON_PATH, 'r', encoding='utf-8') as f:
             hooks = json.load(f)
-    except Exception as e:
-        logging.error(f"❗ 후킹 JSON 파일 읽기 오류: {e}")
+        validate(hooks, HOOK_OUTPUT_SCHEMA)
+    except (json.JSONDecodeError, ValidationError) as e:
+        logging.error(f"❗ 후킹 JSON 검증 실패: {e}")
         return
 
     total, success, skipped, failed = 0, 0, 0, 0

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,91 @@
+"""JSON schema definitions for pipeline outputs."""
+
+from typing import Any, Dict
+
+KEYWORD_OUTPUT_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "timestamp": {"type": "string"},
+        "filtered_keywords": {
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {"$ref": "#/definitions/google_trend"},
+                    {"$ref": "#/definitions/twitter"}
+                ]
+            }
+        },
+    },
+    "required": ["timestamp", "filtered_keywords"],
+    "definitions": {
+        "base": {
+            "type": "object",
+            "properties": {
+                "keyword": {"type": "string"},
+                "source": {"type": "string"},
+                "cpc": {"type": "number"},
+            },
+            "required": ["keyword", "source", "cpc"],
+        },
+        "google_trend": {
+            "allOf": [
+                {"$ref": "#/definitions/base"},
+                {
+                    "properties": {
+                        "source": {"const": "GoogleTrends"},
+                        "score": {"type": "number"},
+                        "growth": {"type": "number"},
+                    },
+                    "required": ["score", "growth"],
+                },
+            ]
+        },
+        "twitter": {
+            "allOf": [
+                {"$ref": "#/definitions/base"},
+                {
+                    "properties": {
+                        "source": {"const": "Twitter"},
+                        "mentions": {"type": "number"},
+                        "top_retweet": {"type": "number"},
+                    },
+                    "required": ["mentions", "top_retweet"],
+                },
+            ]
+        },
+    },
+}
+
+HOOK_OUTPUT_SCHEMA: Dict[str, Any] = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "keyword": {"type": "string"},
+            "hook_prompt": {"type": "string"},
+            "timestamp": {"type": "string"},
+            "hook_lines": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+            "blog_paragraphs": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+            "video_titles": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+            "generated_text": {"type": "string"},
+        },
+        "required": [
+            "keyword",
+            "hook_prompt",
+            "timestamp",
+            "hook_lines",
+            "blog_paragraphs",
+            "video_titles",
+            "generated_text",
+        ],
+    },
+}

--- a/scripts/notion_uploader.py
+++ b/scripts/notion_uploader.py
@@ -5,6 +5,8 @@ import logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from jsonschema import ValidationError, validate
+from schemas import KEYWORD_OUTPUT_SCHEMA
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -73,9 +75,10 @@ def upload_all_keywords():
     try:
         with open(KEYWORD_JSON_PATH, 'r', encoding='utf-8') as f:
             data = json.load(f)
-            keywords = data.get("filtered_keywords", [])
-    except Exception as e:
-        logging.error(f"❗ 키워드 파일 읽기 오류: {e}")
+        validate(data, KEYWORD_OUTPUT_SCHEMA)
+        keywords = data.get("filtered_keywords", [])
+    except (json.JSONDecodeError, ValidationError) as e:
+        logging.error(f"❗ 키워드 파일 검증 실패: {e}")
         return
 
     total = len(keywords)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import pytest
+from jsonschema import ValidationError, validate
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from schemas import KEYWORD_OUTPUT_SCHEMA, HOOK_OUTPUT_SCHEMA
+
+
+def test_keyword_schema_valid():
+    data = {
+        "timestamp": "2024-01-01T00:00:00Z",
+        "filtered_keywords": [
+            {
+                "keyword": "여행 국내여행",
+                "source": "GoogleTrends",
+                "score": 70,
+                "growth": 1.5,
+                "cpc": 1200,
+            },
+            {
+                "keyword": "다이어트 홈트",
+                "source": "Twitter",
+                "mentions": 40,
+                "top_retweet": 60,
+                "cpc": 1500,
+            },
+        ],
+    }
+    validate(data, KEYWORD_OUTPUT_SCHEMA)
+
+
+def test_keyword_schema_invalid():
+    invalid = {"timestamp": "2024-01-01"}
+    with pytest.raises(ValidationError):
+        validate(invalid, KEYWORD_OUTPUT_SCHEMA)
+
+
+def test_hook_schema_valid():
+    hooks = [
+        {
+            "keyword": "여행 국내여행",
+            "hook_prompt": "prompt",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "hook_lines": ["a", "b"],
+            "blog_paragraphs": ["p1", "p2", "p3"],
+            "video_titles": ["t1", "t2"],
+            "generated_text": "all\ntext",
+        }
+    ]
+    validate(hooks, HOOK_OUTPUT_SCHEMA)
+
+
+def test_hook_schema_invalid():
+    hooks = [{"keyword": "test"}]
+    with pytest.raises(ValidationError):
+        validate(hooks, HOOK_OUTPUT_SCHEMA)


### PR DESCRIPTION
## Summary
- add schema definitions for keyword and hook JSON structures
- validate keyword output in generator and notion uploader
- validate hook output before uploading
- implement schema tests

## Testing
- `pylint schemas.py hook_generator.py notion_hook_uploader.py scripts/notion_uploader.py`
- `mypy schemas.py hook_generator.py notion_hook_uploader.py scripts/notion_uploader.py` *(fails: missing stubs)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e31195cf4832e88016d3690400068