### PR TITLE
Update run_pipeline behavior

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -12,16 +12,19 @@ logging.basicConfig(
 
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
+    "keyword_auto_pipeline.py",
     "hook_generator.py",
-    "parse_failed_gpt.py",
+    "notion_hook_uploader.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    "retry_dashboard_notifier.py",
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    full_path = os.path.join(base_dir, "scripts", script)
+    if not os.path.exists(full_path):
+        full_path = os.path.join(base_dir, script)
     if not os.path.exists(full_path):
         logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
         return False


### PR DESCRIPTION
## Summary
- ensure `PIPELINE_SEQUENCE` lists only real scripts
- allow `run_script()` to fall back to repo root if script isn't in `scripts/`
- drop references to unused scripts

## Testing
- `python -m py_compile run_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684bba3f3af0832eb900dfda9c935640