### PR TITLE
Add basic blog automation modules

### DIFF
--- a/automation/content_generation.py
+++ b/automation/content_generation.py
@@ -1,0 +1,30 @@
+import random
+
+
+class ContentGenerationEngine:
+    """Content engine coordinating topic discovery, outline, writing, and review."""
+
+    def discover_topics(self, data):
+        # Placeholder for trend analysis and keyword research.
+        topics = [f"Topic {i}" for i in range(1, 4)]
+        return random.choice(topics)
+
+    def create_outline(self, topic):
+        outline = {"title": topic, "sections": ["Intro", "Body", "Conclusion"]}
+        return outline
+
+    def write_content(self, outline):
+        # Placeholder for AI writing model.
+        body = "\n".join(f"{section}: lorem ipsum..." for section in outline["sections"])
+        return f"{outline['title']}\n{body}"
+
+    def review_content(self, text):
+        # Placeholder for fact checking / quality review.
+        return text + "\n[Reviewed]"
+
+    def generate_full_article(self, data):
+        topic = self.discover_topics(data)
+        outline = self.create_outline(topic)
+        content = self.write_content(outline)
+        reviewed = self.review_content(content)
+        return reviewed

--- a/automation/data_hub.py
+++ b/automation/data_hub.py
@@ -1,0 +1,24 @@
+class DataHub:
+    """Collects and merges various data sources."""
+
+    def collect_social_trends(self):
+        # Example: Query a social API. Here we return mock data.
+        return {"social_trends": ["trend1", "trend2"]}
+
+    def collect_keyword_data(self):
+        # Example: Pull from an SEO tool.
+        return {"keywords": ["keyword1", "keyword2"]}
+
+    def collect_competitor_info(self):
+        return {"competitors": ["comp1", "comp2"]}
+
+    def collect_site_metrics(self):
+        return {"site": {"views": 1000}}
+
+    def collect_all(self):
+        data = {}
+        data.update(self.collect_social_trends())
+        data.update(self.collect_keyword_data())
+        data.update(self.collect_competitor_info())
+        data.update(self.collect_site_metrics())
+        return data

--- a/automation/deployment.py
+++ b/automation/deployment.py
@@ -1,0 +1,31 @@
+import logging
+
+
+class Deployer:
+    """Handles automated publishing and performance tracking."""
+
+    def __init__(self, channels):
+        self.channels = channels
+        self.logger = logging.getLogger(__name__)
+
+    def format_content(self, content, channel):
+        return f"Formatted for {channel}: {content}"
+
+    def publish_to_channel(self, content, channel):
+        formatted = self.format_content(content, channel)
+        # Placeholder for API call to publish.
+        self.logger.info("Published to %s", channel)
+        return formatted
+
+    def deploy(self, content):
+        for channel in self.channels:
+            self.publish_to_channel(content, channel)
+        self.logger.info("Deployment completed")
+
+    def run_ab_test(self, variations):
+        # Placeholder for automated A/B testing logic.
+        self.logger.info("Running A/B test with variations %s", variations)
+
+    def track_performance(self):
+        # Placeholder for collecting performance metrics.
+        self.logger.info("Tracking performance")

--- a/automation/orchestration.py
+++ b/automation/orchestration.py
@@ -1,0 +1,29 @@
+import logging
+from datetime import datetime
+from apscheduler.schedulers.background import BackgroundScheduler
+
+logger = logging.getLogger(__name__)
+scheduler = BackgroundScheduler()
+
+
+def schedule_publication(job_func, run_time):
+    """Schedule a job at the specified datetime."""
+    scheduler.add_job(job_func, 'date', run_date=run_time)
+    logger.info("Scheduled job %s at %s", job_func.__name__, run_time)
+
+
+def monitor_workflow(step: str):
+    """Simple monitoring hook for workflow steps."""
+    logger.info("Workflow step completed: %s", step)
+
+
+def run_workflow(data_hub, content_engine, deployer):
+    """High-level workflow: gather data, generate content, deploy."""
+    trends = data_hub.collect_all()
+    monitor_workflow("data_collected")
+
+    article = content_engine.generate_full_article(trends)
+    monitor_workflow("content_generated")
+
+    deployer.deploy(article)
+    monitor_workflow("deployed")

--- a/automation/run_pipeline.py
+++ b/automation/run_pipeline.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from automation.orchestration import run_workflow, schedule_publication, scheduler
+from automation.content_generation import ContentGenerationEngine
+from automation.data_hub import DataHub
+from automation.deployment import Deployer
+
+
+data_hub = DataHub()
+content_engine = ContentGenerationEngine()
+deployer = Deployer(channels=["blog", "newsletter", "social"])
+
+def main():
+    run_workflow(data_hub, content_engine, deployer)
+
+
+if __name__ == "__main__":
+    # Schedule next run for demonstration
+    schedule_publication(main, datetime.now())
+    scheduler.start()
+    scheduler._event.wait()  # Keep the scheduler running


### PR DESCRIPTION
## Summary
- introduce `automation` package implementing example blog automation
- implement orchestration logic with scheduler
- add content generation, data hub, and deployment modules
- provide a demonstration `run_pipeline` script

## Testing
- `python -m py_compile automation/*.py`
- `python -m automation.run_pipeline` *(fails: ModuleNotFoundError: No module named 'apscheduler')*

------
https://chatgpt.com/codex/tasks/task_e_684bc2ca28a8832eb3e654d86195bcd6