### PR TITLE
Fix pipeline script lookup and sequence

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,20 +13,26 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
     "retry_dashboard_notifier.py"
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    """Locate and execute a script either from the repo root or the scripts/ folder."""
+    # Check both the repository root and the 'scripts' directory for the script
+    candidate_paths = [script, os.path.join("scripts", script)]
+    full_path = None
+    for path in candidate_paths:
+        if os.path.exists(path):
+            full_path = path
+            break
+
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
-    logging.info(f"🚀 실행 중: {script}")
+    logging.info(f"🚀 실행 중: {full_path}")
     result = subprocess.run([sys.executable, full_path], capture_output=True, text=True)
 
     if result.returncode != 0:


### PR DESCRIPTION
## Summary
- search for scripts in both repo root and `scripts/`
- remove missing scripts from `PIPELINE_SEQUENCE`

## Testing
- `python -m py_compile run_pipeline.py`
- `python -m py_compile *.py scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684be1705670832e8b59c9ffed21e4dc