### PR TITLE
Fix workflow filename and run_pipeline path

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+openai
+python-dotenv
+notion-client
+pytrends
+snscrape


### PR DESCRIPTION
## Summary
- rename pipeline workflow file to use `.yml`
- run pipeline directly from repository root
- add requirements file for pipeline dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_684bb7406ff0832eacfe77225030e47e