### PR TITLE
Fix pipeline script references

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -4,6 +4,8 @@ import sys
 import os
 from datetime import datetime
 
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+
 # ---------------------- 로깅 설정 ----------------------
 logging.basicConfig(
     level=logging.INFO,
@@ -12,16 +14,16 @@ logging.basicConfig(
 
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
+    "keyword_auto_pipeline.py",
     "hook_generator.py",
-    "parse_failed_gpt.py",
+    "notion_hook_uploader.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    "retry_dashboard_notifier.py",
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
+    full_path = os.path.join(ROOT_DIR, script)
     if not os.path.exists(full_path):
         logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
         return False


### PR DESCRIPTION
## Summary
- reference scripts that actually exist for pipeline execution
- load scripts relative to project root

## Testing
- `python -m py_compile run_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684bd9550214832e827339840df8e43c