### PR TITLE
Improve run_pipeline script handling

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,17 +13,23 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
     "retry_dashboard_notifier.py"
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    """Run a script located either in the repo root or inside ``scripts/``."""
+
+    candidate_paths = [script, os.path.join("scripts", script)]
+    full_path = None
+    for path in candidate_paths:
+        if os.path.exists(path):
+            full_path = path
+            break
+
+    if full_path is None:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- streamline pipeline script list
- enhance `run_script` to find scripts in repo root or `scripts/`

## Testing
- `python -m py_compile run_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684be46f4fdc832eb5983d2d1b55fc02