### PR TITLE
Add missing retry helper scripts

### DIFF
--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,42 @@
+import os
+import json
+import logging
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def notify_result():
+    if not os.path.exists(SUMMARY_PATH):
+        logging.warning(f"❗ 결과 파일이 존재하지 않습니다: {SUMMARY_PATH}")
+        return
+
+    with open(SUMMARY_PATH, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    total = len(data)
+    failed = len([d for d in data if d.get('retry_error')])
+    success = total - failed
+
+    message = f"재업로드 결과\n총 시도: {total}\n성공: {success}\n실패: {failed}"
+
+    if WEBHOOK_URL:
+        try:
+            response = requests.post(WEBHOOK_URL, json={'text': message})
+            if response.status_code == 200:
+                logging.info("✅ Slack 알림 전송 완료")
+            else:
+                logging.error(f"❌ Slack 응답 오류: {response.status_code} {response.text}")
+        except Exception as e:
+            logging.error(f"❌ Slack 알림 전송 실패: {e}")
+    else:
+        logging.info("SLACK_WEBHOOK_URL 미설정. 다음 메시지 출력:\n" + message)
+
+
+if __name__ == "__main__":
+    notify_result()

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,40 @@
+import os
+import json
+import logging
+from dotenv import load_dotenv
+from notion_hook_uploader import parse_generated_text
+
+load_dotenv()
+FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def parse_failed():
+    if not os.path.exists(FAILED_PATH):
+        logging.error(f"❌ 실패 파일이 존재하지 않습니다: {FAILED_PATH}")
+        return
+
+    with open(FAILED_PATH, 'r', encoding='utf-8') as f:
+        failed_items = json.load(f)
+
+    parsed_items = []
+    for item in failed_items:
+        text = item.get("generated_text", "")
+        parsed = parse_generated_text(text) if text else {
+            "hook_lines": ["", ""],
+            "blog_paragraphs": ["", "", ""],
+            "video_titles": ["", ""]
+        }
+        item["parsed"] = parsed
+        parsed_items.append(item)
+
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        json.dump(parsed_items, f, ensure_ascii=False, indent=2)
+    logging.info(f"✅ 파싱 결과 저장: {OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    parse_failed()


### PR DESCRIPTION
## Summary
- add script to parse failed GPT outputs
- add Slack notifier for retry results

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684be4604f10832e9af2f9ce1faeaf1b