### PR TITLE
Standardize failure path env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Required API keys
+OPENAI_API_KEY=
+NOTION_API_TOKEN=
+
+# Notion database IDs
+NOTION_HOOK_DB_ID=
+NOTION_DB_ID=
+NOTION_KPI_DB_ID=
+
+# Paths
+TOPIC_CHANNELS_PATH=config/topic_channels.json
+KEYWORD_OUTPUT_PATH=data/keyword_output_with_cpc.json
+HOOK_OUTPUT_PATH=data/generated_hooks.json
+FAILED_HOOK_PATH=logs/failed_hooks.json
+REPARSED_OUTPUT_PATH=logs/failed_keywords_reparsed.json
+UPLOADED_CACHE_PATH=data/uploaded_keywords_cache.json
+
+# Timing settings
+UPLOAD_DELAY=0.5
+API_DELAY=1.0
+RETRY_DELAY=0.5

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Auto Pipeline
+
+This repository contains scripts for collecting trending keywords, generating marketing hooks using OpenAI, and uploading the results to Notion. Environment variables control API keys, database IDs and file paths.
+
+## Environment Variables
+See `.env.example` for default values. Important variables include:
+
+- `OPENAI_API_KEY` – API key for OpenAI
+- `NOTION_API_TOKEN` – Notion integration token
+- `NOTION_HOOK_DB_ID` – ID of the Notion database for hooks
+- `NOTION_DB_ID` – ID of the Notion database for keywords
+- `NOTION_KPI_DB_ID` – ID of the Notion database for KPI tracking
+- `KEYWORD_OUTPUT_PATH` – path for keyword collection output
+- `HOOK_OUTPUT_PATH` – path for generated hooks
+- `FAILED_HOOK_PATH` – file for failed hook generation results
+- `REPARSED_OUTPUT_PATH` – file for failed uploads after reparsing
+- `UPLOADED_CACHE_PATH` – cache file for successfully uploaded keywords
+- `UPLOAD_DELAY`, `API_DELAY`, `RETRY_DELAY` – timing configurations
+
+Configure these variables in an `.env` file before running the pipeline.

--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -12,7 +12,7 @@ load_dotenv()
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
 HOOK_JSON_PATH = os.getenv("HOOK_OUTPUT_PATH", "data/generated_hooks.json")
-FAILED_OUTPUT_PATH = "data/upload_failed_hooks.json"
+REPARSED_OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "data/upload_failed_hooks.json")
 UPLOAD_DELAY = float(os.getenv("UPLOAD_DELAY", "0.5"))
 
 notion = Client(auth=NOTION_TOKEN)
@@ -119,10 +119,10 @@ def upload_all_hooks():
         time.sleep(UPLOAD_DELAY)
 
     if failed_items:
-        os.makedirs(os.path.dirname(FAILED_OUTPUT_PATH), exist_ok=True)
-        with open(FAILED_OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        os.makedirs(os.path.dirname(REPARSED_OUTPUT_PATH), exist_ok=True)
+        with open(REPARSED_OUTPUT_PATH, 'w', encoding='utf-8') as f:
             json.dump(failed_items, f, ensure_ascii=False, indent=2)
-        logging.info(f"❗ 실패 항목 저장됨: {FAILED_OUTPUT_PATH}")
+        logging.info(f"❗ 실패 항목 저장됨: {REPARSED_OUTPUT_PATH}")
 
     logging.info("📊 후킹 업로드 요약")
     logging.info(f"총 항목: {total} | 성공: {success} | 중복스킵: {skipped} | 실패: {failed}")

--- a/scripts/notion_uploader.py
+++ b/scripts/notion_uploader.py
@@ -13,7 +13,7 @@ NOTION_DB_ID = os.getenv("NOTION_DB_ID")
 KEYWORD_JSON_PATH = os.getenv("KEYWORD_OUTPUT_PATH", "data/keyword_output_with_cpc.json")
 UPLOAD_DELAY = float(os.getenv("UPLOAD_DELAY", "0.5"))
 CACHE_PATH = os.getenv("UPLOADED_CACHE_PATH", "data/uploaded_keywords_cache.json")
-FAILED_PATH = os.getenv("FAILED_UPLOADS_PATH", "logs/failed_uploads.json")
+REPARSED_OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_uploads.json")
 
 # ---------------------- 로깅 설정 ----------------------
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
@@ -120,10 +120,10 @@ def upload_all_keywords():
     # 실패 로그 저장
     if failed_uploads:
         try:
-            os.makedirs(os.path.dirname(FAILED_PATH), exist_ok=True)
-            with open(FAILED_PATH, 'w', encoding='utf-8') as f:
+            os.makedirs(os.path.dirname(REPARSED_OUTPUT_PATH), exist_ok=True)
+            with open(REPARSED_OUTPUT_PATH, 'w', encoding='utf-8') as f:
                 json.dump(failed_uploads, f, ensure_ascii=False, indent=2)
-            logging.info(f"❗ 실패 항목 기록 완료: {FAILED_PATH}")
+            logging.info(f"❗ 실패 항목 기록 완료: {REPARSED_OUTPUT_PATH}")
         except Exception as e:
             logging.warning(f"⚠️ 실패 로그 저장 실패: {e}")
 


### PR DESCRIPTION
## Summary
- use `REPARSED_OUTPUT_PATH` in uploader scripts
- document env vars in new `.env.example`
- add README describing the configuration

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684bd950ccf4832e8a99e403ae425e62