### PR TITLE
Fix run pipeline location and sequence

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -11,17 +11,20 @@ logging.basicConfig(
 )
 
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
+# 실행 순서를 정의합니다. 경로는 레포 루트 기준으로 작성합니다.
 PIPELINE_SEQUENCE = [
+    "keyword_auto_pipeline.py",
     "hook_generator.py",
-    "parse_failed_gpt.py",
+    "notion_hook_uploader.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    "retry_dashboard_notifier.py",
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
-def run_script(script):
-    full_path = os.path.join("scripts", script)
+def run_script(script: str) -> bool:
+    """개별 파이썬 스크립트를 실행합니다."""
+    base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    full_path = os.path.join(base_dir, script)
     if not os.path.exists(full_path):
         logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
         return False


### PR DESCRIPTION
## Summary
- remove outdated script references and add existing ones
- run scripts relative to repo root
- move pipeline entrypoint into `scripts/` so workflow path matches

## Testing
- `python -m py_compile scripts/run_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_684b83fbc950832e9851f541558bf5c5