### PR TITLE
Centralize logging setup

### DIFF
--- a/hook_generator.py
+++ b/hook_generator.py
@@ -2,6 +2,7 @@ import os
 import json
 import time
 import logging
+from utils.logger import setup_logging
 from datetime import datetime
 from dotenv import load_dotenv
 import openai
@@ -17,7 +18,7 @@ API_DELAY = float(os.getenv("API_DELAY", "1.0"))
 openai.api_key = OPENAI_API_KEY
 
 # ---------------------- 로깅 설정 ----------------------
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+setup_logging()
 
 # ---------------------- GPT 프롬프트 생성 함수 ----------------------
 def generate_hook_prompt(keyword, topic, source, score, growth, mentions):

--- a/keyword_auto_pipeline.py
+++ b/keyword_auto_pipeline.py
@@ -1,6 +1,7 @@
 import os
 import json
 import logging
+from utils.logger import setup_logging
 from datetime import datetime
 from itertools import islice
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -19,10 +20,7 @@ TWITTER_MIN_TOP_RETWEET = 50
 MIN_CPC = 1000  # 원 (더미 기준)
 
 # ---------------------- 로깅 설정 ----------------------
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s %(levelname)s:%(message)s'
-)
+setup_logging()
 
 # ---------------------- 토픽별 세부 키워드 쌍 ----------------------
 TOPIC_DETAILS = {

--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -2,6 +2,7 @@ import os
 import json
 import time
 import logging
+from utils.logger import setup_logging
 import re
 from datetime import datetime
 from notion_client import Client
@@ -16,14 +17,7 @@ FAILED_OUTPUT_PATH = "data/upload_failed_hooks.json"
 UPLOAD_DELAY = float(os.getenv("UPLOAD_DELAY", "0.5"))
 
 notion = Client(auth=NOTION_TOKEN)
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s %(levelname)s:%(message)s',
-    handlers=[
-        logging.FileHandler("logs/notion_upload.log"),
-        logging.StreamHandler()
-    ]
-)
+setup_logging()
 
 # ---------------------- 유틸: Notion rich_text 제한 처리 ----------------------
 def truncate_text(text, max_length=2000):

--- a/retry_dashboard_notifier.py
+++ b/retry_dashboard_notifier.py
@@ -1,6 +1,7 @@
 import os
 import json
 import logging
+from utils.logger import setup_logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
@@ -11,7 +12,7 @@ NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_KPI_DB_ID = os.getenv("NOTION_KPI_DB_ID")
 SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+setup_logging()
 
 # ---------------------- Notion 클라이언트 ----------------------
 if not NOTION_TOKEN or not NOTION_KPI_DB_ID:

--- a/retry_failed_uploads.py
+++ b/retry_failed_uploads.py
@@ -2,6 +2,7 @@ import os
 import json
 import time
 import logging
+from utils.logger import setup_logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
@@ -13,7 +14,7 @@ NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
 FAILED_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
 RETRY_DELAY = float(os.getenv("RETRY_DELAY", "0.5"))
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+setup_logging()
 
 # ---------------------- Notion 클라이언트 ----------------------
 if not NOTION_TOKEN or not NOTION_HOOK_DB_ID:

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,14 +1,12 @@
 import logging
+from utils.logger import setup_logging
 import subprocess
 import sys
 import os
 from datetime import datetime
 
 # ---------------------- 로깅 설정 ----------------------
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s %(levelname)s:%(message)s'
-)
+setup_logging()
 
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [

--- a/scripts/notion_uploader.py
+++ b/scripts/notion_uploader.py
@@ -2,6 +2,7 @@ import os
 import json
 import time
 import logging
+from utils.logger import setup_logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
@@ -16,7 +17,7 @@ CACHE_PATH = os.getenv("UPLOADED_CACHE_PATH", "data/uploaded_keywords_cache.json
 FAILED_PATH = os.getenv("FAILED_UPLOADS_PATH", "logs/failed_uploads.json")
 
 # ---------------------- 로깅 설정 ----------------------
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+setup_logging()
 
 # ---------------------- Notion 클라이언트 ----------------------
 notion = Client(auth=NOTION_TOKEN)

--- a/scripts/retry_failed_uploads.py
+++ b/scripts/retry_failed_uploads.py
@@ -2,6 +2,7 @@ import os
 import json
 import time
 import logging
+from utils.logger import setup_logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
@@ -13,7 +14,7 @@ NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
 FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_keywords.json")
 RETRY_DELAY = float(os.getenv("RETRY_DELAY", "0.5"))
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+setup_logging()
 
 # ---------------------- Notion 클라이언트 ----------------------
 if not NOTION_TOKEN or not NOTION_HOOK_DB_ID:

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,0 +1,37 @@
+import logging
+import os
+
+def setup_logging(log_file: str = "logs/app.log", level: int = logging.INFO) -> logging.Logger:
+    """Configure root logger to log to console and a file with uniform format.
+
+    Parameters
+    ----------
+    log_file : str
+        Path to the log file.
+    level : int
+        Logging level.
+
+    Returns
+    -------
+    logging.Logger
+        Configured root logger instance.
+    """
+    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+
+    logger = logging.getLogger()
+    logger.setLevel(level)
+    formatter = logging.Formatter("%(asctime)s %(levelname)s:%(message)s")
+
+    # Prevent duplicate handlers in case of multiple calls
+    if logger.handlers:
+        logger.handlers.clear()
+
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setFormatter(formatter)
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+
+    logger.addHandler(file_handler)
+    logger.addHandler(console_handler)
+
+    return logger


### PR DESCRIPTION
## Summary
- add utility for logging setup with file and console handlers
- update all scripts to use the shared logger

## Testing
- `pytest -q`
- `pylint $(git ls-files '*.py')`
- `mypy $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684dfe28c780832e9c3187a26d31fa98