### PR TITLE
Add tracing contextmanager helper

### DIFF
--- a/scripts/tracing.py
+++ b/scripts/tracing.py
@@ -1,0 +1,27 @@
+"""Utility helpers for OpenTelemetry tracing."""
+
+import os
+from contextlib import contextmanager
+
+from opentelemetry import trace
+
+tracer = trace.get_tracer(__name__)
+
+
+def start_span(name: str):
+    """Start and return a span with optional dry-run attribute."""
+    span = tracer.start_span(name)
+    # DRY_RUN attribute makes it easy to filter traces in Datadog
+    if os.getenv("DRY_RUN"):
+        span.set_attribute("dry", True)
+    return span
+
+
+@contextmanager
+def traced(name: str):
+    """Context manager that automatically ends the span."""
+    span = start_span(name)
+    try:
+        yield span
+    finally:
+        span.end()


### PR DESCRIPTION
## Summary
- add `scripts/tracing.py` with helper functions for OpenTelemetry
- include a context manager to easily trace blocks of code

## Testing
- `mypy --ignore-missing-imports scripts/tracing.py`
- `pylint scripts/tracing.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dfc060994832ebb8d6648e9666e6e