### PR TITLE
Add CLI filtering and test

### DIFF
--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -1,0 +1,11 @@
+import subprocess
+
+
+def test_only_flag() -> None:
+    res = subprocess.run(
+        ["python", "run_pipeline.py", "--dry-run", "--only", "hook_generator.py"],
+        text=True,
+        capture_output=True,
+    )
+    assert "hook_generator.py" in res.stdout
+    assert "notion_hook_uploader.py" not in res.stdout


### PR DESCRIPTION
## Summary
- implement `--dry-run`, `--only`, and `--skip` flags for `run_pipeline.py`
- print steps when using dry-run and apply filtering
- add regression test for `--only`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dfb01586c832ea93874a55e0aa613