### PR TITLE
Fix pipeline sequence & workflow entrypoint

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -12,18 +12,25 @@ logging.basicConfig(
 
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
+    # 키워드 수집 및 필터링
+    "keyword_auto_pipeline.py",
+    # 후킹 문장 생성
     "hook_generator.py",
-    "parse_failed_gpt.py",
+    # 생성된 결과 노션 업로드
+    "notion_hook_uploader.py",
+    # 실패한 항목 재업로드
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    # KPI 대시보드 갱신
+    "retry_dashboard_notifier.py",
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
-def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+def run_script(script: str) -> bool:
+    """Run a python script located either in the repository root or in scripts/."""
+    search_paths = [script, os.path.join("scripts", script)]
+    full_path = next((p for p in search_paths if os.path.exists(p)), None)
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- update pipeline order to reference existing scripts
- allow running scripts in repo root
- correct GitHub Actions entrypoint

## Testing
- `python -m py_compile run_pipeline.py`
- `python -m py_compile keyword_auto_pipeline.py hook_generator.py notion_hook_uploader.py scripts/retry_failed_uploads.py retry_dashboard_notifier.py`


------
https://chatgpt.com/codex/tasks/task_e_684b56a7dc10832e972a68e7b43a7601