### PR TITLE
Add missing pipeline scripts

### DIFF
--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,52 @@
+import os
+import json
+import logging
+from datetime import datetime
+from dotenv import load_dotenv
+import requests
+
+load_dotenv()
+REPARSED_OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def summarize_results(items):
+    total = len(items)
+    failed = len([i for i in items if i.get("retry_error")])
+    success = total - failed
+    return total, success, failed
+
+
+def send_slack_notification(message: str) -> None:
+    if not SLACK_WEBHOOK_URL:
+        logging.info("ℹ️ SLACK_WEBHOOK_URL not set; skipping Slack notification")
+        return
+    try:
+        resp = requests.post(SLACK_WEBHOOK_URL, json={"text": message}, timeout=10)
+        if resp.status_code != 200:
+            raise RuntimeError(f"status {resp.status_code}: {resp.text}")
+    except Exception as e:
+        logging.error(f"❌ Failed to send Slack message: {e}")
+        raise
+
+
+def main():
+    if not os.path.exists(REPARSED_OUTPUT_PATH):
+        logging.info(f"✅ No retry results to notify: {REPARSED_OUTPUT_PATH} not found")
+        return
+    with open(REPARSED_OUTPUT_PATH, 'r', encoding='utf-8') as f:
+        items = json.load(f)
+    total, success, failed = summarize_results(items)
+    msg = f"Retry Summary {datetime.now().strftime('%Y-%m-%d %H:%M')}: success {success}/{total}, failed {failed}"
+    logging.info(msg)
+    send_slack_notification(msg)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        exit(1)
+

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,46 @@
+import os
+import json
+import logging
+from dotenv import load_dotenv
+from notion_hook_uploader import parse_generated_text
+
+load_dotenv()
+FAILED_HOOK_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+REPARSED_OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def parse_failed_items():
+    if not os.path.exists(FAILED_HOOK_PATH):
+        logging.info(f"✅ No failed hooks to parse: {FAILED_HOOK_PATH} not found")
+        return []
+    try:
+        with open(FAILED_HOOK_PATH, 'r', encoding='utf-8') as f:
+            items = json.load(f)
+    except Exception as e:
+        logging.error(f"❌ Could not read {FAILED_HOOK_PATH}: {e}")
+        raise
+
+    parsed_items = []
+    for item in items:
+        text = item.get("generated_text", "")
+        parsed = parse_generated_text(text)
+        parsed_items.append({
+            "keyword": item.get("keyword"),
+            "parsed": parsed,
+            "generated_text": text
+        })
+    os.makedirs(os.path.dirname(REPARSED_OUTPUT_PATH), exist_ok=True)
+    with open(REPARSED_OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        json.dump(parsed_items, f, ensure_ascii=False, indent=2)
+    logging.info(f"✅ Parsed results saved to {REPARSED_OUTPUT_PATH}")
+    return parsed_items
+
+
+if __name__ == "__main__":
+    try:
+        parse_failed_items()
+    except Exception:
+        exit(1)
+


### PR DESCRIPTION
## Summary
- implement parse_failed_gpt.py to parse failed hook outputs
- implement notify_retry_result.py to send summary notifications
- keep these scripts in the pipeline sequence

## Testing
- `python -m py_compile run_pipeline.py scripts/*.py hook_generator.py notion_hook_uploader.py retry_dashboard_notifier.py retry_failed_uploads.py keyword_auto_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684b86661ccc832ead2e5e9de8a34815