### PR TITLE
Parse GPT hook output via JSON

### DIFF
--- a/hook_generator.py
+++ b/hook_generator.py
@@ -25,11 +25,15 @@ def generate_hook_prompt(keyword, topic, source, score, growth, mentions):
     주제: {keyword}
     출처: {source}
     트렌드 점수: {score}, 성장률: {growth}, 트윗 수: {mentions}
-    이 정보를 기반으로:
-    - 숏폼 영상의 후킹 문장 2개
-    - 블로그 포스트의 3문단 초안
-    - YouTube 영상 제목 예시 2개
-    를 마케팅적으로 끌리는 문장으로 생성해줘. 말투는 친근하면서도 전문가처럼.
+    이 정보를 기반으로 다음 JSON 형식의 결과만 응답해 줘. 다른 설명은 필요 없어.
+    ```json
+    {{
+      "hook_lines": ["첫 번째 후킹 문장", "두 번째 후킹 문장"],
+      "blog_paragraphs": ["1문단", "2문단", "3문단"],
+      "video_titles": ["영상 제목1", "영상 제목2"]
+    }}
+    ```
+    말투는 친근하면서도 전문가처럼 작성해 줘.
     """
     return base.strip()
 

--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -44,15 +44,18 @@ def page_exists(keyword):
 
 # ---------------------- GPT 결과 파싱 함수 ----------------------
 def parse_generated_text(text):
-    hook_lines = re.findall(r"후킹 ?문장[0-9]?[\s:：\-\)]*([^\n]+)", text)
-    blog_match = re.search(r"블로그(?:\s*초안)?[\s:：\-\)]*(.*?)\n+\s*(.*?\n+.*?\n+.*?)(?:\n|$)", text, re.DOTALL)
-    video_titles = re.findall(r"(?:영상 제목|YouTube 제목)[\s:：\-\)]*[^\n]*\n?-\s*(.+)", text)
+    """Parse JSON-formatted GPT output."""
+    try:
+        json_text = re.search(r"\{.*\}", text, re.DOTALL).group(0)
+        data = json.loads(json_text)
+    except Exception as e:
+        logging.warning(f"⚠️ JSON 파싱 실패: {e}")
+        data = {}
 
-    blog_paragraphs = [p.strip() for p in blog_match[1].strip().split('\n')[:3]] if blog_match else ["", "", ""]
     return {
-        "hook_lines": hook_lines[:2] if len(hook_lines) >= 2 else ["", ""],
-        "blog_paragraphs": blog_paragraphs,
-        "video_titles": video_titles[:2] if video_titles else ["", ""]
+        "hook_lines": data.get("hook_lines", ["", ""]),
+        "blog_paragraphs": data.get("blog_paragraphs", ["", "", ""]),
+        "video_titles": data.get("video_titles", ["", ""]),
     }
 
 # ---------------------- Notion 페이지 생성 함수 ----------------------

--- a/tests/test_parse_generated_text.py
+++ b/tests/test_parse_generated_text.py
@@ -1,0 +1,17 @@
+import json
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from notion_hook_uploader import parse_generated_text
+
+def test_parse_generated_text_json():
+    sample = json.dumps({
+        "hook_lines": ["Hook1", "Hook2"],
+        "blog_paragraphs": ["Para1", "Para2", "Para3"],
+        "video_titles": ["Title1", "Title2"]
+    })
+    result = parse_generated_text(sample)
+    assert result["hook_lines"] == ["Hook1", "Hook2"]
+    assert result["blog_paragraphs"] == ["Para1", "Para2", "Para3"]
+    assert result["video_titles"] == ["Title1", "Title2"]


### PR DESCRIPTION
## Summary
- change hook prompt to request JSON output
- parse hook responses as JSON when uploading to Notion
- test JSON parsing

## Testing
- `flake8 hook_generator.py notion_hook_uploader.py tests/test_parse_generated_text.py | head -n 20`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dfe26dbf8832e91167fca5537fd0d