### PR TITLE
Integrate Google Ads CPC lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Auto Pipeline
+
+This repository contains automation scripts for keyword discovery and publishing.
+
+## Google Ads Integration
+
+To fetch real CPC values for each keyword, the pipeline uses the Google Ads API.
+Set the following environment variables before running `keyword_auto_pipeline.py`:
+
+- `GOOGLE_ADS_DEVELOPER_TOKEN`
+- `GOOGLE_ADS_CLIENT_ID`
+- `GOOGLE_ADS_CLIENT_SECRET`
+- `GOOGLE_ADS_REFRESH_TOKEN`
+- `GOOGLE_ADS_CUSTOMER_ID`
+- `GOOGLE_ADS_LOGIN_CUSTOMER_ID` *(optional)*
+
+Refer to the [Google Ads API documentation](https://developers.google.com/google-ads/api/docs/client-libs/python/oauth-service) for steps to obtain these credentials.

--- a/google_ads_cpc.py
+++ b/google_ads_cpc.py
@@ -1,0 +1,52 @@
+import os
+import logging
+from functools import lru_cache
+from google.ads.googleads.client import GoogleAdsClient
+from google.ads.googleads.errors import GoogleAdsException
+
+
+def _get_client() -> GoogleAdsClient:
+    """Create Google Ads client using environment variables."""
+    config = {
+        "developer_token": os.getenv("GOOGLE_ADS_DEVELOPER_TOKEN"),
+        "client_id": os.getenv("GOOGLE_ADS_CLIENT_ID"),
+        "client_secret": os.getenv("GOOGLE_ADS_CLIENT_SECRET"),
+        "refresh_token": os.getenv("GOOGLE_ADS_REFRESH_TOKEN"),
+        "login_customer_id": os.getenv("GOOGLE_ADS_LOGIN_CUSTOMER_ID"),
+        "use_proto_plus": True,
+    }
+    missing = [k for k, v in config.items() if k != "login_customer_id" and not v]
+    if missing:
+        raise ValueError(f"Missing Google Ads credentials: {', '.join(missing)}")
+    return GoogleAdsClient.load_from_dict(config)
+
+
+@lru_cache(maxsize=128)
+def fetch_cpc(keyword: str, customer_id: str | None = None) -> float:
+    """Fetch average CPC for a keyword from Google Ads.
+
+    Args:
+        keyword: Keyword text to query.
+        customer_id: Google Ads customer ID. If None, uses GOOGLE_ADS_CUSTOMER_ID.
+
+    Returns:
+        Average CPC in the account's currency as a float, or 0 if not found.
+    """
+    client = _get_client()
+    ga_service = client.get_service("GoogleAdsService")
+    customer_id = customer_id or os.getenv("GOOGLE_ADS_CUSTOMER_ID")
+    if not customer_id:
+        raise ValueError("GOOGLE_ADS_CUSTOMER_ID is not set")
+
+    query = (
+        "SELECT metrics.average_cpc FROM keyword_view "
+        f"WHERE segments.keyword.text = '{keyword}' LIMIT 1"
+    )
+    try:
+        response = ga_service.search(customer_id=customer_id, query=query)
+        for row in response:
+            micros = row.metrics.average_cpc.micros
+            return micros / 1_000_000
+    except GoogleAdsException as exc:
+        logging.error("Google Ads API error for %s: %s", keyword, exc)
+    return 0.0

--- a/keyword_auto_pipeline.py
+++ b/keyword_auto_pipeline.py
@@ -6,7 +6,8 @@ from itertools import islice
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pytrends.request import TrendReq
 import snscrape.modules.twitter as sntwitter
-import random  # CPC 더미 데이터용
+
+from google_ads_cpc import fetch_cpc
 
 # ---------------------- 설정 ----------------------
 CONFIG_PATH = os.getenv("TOPIC_CHANNELS_PATH", "config/topic_channels.json")
@@ -16,7 +17,7 @@ GOOGLE_TRENDS_MIN_SCORE = 60
 GOOGLE_TRENDS_MIN_GROWTH = 1.3
 TWITTER_MIN_MENTIONS = 30
 TWITTER_MIN_TOP_RETWEET = 50
-MIN_CPC = 1000  # 원 (더미 기준)
+MIN_CPC = 1000  # 원 기준 최소 CPC
 
 # ---------------------- 로깅 설정 ----------------------
 logging.basicConfig(
@@ -46,14 +47,6 @@ def generate_keyword_pairs(topic_details):
             pairs.append(f"{topic} {sub}")
     return pairs
 
-# ---------------------- CPC 캐시 ----------------------
-cpc_cache = {}
-
-def fetch_cpc_dummy(keyword):
-    if keyword not in cpc_cache:
-        cpc_cache[keyword] = random.randint(500, 2000)
-        logging.debug(f"CPC 캐시 생성: {keyword} = {cpc_cache[keyword]}")
-    return cpc_cache[keyword]
 
 # ---------------------- 데이터 수집 함수 ----------------------
 def fetch_google_trends(keyword, pytrends):
@@ -73,7 +66,7 @@ def fetch_google_trends(keyword, pytrends):
             "source": "GoogleTrends",
             "score": int(recent_avg),
             "growth": growth,
-            "cpc": fetch_cpc_dummy(keyword)
+            "cpc": fetch_cpc(keyword)
         }
         logging.info(f"Google Trends 수집 완료: {keyword} score={result['score']} growth={result['growth']} cpc={result['cpc']}")
         return result
@@ -97,7 +90,7 @@ def fetch_twitter_metrics(keyword, max_tweets=100):
             "source": "Twitter",
             "mentions": mentions,
             "top_retweet": top_retweets[0] if top_retweets else 0,
-            "cpc": fetch_cpc_dummy(keyword)
+            "cpc": fetch_cpc(keyword)
         }
         logging.info(f"Twitter 수집 완료: {keyword} mentions={mentions} top_retweet={result['top_retweet']} cpc={result['cpc']}")
         return result

