### PR TITLE
Fix pipeline workflow path

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+openai
+python-dotenv
+notion-client
+pytrends
+snscrape


### PR DESCRIPTION
## Summary
- rename workflow file for GitHub Actions
- install dependencies from `requirements.txt`
- point workflow to run correct `run_pipeline.py` entrypoint
- add initial list of dependencies

## Testing
- `git commit -am "Fix pipeline workflow path"`

------
https://chatgpt.com/codex/tasks/task_e_684bb3a2e9c4832e89ee1d27628f4e84