### PR TITLE
Add retry parsing and Slack notification scripts

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -21,9 +21,15 @@ PIPELINE_SEQUENCE = [
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    """Run a script located either in ./scripts or project root."""
+    candidates = [os.path.join("scripts", script), script]
+    full_path = None
+    for path in candidates:
+        if os.path.exists(path):
+            full_path = path
+            break
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {candidates[0]} 또는 {candidates[1]}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")

--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,45 @@
+import os
+import json
+import logging
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+FAILED_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def summarize_results():
+    if not os.path.exists(FAILED_PATH):
+        return 0
+    with open(FAILED_PATH, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    return len(data)
+
+
+def send_slack_message(text):
+    if not WEBHOOK_URL:
+        logging.error("❌ SLACK_WEBHOOK_URL 환경 변수가 없습니다.")
+        return
+    try:
+        requests.post(WEBHOOK_URL, json={"text": text}, timeout=10)
+        logging.info("📣 Slack 알림 전송 완료")
+    except Exception as e:
+        logging.error(f"❌ Slack 알림 실패: {e}")
+
+
+def notify():
+    remaining = summarize_results()
+    if remaining == 0:
+        message = "✅ Retry succeeded. No failed keywords remain."
+    else:
+        message = f"⚠️ Retry complete. {remaining} keywords still failed."
+    send_slack_message(message)
+    print(message)
+
+
+if __name__ == "__main__":
+    notify()

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,47 @@
+import os
+import json
+import logging
+import sys
+
+# allow import from project root
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from notion_hook_uploader import parse_generated_text
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+INPUT_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+
+def parse_failed_items():
+    if not os.path.exists(INPUT_PATH):
+        logging.warning(f"❗ 입력 파일이 존재하지 않습니다: {INPUT_PATH}")
+        return
+
+    with open(INPUT_PATH, 'r', encoding='utf-8') as f:
+        failed = json.load(f)
+
+    reparsed = []
+    for item in failed:
+        keyword = item.get("keyword")
+        entry = {"keyword": keyword}
+        text = item.get("generated_text") or ""
+        if text:
+            try:
+                entry["parsed"] = parse_generated_text(text)
+            except Exception as e:
+                entry["parse_error"] = str(e)
+        else:
+            entry["parse_error"] = item.get("error", "no generated text")
+        reparsed.append(entry)
+
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        json.dump(reparsed, f, ensure_ascii=False, indent=2)
+
+    logging.info(f"📑 변환된 실패 항목 {len(reparsed)}개 저장: {OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    parse_failed_items()


### PR DESCRIPTION
## Summary
- add new `parse_failed_gpt.py` for converting failed GPT results
- add `notify_retry_result.py` to send Slack messages after retries
- support scripts in both root and `scripts/` folder in `run_pipeline.py`

## Testing
- `python -m py_compile scripts/parse_failed_gpt.py scripts/notify_retry_result.py run_pipeline.py`
- `python scripts/parse_failed_gpt.py && cat logs/failed_keywords_reparsed.json` *(fails: ModuleNotFoundError -> installed dependencies -> success)*
- `python scripts/notify_retry_result.py` *(fails: ModuleNotFoundError -> installed dependencies -> success)*

------
https://chatgpt.com/codex/tasks/task_e_684b62d60810832e9aa3122a1b924bf4