### PR TITLE
Fix pipeline script paths

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,15 +13,21 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
+    # "parse_failed_gpt.py",  # TODO: 구현 전까지 비활성화
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
+    # "notify_retry_result.py",  # TODO: 구현 전까지 비활성화
     "retry_dashboard_notifier.py"
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
+    """지정된 스크립트를 실행한다.
+
+    스크립트가 현재 디렉터리에 존재하면 그 경로를 사용하고,
+    그렇지 않으면 ``scripts/`` 하위에서 찾는다.
+    """
+
+    full_path = script if os.path.exists(script) else os.path.join("scripts", script)
     if not os.path.exists(full_path):
         logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
         return False


### PR DESCRIPTION
## Summary
- disable missing parse/notify scripts
- detect scripts in root or `scripts/`
- fix pipeline path in workflow

## Testing
- `python run_pipeline.py >/tmp/run_pipeline.log && tail -n 20 /tmp/run_pipeline.log`
- `python -m py_compile run_pipeline.py`
- `python -m py_compile *.py scripts/*.py >/tmp/compile.log`

------
https://chatgpt.com/codex/tasks/task_e_684bdb826604832e95d51b90ca42b397