### PR TITLE
Ensure log dir creation in uploader

### DIFF
--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -16,6 +16,7 @@ FAILED_OUTPUT_PATH = "data/upload_failed_hooks.json"
 UPLOAD_DELAY = float(os.getenv("UPLOAD_DELAY", "0.5"))
 
 notion = Client(auth=NOTION_TOKEN)
+os.makedirs("logs", exist_ok=True)
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s %(levelname)s:%(message)s',


### PR DESCRIPTION
## Summary
- create `logs` directory before configuring notion uploader logging

## Testing
- `pytest -q`
- `python -m py_compile notion_hook_uploader.py`


------
https://chatgpt.com/codex/tasks/task_e_684b57b322bc832e9ffce4122a2b3c67