### PR TITLE
Fix script path handling

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -21,9 +21,17 @@ PIPELINE_SEQUENCE = [
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    """Search for the given script in known directories and execute it."""
+    search_paths = ["scripts", "."]
+    full_path = None
+    for path in search_paths:
+        candidate = os.path.join(path, script)
+        if os.path.exists(candidate):
+            full_path = candidate
+            break
+
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- allow `run_script` to locate modules in `scripts/` or repo root
- call the correct `run_pipeline.py` path in the workflow

## Testing
- `python run_pipeline.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684bb20a3b18832eb72304eaf9c64164