### PR TITLE
Add DRY-run logging and duplicate import test

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,13 @@
+name: Release Docker
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Smoke test image (DRY_RUN)
+        run: |
+          docker run --rm -e DRY_RUN=1 ghcr.io/${{ github.repository }}:${{ github.ref_name }} run_pipeline --dry-run

--- a/.github/workflows/rotate-secrets.yml
+++ b/.github/workflows/rotate-secrets.yml
@@ -1,0 +1,29 @@
+name: Rotate Secrets
+on:
+  workflow_dispatch:
+jobs:
+  rotate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rotate secrets
+        id: rotate
+        run: python scripts/rotate_secrets.py
+  notify:
+    needs: rotate
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: slackapi/slack-github-action@v1
+        with:
+          payload: |
+            {
+              "text": ":white_check_mark: Secrets rotation *succeeded* :tada:"
+            }
+        if: ${{ success() }}
+      - uses: slackapi/slack-github-action@v1
+        with:
+          payload: |
+            {
+              "text": ":warning: Secrets rotation *failed!* Check logs <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>."
+            }
+        if: ${{ failure() }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Auto Pipeline
+
+## Docker
+
+```bash
+# 최신 이미지 풀
+docker pull ghcr.io/your-org/v-infinity:latest
+# DRY-RUN 테스트
+docker run --rm -e DRY_RUN=1 ghcr.io/your-org/v-infinity run_pipeline
+```
+
+GitHub Actions에서 push 되면 자동으로 latest 태그 업데이트됩니다.

--- a/auto_optimize.py
+++ b/auto_optimize.py
@@ -1,0 +1,17 @@
+import os
+import structlog
+
+logger = structlog.get_logger()
+
+def main():
+    if os.getenv("DRY_RUN"):
+        logger.warning("DRY_RUN=1 \u2192 Skipping actual ad-budget API calls")
+        return {"status": "dry_run", "ads_updated": 0}
+
+    # Placeholder for real optimization logic
+    logger.info("Optimizing ad budget")
+    # ... API calls would occur here ...
+    return {"status": "ok", "ads_updated": 42}
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+structlog>=23.0.0
+pytest>=7.0

--- a/tests/test_duplicate_import.py
+++ b/tests/test_duplicate_import.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import run_pipeline
+
+def test_duplicate_import_raises(tmp_path, monkeypatch):
+    code = "def main(): pass"
+    file_path = tmp_path / "dup.py"
+    file_path.write_text(code)
+    sys.path.insert(0, str(tmp_path))
+
+    run_pipeline._import_and_run("dup")
+
+    alias_path = tmp_path / "dup_alias.py"
+    alias_path.write_text(code)
+    with pytest.raises(ImportError):
+        run_pipeline._import_and_run("dup_alias")
+
+    sys.path.remove(str(tmp_path))


### PR DESCRIPTION
## Summary
- set up structlog-based logging for the pipeline
- add dry-run support via `--dry-run` argument
- implement `_import_and_run` with duplicate import check
- create auto optimization stub with DRY_RUN handling
- document Docker usage
- add Docker release workflow and rotate secrets Slack alerts
- provide test for duplicate imports
- add structlog and pytest to requirements

## Testing
- `pytest -q`
- `pylint run_pipeline.py auto_optimize.py tests/test_duplicate_import.py`
- `mypy run_pipeline.py auto_optimize.py tests/test_duplicate_import.py`


------
https://chatgpt.com/codex/tasks/task_e_684dfaf1bb14832e8ea17eec6fa9b30d