### PR TITLE
Fix pipeline invocation command

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()


### PR DESCRIPTION
## Summary
- call the pipeline via `python run_pipeline.py` in the workflow

## Testing
- `python -m py_compile run_pipeline.py`
- `python -m py_compile scripts/notion_uploader.py`
- `python -m py_compile scripts/retry_failed_uploads.py notion_hook_uploader.py retry_dashboard_notifier.py keyword_auto_pipeline.py hook_generator.py retry_failed_uploads.py`


------
https://chatgpt.com/codex/tasks/task_e_684b57b133cc832eaade6a64ff64ee2c