### PR TITLE
Fix pipeline script order and path lookup

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -12,19 +12,23 @@ logging.basicConfig(
 
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
+    "keyword_auto_pipeline.py",
     "hook_generator.py",
-    "parse_failed_gpt.py",
+    "notion_hook_uploader.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    "retry_dashboard_notifier.py",
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
+    """Execute a python script either from scripts/ or repo root."""
     full_path = os.path.join("scripts", script)
     if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
-        return False
+        # Fallback to repository root
+        full_path = script
+        if not os.path.exists(full_path):
+            logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
+            return False
 
     logging.info(f"🚀 실행 중: {script}")
     result = subprocess.run([sys.executable, full_path], capture_output=True, text=True)


### PR DESCRIPTION
## Summary
- update `PIPELINE_SEQUENCE` to reference real scripts
- allow `run_script` to fall back to repo root when a script isn't in `scripts/`
- drop unused references to missing scripts

## Testing
- `python -m py_compile keyword_auto_pipeline.py hook_generator.py notion_hook_uploader.py retry_failed_uploads.py retry_dashboard_notifier.py`
- `python -m py_compile run_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_684bb73fb5cc832e911a1d38482fa7c8