### PR TITLE
Add failed hook parser

### DIFF
--- a/parse_failed_gpt.py
+++ b/parse_failed_gpt.py
@@ -1,0 +1,54 @@
+import os
+import json
+import logging
+import re
+from dotenv import load_dotenv
+
+load_dotenv()
+
+FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def parse_generated_text(text: str):
+    """Parse raw GPT output into structured fields."""
+    hook_lines = re.findall(r"후킹 ?문장[0-9]?[\s:：\-\)]*([^\n]+)", text)
+    blog_match = re.search(
+        r"블로그(?:\s*초안)?[\s:：\-\)]*(.*?)\n+\s*(.*?\n+.*?\n+.*?)(?:\n|$)",
+        text,
+        re.DOTALL,
+    )
+    video_titles = re.findall(r"(?:영상 제목|YouTube 제목)[\s:：\-\)]*[^\n]*\n?-\s*(.+)", text)
+
+    blog_paragraphs = [p.strip() for p in blog_match[1].strip().split("\n")[:3]] if blog_match else ["", "", ""]
+    return {
+        "hook_lines": hook_lines[:2] if len(hook_lines) >= 2 else ["", ""],
+        "blog_paragraphs": blog_paragraphs,
+        "video_titles": video_titles[:2] if video_titles else ["", ""],
+    }
+
+
+def reparse_failed():
+    if not os.path.exists(FAILED_PATH):
+        logging.error(f"❌ 실패 로그 파일이 없습니다: {FAILED_PATH}")
+        return
+
+    with open(FAILED_PATH, "r", encoding="utf-8") as f:
+        failed_items = json.load(f)
+
+    reparsed = []
+    for item in failed_items:
+        text = item.get("generated_text", "") or ""
+        item["parsed"] = parse_generated_text(text)
+        reparsed.append(item)
+
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, "w", encoding="utf-8") as f:
+        json.dump(reparsed, f, ensure_ascii=False, indent=2)
+    logging.info(f"✅ 재파싱 결과 저장: {OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    reparse_failed()

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -20,10 +20,17 @@ PIPELINE_SEQUENCE = [
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
+
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    search_paths = ["scripts", "."]
+    full_path = None
+    for base in search_paths:
+        candidate = os.path.join(base, script)
+        if os.path.exists(candidate):
+            full_path = candidate
+            break
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {os.path.join('scripts', script)}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- parse and save failed GPT hook logs
- support running pipeline scripts from repo root or `scripts/`

## Testing
- `python -m py_compile run_pipeline.py parse_failed_gpt.py retry_dashboard_notifier.py retry_failed_uploads.py hook_generator.py notion_hook_uploader.py scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684bbbfe48e8832ea75cfc43a72180c3