### PR TITLE
Fix log directory creation before logging setup

### DIFF
--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -16,6 +16,7 @@ FAILED_OUTPUT_PATH = "data/upload_failed_hooks.json"
 UPLOAD_DELAY = float(os.getenv("UPLOAD_DELAY", "0.5"))
 
 notion = Client(auth=NOTION_TOKEN)
+os.makedirs("logs", exist_ok=True)
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s %(levelname)s:%(message)s',


### PR DESCRIPTION
## Summary
- ensure `logs` directory exists in `notion_hook_uploader.py` before configuring logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b5cc39d78832ea550700efea7bb21