### PR TITLE
Fix pipeline script paths and sequence

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -12,18 +12,23 @@ logging.basicConfig(
 
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
+    "keyword_auto_pipeline.py",
     "hook_generator.py",
-    "parse_failed_gpt.py",
+    "notion_hook_uploader.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    "retry_dashboard_notifier.py",
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    root_dir = os.path.dirname(os.path.abspath(__file__))
+    candidates = [
+        os.path.join(root_dir, script),
+        os.path.join(root_dir, "scripts", script),
+    ]
+    full_path = next((p for p in candidates if os.path.exists(p)), None)
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- reference root python scripts rather than `scripts/`
- remove missing script names from pipeline sequence

## Testing
- `python -m py_compile keyword_auto_pipeline.py hook_generator.py notion_hook_uploader.py retry_failed_uploads.py retry_dashboard_notifier.py run_pipeline.py scripts/notion_uploader.py scripts/retry_failed_uploads.py`


------
https://chatgpt.com/codex/tasks/task_e_684bdd087f74832eb2f821c49a76babc