### PR TITLE
Add missing pipeline scripts

### DIFF
--- a/scripts/hook_generator.py
+++ b/scripts/hook_generator.py
@@ -1,0 +1,142 @@
+import os
+import json
+import time
+import logging
+from datetime import datetime
+from dotenv import load_dotenv
+import openai
+
+# ---------------------- 설정 로딩 ----------------------
+load_dotenv()
+KEYWORD_JSON_PATH = os.getenv("KEYWORD_OUTPUT_PATH", "data/keyword_output_with_cpc.json")
+HOOK_OUTPUT_PATH = os.getenv("HOOK_OUTPUT_PATH", "data/generated_hooks.json")
+FAILED_HOOK_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+API_DELAY = float(os.getenv("API_DELAY", "1.0"))
+
+openai.api_key = OPENAI_API_KEY
+
+# ---------------------- 로깅 설정 ----------------------
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+# ---------------------- GPT 프롬프트 생성 함수 ----------------------
+def generate_hook_prompt(keyword, topic, source, score, growth, mentions):
+    base = f"""
+    주제: {keyword}
+    출처: {source}
+    트렌드 점수: {score}, 성장률: {growth}, 트윗 수: {mentions}
+    이 정보를 기반으로:
+    - 숏폼 영상의 후킹 문장 2개
+    - 블로그 포스트의 3문단 초안
+    - YouTube 영상 제목 예시 2개
+    를 마케팅적으로 끌리는 문장으로 생성해줘. 말투는 친근하면서도 전문가처럼.
+    """
+    return base.strip()
+
+# ---------------------- GPT 호출 함수 (재시도 포함) ----------------------
+def get_gpt_response(prompt, retries=3):
+    for attempt in range(retries):
+        try:
+            response = openai.ChatCompletion.create(
+                model="gpt-4",
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.7
+            )
+            return response.choices[0].message['content']
+        except Exception as e:
+            logging.warning(f"GPT 호출 실패 {attempt + 1}/{retries}: {e}")
+            time.sleep(2)
+    return None
+
+# ---------------------- 메인 실행 함수 ----------------------
+def generate_hooks():
+    if not OPENAI_API_KEY:
+        logging.error("❗ OpenAI API 키가 누락되었습니다. .env 파일 확인 필요")
+        return
+
+    try:
+        with open(KEYWORD_JSON_PATH, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+            keywords = data.get("filtered_keywords", [])
+    except Exception as e:
+        logging.error(f"❗ 키워드 파일 읽기 오류: {e}")
+        return
+
+    existing = {}
+    if os.path.exists(HOOK_OUTPUT_PATH):
+        try:
+            with open(HOOK_OUTPUT_PATH, 'r', encoding='utf-8') as f:
+                existing_data = json.load(f)
+                for entry in existing_data:
+                    existing[entry['keyword']] = entry
+        except Exception as e:
+            logging.warning(f"기존 결과 로딩 실패: {e}")
+
+    new_output = []
+    failed_output = []
+    skipped, success, failed = 0, 0, 0
+
+    for item in keywords:
+        keyword = item.get('keyword')
+        if not keyword:
+            logging.warning("⛔ 빈 키워드 항목, 건너뜁니다.")
+            continue
+
+        if keyword in existing:
+            logging.info(f"⏭️ 중복 스킵: {keyword}")
+            skipped += 1
+            continue
+
+        prompt = generate_hook_prompt(
+            keyword=keyword,
+            topic=keyword.split()[0],
+            source=item.get('source'),
+            score=item.get('score', 0),
+            growth=item.get('growth', 0),
+            mentions=item.get('mentions', 0)
+        )
+        response = get_gpt_response(prompt)
+
+        result = {
+            "keyword": keyword,
+            "hook_prompt": prompt,
+            "timestamp": datetime.utcnow().isoformat() + 'Z'
+        }
+
+        if response:
+            lines = response.split('\n')
+            result.update({
+                "hook_lines": lines[0:2],
+                "blog_paragraphs": lines[2:5],
+                "video_titles": lines[5:],
+                "generated_text": response
+            })
+            new_output.append(result)
+            logging.info(f"✅ 생성 완료: {keyword}")
+            success += 1
+        else:
+            result["generated_text"] = None
+            result["error"] = "GPT 응답 실패"
+            failed_output.append(result)
+            logging.error(f"❌ 생성 실패: {keyword}")
+            failed += 1
+
+        time.sleep(API_DELAY)
+
+    full_output = list(existing.values()) + new_output
+    os.makedirs(os.path.dirname(HOOK_OUTPUT_PATH), exist_ok=True)
+    with open(HOOK_OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        json.dump(full_output, f, ensure_ascii=False, indent=2)
+
+    if failed_output:
+        os.makedirs(os.path.dirname(FAILED_HOOK_PATH), exist_ok=True)
+        with open(FAILED_HOOK_PATH, 'w', encoding='utf-8') as f:
+            json.dump(failed_output, f, ensure_ascii=False, indent=2)
+        logging.warning(f"⚠️ 실패 후킹 저장 완료: {FAILED_HOOK_PATH}")
+
+    logging.info("📊 생성 작업 요약")
+    logging.info(f"총 키워드: {len(keywords)} | 성공: {success} | 중복스킵: {skipped} | 실패: {failed}")
+    logging.info(f"🎉 후킹 문장 저장 완료: {HOOK_OUTPUT_PATH}")
+
+if __name__ == "__main__":
+    generate_hooks()

--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,38 @@
+import os
+import json
+import logging
+from dotenv import load_dotenv
+import requests
+
+load_dotenv()
+WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+def notify_result():
+    if not os.path.exists(SUMMARY_PATH):
+        logging.warning(f"\u2757\ufe0f 요약 파일이 없습니다: {SUMMARY_PATH}")
+        return
+    with open(SUMMARY_PATH, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    total = len(data)
+    failed = len([d for d in data if d.get("retry_error")])
+    success = total - failed
+    message = f"재시도 결과: 총 {total}건 중 {success}건 성공, {failed}건 실패"
+
+    if WEBHOOK_URL:
+        try:
+            resp = requests.post(WEBHOOK_URL, json={"text": message})
+            if resp.status_code == 200:
+                logging.info("\uD83D\uDCE2 Slack 알림 전송 완료")
+            else:
+                logging.error(f"Slack 응답 오류: {resp.text}")
+        except Exception as e:
+            logging.error(f"Slack 전송 실패: {e}")
+    else:
+        logging.info(message)
+
+if __name__ == "__main__":
+    notify_result()

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,38 @@
+import os
+import json
+import logging
+from dotenv import load_dotenv
+
+load_dotenv()
+FAILED_INPUT_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+def parse_failed_items():
+    if not os.path.exists(FAILED_INPUT_PATH):
+        logging.warning(f"\u2757\ufe0f 실패 파일이 존재하지 않습니다: {FAILED_INPUT_PATH}")
+        return
+    with open(FAILED_INPUT_PATH, 'r', encoding='utf-8') as f:
+        try:
+            data = json.load(f)
+        except Exception as e:
+            logging.error(f"JSON 로딩 실패: {e}")
+            return
+
+    parsed = []
+    for item in data:
+        parsed.append({
+            "keyword": item.get("keyword"),
+            "hook_prompt": item.get("hook_prompt"),
+            "error": item.get("error"),
+            "timestamp": item.get("timestamp"),
+        })
+
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        json.dump(parsed, f, ensure_ascii=False, indent=2)
+    logging.info(f"\uD83D\uDD0D 실패 항목 {len(parsed)}개 파싱 완료: {OUTPUT_PATH}")
+
+if __name__ == "__main__":
+    parse_failed_items()

--- a/scripts/retry_dashboard_notifier.py
+++ b/scripts/retry_dashboard_notifier.py
@@ -1,0 +1,67 @@
+import os
+import json
+import logging
+from datetime import datetime
+from notion_client import Client
+from dotenv import load_dotenv
+
+# ---------------------- 설정 로딩 ----------------------
+load_dotenv()
+NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
+NOTION_KPI_DB_ID = os.getenv("NOTION_KPI_DB_ID")
+SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+# ---------------------- Notion 클라이언트 ----------------------
+if not NOTION_TOKEN or not NOTION_KPI_DB_ID:
+    logging.error("❗ 환경 변수(NOTION_API_TOKEN, NOTION_KPI_DB_ID)가 누락되었습니다.")
+    exit(1)
+notion = Client(auth=NOTION_TOKEN)
+
+# ---------------------- KPI 데이터 수집 ----------------------
+def get_retry_stats():
+    if not os.path.exists(SUMMARY_PATH):
+        logging.error(f"❌ 재시도 데이터 파일이 없습니다: {SUMMARY_PATH}")
+        return None
+
+    with open(SUMMARY_PATH, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    total = len(data)
+    failed = len([d for d in data if d.get("retry_error")])
+    success = total - failed
+    rate = round((success / total) * 100, 1) if total > 0 else 0.0
+
+    now = datetime.now()
+    return {
+        "date": now,
+        "total": total,
+        "success": success,
+        "failed": failed,
+        "rate": rate
+    }
+
+# ---------------------- Notion KPI 행 추가 ----------------------
+def push_kpi_to_notion(kpi):
+    try:
+        notion.pages.create(
+            parent={"database_id": NOTION_KPI_DB_ID},
+            properties={
+                "날짜": {"date": {"start": kpi["date"].isoformat()}},
+                "전체 시도": {"number": kpi["total"]},
+                "성공": {"number": kpi["success"]},
+                "실패": {"number": kpi["failed"]},
+                "성공률(%)": {"number": kpi["rate"]}
+            }
+        )
+        logging.info("📊 Notion KPI 업데이트 완료")
+    except Exception as e:
+        logging.error(f"❌ Notion KPI 전송 실패: {e}")
+
+# ---------------------- 실행 진입점 ----------------------
+if __name__ == "__main__":
+    kpi = get_retry_stats()
+    if kpi:
+        logging.info(f"📈 KPI 요약: {kpi}")
+        push_kpi_to_notion(kpi)

--- a/scripts/retry_failed_uploads.py
+++ b/scripts/retry_failed_uploads.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 load_dotenv()
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
-FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_keywords.json")
+FAILED_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
 RETRY_DELAY = float(os.getenv("RETRY_DELAY", "0.5"))
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')


### PR DESCRIPTION
## Summary
- implement parse_failed_gpt and notify_retry_result
- copy pipeline scripts into `scripts/` so they are runnable

## Testing
- `python -m py_compile scripts/*.py run_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684bd46cf258832eab40a75b167abdaa