### PR TITLE
Fix pipeline script lookup and add missing steps

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -21,9 +21,11 @@ PIPELINE_SEQUENCE = [
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    """Run a python script located either in the repo root or in ``scripts/``."""
+    candidates = [script, os.path.join("scripts", script)]
+    full_path = next((p for p in candidates if os.path.exists(p)), None)
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")

--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,39 @@
+import os
+import json
+import logging
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+REPARSED_OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def notify_retry_result():
+    if not os.path.exists(REPARSED_OUTPUT_PATH):
+        logging.info(f"❌ 재시도 결과 파일이 존재하지 않습니다: {REPARSED_OUTPUT_PATH}")
+        return
+
+    with open(REPARSED_OUTPUT_PATH, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    total = len(data)
+    failed = len([d for d in data if d.get("retry_error")])
+    success = total - failed
+    message = f"재업로드 결과: 성공 {success}, 실패 {failed}"
+
+    if SLACK_WEBHOOK_URL:
+        try:
+            requests.post(SLACK_WEBHOOK_URL, json={"text": message})
+            logging.info("✅ Slack 알림 전송 완료")
+        except Exception as e:
+            logging.error(f"❌ Slack 알림 실패: {e}")
+    else:
+        print(message)
+
+
+if __name__ == "__main__":
+    notify_retry_result()

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,31 @@
+import os
+import json
+import logging
+from dotenv import load_dotenv
+
+load_dotenv()
+
+FAILED_HOOK_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+REPARSED_OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def parse_failed_gpt():
+    if not os.path.exists(FAILED_HOOK_PATH):
+        logging.info(f"❌ 실패 파일이 존재하지 않습니다: {FAILED_HOOK_PATH}")
+        return
+
+    with open(FAILED_HOOK_PATH, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    # 현재는 단순 복사하여 재시도용 파일 생성
+    os.makedirs(os.path.dirname(REPARSED_OUTPUT_PATH), exist_ok=True)
+    with open(REPARSED_OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+    logging.info(f"✅ 재시도 파일 저장 완료: {REPARSED_OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    parse_failed_gpt()


### PR DESCRIPTION
## Summary
- add placeholder script to parse failed GPT output
- add Slack notification script for retry results
- search both repo root and `scripts/` when running pipeline scripts

## Testing
- `python -m py_compile run_pipeline.py scripts/*py`

------
https://chatgpt.com/codex/tasks/task_e_684be01dc1d8832ea06a6c2965949ce0