### PR TITLE
Integrate Hyper-Scale v10 modules

### DIFF
--- a/edge/kv_to_r2.js
+++ b/edge/kv_to_r2.js
@@ -1,0 +1,13 @@
+export default {
+  async fetch(req, env) {
+    const key = new URL(req.url).pathname;
+    let val = await env.KV_CACHE.get(key);
+    if (!val) {
+      val = await env.R2_BUCKET.get(key);             // ❶ R2 cold fetch
+      if (val) await env.KV_CACHE.put(key, val.body, { expirationTtl: 60 });
+    }
+    // PUT 키(60초 넘은 값) → R2
+    req.cf?.cacheTtl === 0 && env.R2_BUCKET.put(key, val, { httpMetadata: req.headers });
+    return new Response(val);
+  }
+}

--- a/k8s/gpu_quota.yml
+++ b/k8s/gpu_quota.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: gpu-quota-teamA
+  namespace: team-a
+spec:
+  hard:
+    nvidia.com/gpu: "40"          # 팀당 GPU 최대 40
+---
+apiVersion: scheduling.x-k8s.io/v1
+kind: ElasticQuota
+metadata: { name: team-a-elastic }
+spec:
+  max:
+    nvidia.com/gpu: "40"
+  min:
+    nvidia.com/gpu: "4"

--- a/kafka/connect/iceberg_sink.json
+++ b/kafka/connect/iceberg_sink.json
@@ -1,0 +1,10 @@
+{
+  "name": "iceberg-sink",
+  "connector.class": "org.apache.iceberg.kafka.ConnectSink",
+  "topics": "vinfinity.events",
+  "iceberg.catalog": "aws",
+  "iceberg.table": "vinfinity.event_log",
+  "s3.path": "s3a://vinfinity-lake/",
+  "tasks.max": "4",
+  "exactly.once.support": "required"
+}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1,0 +1,7 @@
+global:
+  prometheus:
+    enabled: false          # 외부 Prometheus 사용
+kubecostProductConfigs:
+  productKeySecretName: KUBECOST_KEY
+  gpuUsageMetrics: true
+  networkCosts: true

--- a/ml/bandit_optimizer.py
+++ b/ml/bandit_optimizer.py
@@ -1,0 +1,18 @@
+import pandas as pd, numpy as np, psycopg2, random
+from db_utils import get_conn
+
+def choose_variant(content_id):
+    with get_conn() as conn:
+        df = pd.read_sql(
+            """
+          SELECT variant, views, conversions
+          FROM ab_test_queue
+          WHERE content_id=%s
+        """,
+            conn,
+            params=(content_id,),
+        )
+    alpha = 1 + df["conversions"]
+    beta = 1 + df["views"] - df["conversions"]
+    theta = np.random.beta(alpha, beta)
+    return df.loc[theta.idxmax(), "variant"]

--- a/tests/test_bandit_optimizer.py
+++ b/tests/test_bandit_optimizer.py
@@ -1,0 +1,31 @@
+import sys
+import pathlib
+import types
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pandas as pd
+import numpy as np
+from unittest.mock import patch, MagicMock
+
+sys.modules["db_utils"] = types.SimpleNamespace(get_conn=lambda: None)
+from ml.bandit_optimizer import choose_variant
+
+
+def test_choose_variant_selects_highest_theta():
+    df = pd.DataFrame({
+        "variant": ["A", "B"],
+        "views": [100, 100],
+        "conversions": [10, 20],
+    })
+
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = MagicMock()
+    mock_ctx.__exit__.return_value = False
+
+    with patch("ml.bandit_optimizer.get_conn", return_value=mock_ctx), \
+         patch("pandas.read_sql", return_value=df) as read_sql_mock, \
+         patch("numpy.random.beta", return_value=pd.Series([0.1, 0.9])):
+        variant = choose_variant(1)
+
+    read_sql_mock.assert_called_once()
+    assert variant == "B"

--- a/trino/catalog/iceberg.properties
+++ b/trino/catalog/iceberg.properties
@@ -1,0 +1,3 @@
+connector.name=iceberg
+catalog.warehouse=s3a://vinfinity-lake/
+hive.metastore.uri=thrift://hive-metastore:9083

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,2 @@
+kv_namespaces = [{ binding="KV_CACHE", id="kv_llm_cache" }]
+r2_buckets = [{ binding="R2_BUCKET", bucket_name="vinfinity-cache" }]


### PR DESCRIPTION
## Summary
- add Kubernetes GPU quota and Kubecost Helm values
- implement Edge KV to R2 tiering worker and wrangler config
- introduce RL bandit optimizer module
- add Iceberg sink and Trino catalog configs
- provide unit test for bandit optimizer

## Testing
- `pytest -q`
- `pylint ml/bandit_optimizer.py` *(fails: missing module docstring, wrong-import-order, import-error, unused-import)*
- `mypy ml/bandit_optimizer.py` *(fails: missing library stubs, import-not-found)*

------
https://chatgpt.com/codex/tasks/task_e_684e885757d0832e95e3f76c50a9da0a