### PR TITLE
Fix pipeline references

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,15 +13,19 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    "retry_dashboard_notifier.py",
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
+    # 스크립트가 루트 디렉터리에 존재하는지 우선 확인하고,
+    # 없으면 scripts 폴더에서 찾는다.
+    if os.path.exists(script):
+        full_path = script
+    else:
+        full_path = os.path.join("scripts", script)
+
     if not os.path.exists(full_path):
         logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
         return False


### PR DESCRIPTION
## Summary
- clean up `PIPELINE_SEQUENCE`
- allow scripts to be found in the project root or `scripts/`

## Testing
- `python run_pipeline.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684bce069344832eadb123c07a53a556