### PR TITLE
Add parsing and notification scripts

### DIFF
--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,51 @@
+import os
+import json
+import logging
+import urllib.request
+from dotenv import load_dotenv
+
+load_dotenv()
+WEBHOOK = os.getenv("SLACK_WEBHOOK_URL")
+SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def load_summary():
+    if not os.path.exists(SUMMARY_PATH):
+        logging.error(f"❌ 요약 파일이 없습니다: {SUMMARY_PATH}")
+        return None
+    with open(SUMMARY_PATH, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    total = len(data)
+    failed = len([d for d in data if d.get("retry_error")])
+    success = total - failed
+    rate = round((success / total) * 100, 1) if total > 0 else 0.0
+    return {"total": total, "success": success, "failed": failed, "rate": rate}
+
+
+def send_slack(summary):
+    if not WEBHOOK:
+        logging.error("❗ SLACK_WEBHOOK_URL 환경 변수가 설정되지 않았습니다.")
+        return
+    text = (
+        f"재시도 결과 보고\n"
+        f"전체: {summary['total']}\n"
+        f"성공: {summary['success']} 실패: {summary['failed']}\n"
+        f"성공률: {summary['rate']}%"
+    )
+    payload = json.dumps({"text": text}).encode('utf-8')
+    req = urllib.request.Request(WEBHOOK, data=payload, headers={'Content-Type': 'application/json'})
+    try:
+        with urllib.request.urlopen(req) as resp:
+            resp.read()
+        logging.info("📨 슬랙 알림 전송 완료")
+    except Exception as e:
+        logging.error(f"❌ 슬랙 전송 실패: {e}")
+
+
+if __name__ == "__main__":
+    summary = load_summary()
+    if summary:
+        logging.info(f"📊 재시도 요약: {summary}")
+        send_slack(summary)

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,53 @@
+import os
+import json
+import logging
+import re
+from dotenv import load_dotenv
+
+load_dotenv()
+FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+# Reuse parsing logic similar to notion_hook_uploader
+
+def parse_generated_text(text: str):
+    hook_lines = re.findall(r"후킹 ?문장[0-9]?[\s:：\-\)]*([^\n]+)", text)
+    blog_match = re.search(r"블로그(?:\s*초안)?[\s:：\-\)]*(.*?)\n+\s*(.*?\n+.*?\n+.*?)(?:\n|$)", text, re.DOTALL)
+    video_titles = re.findall(r"(?:영상 제목|YouTube 제목)[\s:：\-\)]*[^\n]*\n?-\s*(.+)", text)
+
+    blog_paragraphs = [p.strip() for p in blog_match[1].strip().split('\n')[:3]] if blog_match else ["", "", ""]
+    return {
+        "hook_lines": hook_lines[:2] if len(hook_lines) >= 2 else ["", ""],
+        "blog_paragraphs": blog_paragraphs,
+        "video_titles": video_titles[:2] if video_titles else ["", ""]
+    }
+
+def parse_failed():
+    if not os.path.exists(FAILED_PATH):
+        logging.error(f"❌ 실패 파일이 존재하지 않습니다: {FAILED_PATH}")
+        return
+
+    with open(FAILED_PATH, 'r', encoding='utf-8') as f:
+        items = json.load(f)
+
+    results = []
+    for item in items:
+        text = item.get("generated_text") or ""
+        if not text:
+            item["retry_error"] = "no_generated_text"
+            results.append(item)
+            continue
+        parsed = parse_generated_text(text)
+        item["parsed"] = parsed
+        results.append(item)
+
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        json.dump(results, f, ensure_ascii=False, indent=2)
+    logging.info(f"📄 재파싱 결과 저장 완료: {OUTPUT_PATH}")
+    logging.info(f"총 항목: {len(results)}")
+
+if __name__ == "__main__":
+    parse_failed()


### PR DESCRIPTION
## Summary
- add script to reparse GPT failure logs
- add script to send retry summary to Slack

## Testing
- `python -m py_compile scripts/parse_failed_gpt.py scripts/notify_retry_result.py`

------
https://chatgpt.com/codex/tasks/task_e_684bb2099bf4832e8dce3b71382b9a26