### PR TITLE
Fix pipeline script discovery

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -20,11 +20,25 @@ PIPELINE_SEQUENCE = [
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
-def run_script(script):
-    full_path = os.path.join("scripts", script)
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def run_script(script: str) -> bool:
+    """Run an individual step in the pipeline.
+
+    Scripts historically lived inside the ``scripts`` directory but several are
+    located in the project root. ``run_script`` now resolves paths relative to
+    ``BASE_DIR`` and falls back to ``scripts/`` when necessary.
+    """
+
+    # Try locating the script relative to the repository root first
+    full_path = os.path.join(BASE_DIR, script)
     if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
-        return False
+        # Fallback to the scripts/ directory for backward compatibility
+        full_path = os.path.join(BASE_DIR, "scripts", script)
+        if not os.path.exists(full_path):
+            logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+            return False
 
     logging.info(f"🚀 실행 중: {script}")
     result = subprocess.run([sys.executable, full_path], capture_output=True, text=True)


### PR DESCRIPTION
## Summary
- fix path discovery in `run_pipeline.py`
- run the pipeline to verify it can locate scripts

## Testing
- `python run_pipeline.py > pipeline.log && tail -n 20 pipeline.log`

------
https://chatgpt.com/codex/tasks/task_e_684b58accf14832e83d873cba3675d28