### PR TITLE
Add environment example and ignore build artifacts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Environment variables for Auto_Pipeline
+OPENAI_API_KEY=
+NOTION_API_TOKEN=
+NOTION_HOOK_DB_ID=
+NOTION_DB_ID=
+NOTION_KPI_DB_ID=
+TOPIC_CHANNELS_PATH=config/topic_channels.json
+KEYWORD_OUTPUT_PATH=data/keyword_output_with_cpc.json
+HOOK_OUTPUT_PATH=data/generated_hooks.json
+FAILED_HOOK_PATH=logs/failed_hooks.json
+FAILED_UPLOADS_PATH=logs/failed_uploads.json
+UPLOADED_CACHE_PATH=data/uploaded_keywords_cache.json
+REPARSED_OUTPUT_PATH=logs/failed_keywords_reparsed.json
+UPLOAD_DELAY=0.5
+API_DELAY=1.0
+RETRY_DELAY=0.5

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 .env
 logs/
+
+# Ignore generated files
+__pycache__/
+*.pyc
+*.pyo
+*.log
+logs/
+data/


### PR DESCRIPTION
## Summary
- add sample `.env.example` showing environment keys
- ignore generated folders and files like `__pycache__/` and `data/`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bce06ea44832e9aa7b19baeebf88c