### PR TITLE
Fix pipeline script paths and add missing helpers

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -21,9 +21,16 @@ PIPELINE_SEQUENCE = [
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    """Run a python script located either in ./scripts or the repo root."""
+    search_paths = [os.path.join("scripts", script), script]
+    full_path = None
+    for path in search_paths:
+        if os.path.exists(path):
+            full_path = path
+            break
+
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")

--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,37 @@
+import os
+import json
+import logging
+from dotenv import load_dotenv
+
+load_dotenv()
+
+SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+def main():
+    if not os.path.exists(SUMMARY_PATH):
+        logging.error(f"❌ 요약 파일이 없습니다: {SUMMARY_PATH}")
+        return
+
+    with open(SUMMARY_PATH, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    total = len(data)
+    failed = len([d for d in data if d.get("retry_error")])
+    success = total - failed
+
+    message = f"재업로드 결과: 전체 {total}개 중 성공 {success}개, 실패 {failed}개"
+    logging.info(message)
+
+    if SLACK_WEBHOOK_URL:
+        try:
+            import requests
+            requests.post(SLACK_WEBHOOK_URL, json={"text": message})
+            logging.info("📣 Slack 알림 전송 완료")
+        except Exception as e:
+            logging.warning(f"Slack 전송 실패: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,51 @@
+import os
+import json
+import logging
+import re
+from dotenv import load_dotenv
+
+load_dotenv()
+
+FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+def parse_generated_text(text: str):
+    hook_lines = re.findall(r"후킹 ?문장[0-9]?[\s:：\-\)]*([^\n]+)", text)
+    blog_match = re.search(r"블로그(?:\s*초안)?[\s:：\-\)]*(.*?)\n+\s*(.*?\n+.*?\n+.*?)(?:\n|$)", text, re.DOTALL)
+    video_titles = re.findall(r"(?:영상 제목|YouTube 제목)[\s:：\-\)]*[^\n]*\n?-\s*(.+)", text)
+
+    blog_paragraphs = [p.strip() for p in blog_match[1].strip().split('\n')[:3]] if blog_match else ["", "", ""]
+    return {
+        "hook_lines": hook_lines[:2] if len(hook_lines) >= 2 else ["", ""],
+        "blog_paragraphs": blog_paragraphs,
+        "video_titles": video_titles[:2] if video_titles else ["", ""]
+    }
+
+def main():
+    if not os.path.exists(FAILED_PATH):
+        logging.error(f"❌ 실패 파일이 존재하지 않습니다: {FAILED_PATH}")
+        return
+
+    with open(FAILED_PATH, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    parsed_items = []
+    for item in data:
+        text = item.get("generated_text", "")
+        item["parsed"] = parse_generated_text(text) if text else {
+            "hook_lines": ["", ""],
+            "blog_paragraphs": ["", "", ""],
+            "video_titles": ["", ""]
+        }
+        parsed_items.append(item)
+
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        json.dump(parsed_items, f, ensure_ascii=False, indent=2)
+
+    logging.info(f"✅ 파싱 결과 저장: {OUTPUT_PATH}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- update `run_script` to look in `scripts/` and repo root
- add missing `parse_failed_gpt.py` to convert failed GPT output
- add missing `notify_retry_result.py` to send summary notifications

## Testing
- `python -m py_compile run_pipeline.py scripts/parse_failed_gpt.py scripts/notify_retry_result.py`

------
https://chatgpt.com/codex/tasks/task_e_684bdb881c3c832ea35f60c38158fcbf