--- a/tests/test_google_ads_cpc.py
+++ b/tests/test_google_ads_cpc.py
@@ -1,0 +1,31 @@
+import builtins
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import google_ads_cpc
+
+
+def test_fetch_cpc_returns_value_and_uses_client(monkeypatch):
+    google_ads_cpc.fetch_cpc.cache_clear()
+    mock_row = MagicMock()
+    mock_row.metrics.average_cpc.micros = 2500000
+
+    service_mock = MagicMock()
+    service_mock.search.return_value = [mock_row]
+
+    client_mock = MagicMock()
+    client_mock.get_service.return_value = service_mock
+
+    with patch('google_ads_cpc.GoogleAdsClient') as client_cls:
+        client_cls.load_from_dict.return_value = client_mock
+        monkeypatch.setenv('GOOGLE_ADS_DEVELOPER_TOKEN', 'token')
+        monkeypatch.setenv('GOOGLE_ADS_CLIENT_ID', 'cid')
+        monkeypatch.setenv('GOOGLE_ADS_CLIENT_SECRET', 'secret')
+        monkeypatch.setenv('GOOGLE_ADS_REFRESH_TOKEN', 'refresh')
+        monkeypatch.setenv('GOOGLE_ADS_CUSTOMER_ID', '123')
+        result = google_ads_cpc.fetch_cpc('test')
+
+    assert result == 2.5
+    service_mock.search.assert_called_once()
+    client_cls.load_from_dict.assert_called_once()


### PR DESCRIPTION
## Summary
- add Google Ads helper to fetch CPC via API
- replace dummy CPC generation with real API call
- document required Google Ads credentials
- cover new code with unit tests

## Testing
- `pylint google_ads_cpc.py keyword_auto_pipeline.py tests/test_google_ads_cpc.py`
- `mypy google_ads_cpc.py keyword_auto_pipeline.py tests/test_google_ads_cpc.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e311f3b40832e9af1d96d160ac7df