### PR TITLE
Add retry helpers and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Auto Pipeline
+
+This project generates marketing hooks from trending keywords and uploads the results to Notion.
+
+## Pipeline Overview
+
+The main entry point is `run_pipeline.py`. It sequentially executes a set of scripts found in the `scripts/` directory:
+
+1. `hook_generator.py` – generate hook copy with OpenAI.
+2. `parse_failed_gpt.py` – parse failed GPT outputs and save them to `logs/failed_keywords_reparsed.json`.
+3. `retry_failed_uploads.py` – upload items that previously failed to Notion.
+4. `notify_retry_result.py` – send a Slack message summarising retry results.
+5. `retry_dashboard_notifier.py` – push KPI information to a Notion dashboard.
+
+Configure environment variables in a `.env` file before running the pipeline:
+
+```bash
+python run_pipeline.py
+```
+
+Each script logs its own progress to the console and may create files inside the `logs/` directory.

--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,43 @@
+import os
+import json
+import logging
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+def load_summary():
+    if not os.path.exists(SUMMARY_PATH):
+        logging.error(f"❌ 결과 파일이 없습니다: {SUMMARY_PATH}")
+        return None
+    with open(SUMMARY_PATH, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+def send_slack(text: str):
+    if not WEBHOOK_URL:
+        logging.error("❗ SLACK_WEBHOOK_URL 환경 변수가 설정되지 않았습니다.")
+        return
+    try:
+        resp = requests.post(WEBHOOK_URL, json={"text": text})
+        resp.raise_for_status()
+        logging.info("📢 Slack 알림 전송 완료")
+    except Exception as e:
+        logging.error(f"❌ Slack 전송 실패: {e}")
+
+def main():
+    data = load_summary()
+    if data is None:
+        return
+    total = len(data)
+    failed = len([d for d in data if d.get("retry_error")])
+    success = total - failed
+
+    message = f"재시도 결과\n총 시도: {total}\n성공: {success}\n실패: {failed}"
+    send_slack(message)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,50 @@
+import os
+import json
+import logging
+from dotenv import load_dotenv
+from notion_hook_uploader import parse_generated_text
+
+load_dotenv()
+FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+def load_failed_items():
+    if not os.path.exists(FAILED_PATH):
+        logging.error(f"❌ 실패 파일이 없습니다: {FAILED_PATH}")
+        return []
+    with open(FAILED_PATH, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+def parse_items(items):
+    parsed = []
+    for item in items:
+        keyword = item.get("keyword")
+        text = item.get("generated_text", "")
+        result = {
+            "keyword": keyword,
+            "generated_text": text,
+            "parsed": parse_generated_text(text) if text else {
+                "hook_lines": ["", ""],
+                "blog_paragraphs": ["", "", ""],
+                "video_titles": ["", ""]
+            }
+        }
+        parsed.append(result)
+    return parsed
+
+def main():
+    items = load_failed_items()
+    if not items:
+        logging.info("✅ 파싱할 항목이 없습니다.")
+        return
+
+    parsed = parse_items(items)
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        json.dump(parsed, f, ensure_ascii=False, indent=2)
+    logging.info(f"✅ 재파싱 결과 저장 완료: {OUTPUT_PATH}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `parse_failed_gpt.py` to parse failed GPT hooks
- add `notify_retry_result.py` to post retry summary to Slack
- document pipeline steps in `README.md`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b6587d044832ebaf2abaefed4ff91