### PR TITLE
Fix script sequence and fallback path handling

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -12,18 +12,24 @@ logging.basicConfig(
 
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
+    "keyword_auto_pipeline.py",
     "hook_generator.py",
-    "parse_failed_gpt.py",
+    "notion_hook_uploader.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    "retry_dashboard_notifier.py",
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    """Execute a script from ``scripts/`` or fall back to the repository root."""
+
+    script_paths = [os.path.join("scripts", script), script]
+    for path in script_paths:
+        if os.path.exists(path):
+            full_path = path
+            break
+    else:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- run pipeline with the actual script list
- search `scripts/` first and fall back to repo root when executing scripts
- remove references to deleted scripts

## Testing
- `python -m py_compile run_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_684bbdd4f1cc832ea26597301baf1818