### PR TITLE
Refactor hook generator to async

### DIFF
--- a/hook_generator.py
+++ b/hook_generator.py
@@ -1,10 +1,10 @@
 import os
 import json
-import time
 import logging
 from datetime import datetime
 from dotenv import load_dotenv
 import openai
+import asyncio
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -13,6 +13,7 @@ HOOK_OUTPUT_PATH = os.getenv("HOOK_OUTPUT_PATH", "data/generated_hooks.json")
 FAILED_HOOK_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 API_DELAY = float(os.getenv("API_DELAY", "1.0"))
+MAX_CONCURRENT_REQUESTS = int(os.getenv("MAX_CONCURRENT_REQUESTS", "5"))
 
 openai.api_key = OPENAI_API_KEY
 
@@ -33,11 +34,11 @@ def generate_hook_prompt(keyword, topic, source, score, growth, mentions):
     """
     return base.strip()
 
-# ---------------------- GPT 호출 함수 (재시도 포함) ----------------------
-def get_gpt_response(prompt, retries=3):
+# ---------------------- GPT 호출 함수 (재시도 포함, 비동기) ----------------------
+async def get_gpt_response(prompt, retries=3):
     for attempt in range(retries):
         try:
-            response = openai.ChatCompletion.create(
+            response = await openai.ChatCompletion.acreate(
                 model="gpt-4",
                 messages=[{"role": "user", "content": prompt}],
                 temperature=0.7
@@ -45,11 +46,11 @@ def get_gpt_response(prompt, retries=3):
             return response.choices[0].message['content']
         except Exception as e:
             logging.warning(f"GPT 호출 실패 {attempt + 1}/{retries}: {e}")
-            time.sleep(2)
+            await asyncio.sleep(2)
     return None
 
 # ---------------------- 메인 실행 함수 ----------------------
-def generate_hooks():
+async def generate_hooks():
     if not OPENAI_API_KEY:
         logging.error("❗ OpenAI API 키가 누락되었습니다. .env 파일 확인 필요")
         return
@@ -74,18 +75,23 @@ def generate_hooks():
 
     new_output = []
     failed_output = []
-    skipped, success, failed = 0, 0, 0
+    skipped = 0
+    success = 0
+    failed = 0
 
-    for item in keywords:
+    semaphore = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
+
+    async def process_item(item):
+        nonlocal skipped, success, failed
         keyword = item.get('keyword')
         if not keyword:
             logging.warning("⛔ 빈 키워드 항목, 건너뜁니다.")
-            continue
+            return None
 
         if keyword in existing:
             logging.info(f"⏭️ 중복 스킵: {keyword}")
             skipped += 1
-            continue
+            return None
 
         prompt = generate_hook_prompt(
             keyword=keyword,
@@ -95,13 +101,16 @@ def generate_hooks():
             growth=item.get('growth', 0),
             mentions=item.get('mentions', 0)
         )
-        response = get_gpt_response(prompt)
 
         result = {
             "keyword": keyword,
             "hook_prompt": prompt,
             "timestamp": datetime.utcnow().isoformat() + 'Z'
         }
+
+        async with semaphore:
+            response = await get_gpt_response(prompt)
+            await asyncio.sleep(API_DELAY)
 
         if response:
             lines = response.split('\n')
@@ -121,7 +130,8 @@ def generate_hooks():
             logging.error(f"❌ 생성 실패: {keyword}")
             failed += 1
 
-        time.sleep(API_DELAY)
+    tasks = [process_item(item) for item in keywords]
+    await asyncio.gather(*tasks)
 
     full_output = list(existing.values()) + new_output
     os.makedirs(os.path.dirname(HOOK_OUTPUT_PATH), exist_ok=True)
@@ -139,4 +149,4 @@ def generate_hooks():
     logging.info(f"🎉 후킹 문장 저장 완료: {HOOK_OUTPUT_PATH}")
 
 if __name__ == "__main__":
-    generate_hooks()
+    asyncio.run(generate_hooks())


### PR DESCRIPTION
## Summary
- rewrite hook generation to use `asyncio` for multiple concurrent GPT requests
- add concurrency control via `MAX_CONCURRENT_REQUESTS`
- keep API delay and error handling with async retries

## Testing
- `python -m py_compile hook_generator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684be0add234832ebc1246751ec90458