### PR TITLE
Fix pipeline execution path

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()


### PR DESCRIPTION
## Summary
- use the correct run_pipeline.py path in workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b61181c3c832eb91d81e8df3c6f50