### PR TITLE
Fix pipeline sequence paths

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,17 +13,23 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    "retry_dashboard_notifier.py",
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    """Execute a script located either in ./scripts or the repository root."""
+    search_paths = ["scripts", "."]
+    full_path = None
+    for path in search_paths:
+        candidate = os.path.join(path, script)
+        if os.path.exists(candidate):
+            full_path = candidate
+            break
+
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- remove missing scripts from `PIPELINE_SEQUENCE`
- allow `run_pipeline` to find scripts either in `scripts/` or repo root

## Testing
- `python -m py_compile run_pipeline.py`
- `python -m py_compile hook_generator.py retry_dashboard_notifier.py scripts/retry_failed_uploads.py retry_failed_uploads.py`
- `python run_pipeline.py` *(fails: ModuleNotFoundError: dotenv, notion_client)*

------
https://chatgpt.com/codex/tasks/task_e_684bd9488464832eb54fb538a7a0bb25