### PR TITLE
Fix workflow path to run_pipeline

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()


### PR DESCRIPTION
## Summary
- correct workflow entrypoint path for the daily pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bb86acc68832e9675fa4f04babad5