### PR TITLE
Remove unused topic parameter

### DIFF
--- a/hook_generator.py
+++ b/hook_generator.py
@@ -20,7 +20,7 @@ openai.api_key = OPENAI_API_KEY
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
 
 # ---------------------- GPT 프롬프트 생성 함수 ----------------------
-def generate_hook_prompt(keyword, topic, source, score, growth, mentions):
+def generate_hook_prompt(keyword, source, score, growth, mentions):
     base = f"""
     주제: {keyword}
     출처: {source}
@@ -89,7 +89,6 @@ def generate_hooks():
 
         prompt = generate_hook_prompt(
             keyword=keyword,
-            topic=keyword.split()[0],
             source=item.get('source'),
             score=item.get('score', 0),
             growth=item.get('growth', 0),


### PR DESCRIPTION
## Summary
- drop unused `topic` arg from generate_hook_prompt
- update call sites accordingly

## Testing
- `python -m py_compile hook_generator.py notion_hook_uploader.py scripts/notion_uploader.py scripts/retry_failed_uploads.py keyword_auto_pipeline.py run_pipeline.py retry_dashboard_notifier.py`

------
https://chatgpt.com/codex/tasks/task_e_684b56ac3ca0832ea2297c2bd6694b9c