### PR TITLE
Update pipeline paths

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Auto Pipeline
+
+This repository contains scripts for generating and uploading hooks to Notion as part of an automated pipeline.
+
+The main entrypoint for running the full workflow is `run_pipeline.py`. The GitHub Actions workflow calls this script directly.
+
+## Missing scripts
+
+The original pipeline referenced `parse_failed_gpt.py` and `notify_retry_result.py`, but these files are not included in the repository. The pipeline definition in `run_pipeline.py` has been updated to comment out these entries.

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,15 +13,18 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
+    # "parse_failed_gpt.py",  # script not present
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
+    # "notify_retry_result.py",  # script not present
     "retry_dashboard_notifier.py"
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
 def run_script(script):
-    full_path = os.path.join("scripts", script)
+    full_path = os.path.join(ROOT_DIR, script)
     if not os.path.exists(full_path):
         logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
         return False


### PR DESCRIPTION
## Summary
- update workflow to call `run_pipeline.py` directly
- comment out missing scripts in `run_pipeline.py`
- make script runner use repo root paths
- document missing scripts in new README

## Testing
- `python -m py_compile run_pipeline.py`
- `python -m py_compile hook_generator.py retry_dashboard_notifier.py retry_failed_uploads.py notion_hook_uploader.py`
- `python -m py_compile scripts/notion_uploader.py scripts/retry_failed_uploads.py`


------
https://chatgpt.com/codex/tasks/task_e_684bcae1fc44832ea33bc177cc16ff54