### PR TITLE
Fix pipeline path resolution

### DIFF
--- a/notify_retry_result.py
+++ b/notify_retry_result.py
@@ -1,0 +1,8 @@
+import logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+def main():
+    logging.info("Notify retry result (placeholder)")
+
+if __name__ == "__main__":
+    main()

--- a/parse_failed_gpt.py
+++ b/parse_failed_gpt.py
@@ -1,0 +1,8 @@
+import logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+def main():
+    logging.info("Parsing failed GPT outputs (placeholder)")
+
+if __name__ == "__main__":
+    main()

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -21,9 +21,28 @@ PIPELINE_SEQUENCE = [
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    """Locate and execute a pipeline script.
+
+    The repository originally assumed that every step lived inside the
+    ``scripts/`` directory, but several utilities are stored at the
+    repository root.  ``full_path`` now searches both locations to find the
+    actual file to run.
+    """
+    repo_root = os.path.dirname(os.path.abspath(__file__))
+
+    # Look for ``script`` first in the repository root and then in ``scripts/``
+    candidate_paths = [os.path.join(repo_root, script),
+                      os.path.join(repo_root, "scripts", script)]
+
+    full_path = None
+    for path in candidate_paths:
+        if os.path.exists(path):
+            full_path = path
+            break
+
+    if full_path is None:
+        logging.error(
+            f"❌ 파일이 존재하지 않습니다: {script} (searched {candidate_paths})")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- allow `run_pipeline.py` to search for steps both in repo root and in `scripts/`
- provide placeholder scripts `parse_failed_gpt.py` and `notify_retry_result.py`

## Testing
- `python run_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684b58a2a37c832ea0976860a15cffaf