### PR TITLE
Add unit tests and CI test step

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -31,6 +31,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: 🧪 Run tests
+        run: |
+          pytest -q
+
       - name: ▶️ Run full pipeline (single entrypoint)
         run: python scripts/run_pipeline.py
 

--- a/tests/test_filter_keywords.py
+++ b/tests/test_filter_keywords.py
@@ -1,0 +1,59 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import types
+
+dummy_pt = types.ModuleType('pytrends')
+dummy_pt.__path__ = []
+request_mod = types.ModuleType('pytrends.request')
+request_mod.TrendReq = lambda *a, **k: None
+sys.modules.setdefault('pytrends', dummy_pt)
+sys.modules.setdefault('pytrends.request', request_mod)
+
+dummy_sn = types.ModuleType('snscrape.modules.twitter')
+sys.modules.setdefault('snscrape', types.ModuleType('snscrape'))
+sys.modules.setdefault('snscrape.modules', types.ModuleType('snscrape.modules'))
+sys.modules.setdefault('snscrape.modules.twitter', dummy_sn)
+
+import keyword_auto_pipeline as kap
+
+
+def test_filter_keywords():
+    entries = [
+        {
+            'keyword': 'a',
+            'source': 'GoogleTrends',
+            'score': kap.GOOGLE_TRENDS_MIN_SCORE + 10,
+            'growth': kap.GOOGLE_TRENDS_MIN_GROWTH + 0.5,
+            'cpc': kap.MIN_CPC + 100
+        },
+        {
+            'keyword': 'b',
+            'source': 'GoogleTrends',
+            'score': kap.GOOGLE_TRENDS_MIN_SCORE - 5,
+            'growth': kap.GOOGLE_TRENDS_MIN_GROWTH + 0.5,
+            'cpc': kap.MIN_CPC + 100
+        },
+        {
+            'keyword': 'c',
+            'source': 'Twitter',
+            'mentions': kap.TWITTER_MIN_MENTIONS + 5,
+            'top_retweet': kap.TWITTER_MIN_TOP_RETWEET + 1,
+            'cpc': kap.MIN_CPC + 100
+        },
+        {
+            'keyword': 'd',
+            'source': 'Twitter',
+            'mentions': kap.TWITTER_MIN_MENTIONS - 1,
+            'top_retweet': kap.TWITTER_MIN_TOP_RETWEET + 1,
+            'cpc': kap.MIN_CPC + 100
+        },
+    ]
+
+    result = kap.filter_keywords(entries)
+    assert entries[0] in result
+    assert entries[2] in result
+    assert entries[1] not in result
+    assert entries[3] not in result

--- a/tests/test_page_exists.py
+++ b/tests/test_page_exists.py
@@ -1,0 +1,57 @@
+import importlib
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+
+
+def _setup_module(module_name, monkeypatch):
+    dummy_nc = types.ModuleType('notion_client')
+    class DummyClient:
+        def __init__(self, *a, **kw):
+            pass
+    dummy_nc.Client = DummyClient
+    monkeypatch.setitem(sys.modules, 'notion_client', dummy_nc)
+
+    dummy_dotenv = types.ModuleType('dotenv')
+    dummy_dotenv.load_dotenv = lambda *a, **kw: None
+    monkeypatch.setitem(sys.modules, 'dotenv', dummy_dotenv)
+
+    os.makedirs('logs', exist_ok=True)
+
+    module = importlib.import_module(module_name)
+    return module
+
+
+def test_page_exists_hook(monkeypatch):
+    mod = _setup_module('notion_hook_uploader', monkeypatch)
+    class DummyDB:
+        def query(self, database_id, filter, page_size):
+            if filter['title']['equals'] == 'exist':
+                return {'results': [1]}
+            return {'results': []}
+    mod.notion = types.SimpleNamespace(databases=DummyDB())
+    mod.NOTION_HOOK_DB_ID = 'db'
+
+    assert mod.page_exists('exist') is True
+    assert mod.page_exists('none') is False
+
+
+def test_page_exists_keywords(monkeypatch):
+    mod = _setup_module('scripts.notion_uploader', monkeypatch)
+    class DummyDB:
+        def query(self, database_id, filter, page_size):
+            if filter['title']['equals'] == 'exist':
+                return {'results': [1]}
+            return {'results': []}
+    mod.notion = types.SimpleNamespace(databases=DummyDB())
+    mod.NOTION_DB_ID = 'db'
+    mod.uploaded_cache = set()
+
+    assert mod.page_exists('exist') is True
+    assert mod.page_exists('none') is False
+    mod.uploaded_cache.add('cached')
+    assert mod.page_exists('cached') is True


### PR DESCRIPTION
## Summary
- add basic tests for filter_keywords and page_exists
- run pytest as part of daily pipeline workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684bbc004a6c832e8b9d22beacb0e3aa