### PR TITLE
Fix log variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Auto Pipeline
+
+This repository contains scripts to generate marketing hooks, upload them to Notion and retry failed uploads. The pipeline relies on several environment variables.
+
+## Environment variables
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `OPENAI_API_KEY` | API key for OpenAI GPT | - |
+| `TOPIC_CHANNELS_PATH` | Path to topic/channel config JSON | `config/topic_channels.json` |
+| `KEYWORD_OUTPUT_PATH` | Output path for generated keywords | `data/keyword_output_with_cpc.json` |
+| `HOOK_OUTPUT_PATH` | Output path for generated hooks | `data/generated_hooks.json` |
+| `FAILED_HOOK_PATH` | JSON file for failed hook generation logs | `logs/failed_hooks.json` |
+| `REPARSED_OUTPUT_PATH` | JSON file for failed upload entries | `logs/failed_uploads.json` |
+| `NOTION_API_TOKEN` | Token for Notion API | - |
+| `NOTION_DB_ID` | Notion database ID for keyword upload | - |
+| `NOTION_HOOK_DB_ID` | Notion database ID for hook upload | - |
+| `NOTION_KPI_DB_ID` | Notion database ID for KPI logging | - |
+| `UPLOAD_DELAY` | Delay between Notion uploads | `0.5` |
+| `RETRY_DELAY` | Delay between retry attempts | `0.5` |
+| `UPLOADED_CACHE_PATH` | Cache path for already uploaded keywords | `data/uploaded_keywords_cache.json` |
+| `API_DELAY` | Delay between GPT requests | `1.0` |

--- a/retry_dashboard_notifier.py
+++ b/retry_dashboard_notifier.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 load_dotenv()
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_KPI_DB_ID = os.getenv("NOTION_KPI_DB_ID")
-SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+REPARSED_OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
 
@@ -21,11 +21,11 @@ notion = Client(auth=NOTION_TOKEN)
 
 # ---------------------- KPI 데이터 수집 ----------------------
 def get_retry_stats():
-    if not os.path.exists(SUMMARY_PATH):
-        logging.error(f"❌ 재시도 데이터 파일이 없습니다: {SUMMARY_PATH}")
+    if not os.path.exists(REPARSED_OUTPUT_PATH):
+        logging.error(f"❌ 재시도 데이터 파일이 없습니다: {REPARSED_OUTPUT_PATH}")
         return None
 
-    with open(SUMMARY_PATH, 'r', encoding='utf-8') as f:
+    with open(REPARSED_OUTPUT_PATH, 'r', encoding='utf-8') as f:
         data = json.load(f)
 
     total = len(data)

--- a/retry_failed_uploads.py
+++ b/retry_failed_uploads.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 load_dotenv()
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
-FAILED_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+REPARSED_OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
 RETRY_DELAY = float(os.getenv("RETRY_DELAY", "0.5"))
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
@@ -27,10 +27,10 @@ def truncate_text(text, max_length=2000):
 
 # ---------------------- 실패 키워드 로딩 ----------------------
 def load_failed_items():
-    if not os.path.exists(FAILED_PATH):
-        logging.warning(f"❗ 실패 항목 파일이 존재하지 않습니다: {FAILED_PATH}")
+    if not os.path.exists(REPARSED_OUTPUT_PATH):
+        logging.warning(f"❗ 실패 항목 파일이 존재하지 않습니다: {REPARSED_OUTPUT_PATH}")
         return []
-    with open(FAILED_PATH, 'r', encoding='utf-8') as f:
+    with open(REPARSED_OUTPUT_PATH, 'r', encoding='utf-8') as f:
         return json.load(f)
 
 # ---------------------- Notion 페이지 재생성 ----------------------
@@ -88,7 +88,7 @@ def retry_failed_uploads():
 
     # 실패 파일 덮어쓰기
     if still_failed:
-        with open(FAILED_PATH, 'w', encoding='utf-8') as f:
+        with open(REPARSED_OUTPUT_PATH, 'w', encoding='utf-8') as f:
             json.dump(still_failed, f, ensure_ascii=False, indent=2)
         logging.warning(f"🔁 여전히 실패한 항목 {len(still_failed)}개가 남아 있습니다.")
 

--- a/scripts/notion_uploader.py
+++ b/scripts/notion_uploader.py
@@ -13,7 +13,7 @@ NOTION_DB_ID = os.getenv("NOTION_DB_ID")
 KEYWORD_JSON_PATH = os.getenv("KEYWORD_OUTPUT_PATH", "data/keyword_output_with_cpc.json")
 UPLOAD_DELAY = float(os.getenv("UPLOAD_DELAY", "0.5"))
 CACHE_PATH = os.getenv("UPLOADED_CACHE_PATH", "data/uploaded_keywords_cache.json")
-FAILED_PATH = os.getenv("FAILED_UPLOADS_PATH", "logs/failed_uploads.json")
+REPARSED_OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_uploads.json")
 
 # ---------------------- 로깅 설정 ----------------------
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
@@ -120,10 +120,10 @@ def upload_all_keywords():
     # 실패 로그 저장
     if failed_uploads:
         try:
-            os.makedirs(os.path.dirname(FAILED_PATH), exist_ok=True)
-            with open(FAILED_PATH, 'w', encoding='utf-8') as f:
+            os.makedirs(os.path.dirname(REPARSED_OUTPUT_PATH), exist_ok=True)
+            with open(REPARSED_OUTPUT_PATH, 'w', encoding='utf-8') as f:
                 json.dump(failed_uploads, f, ensure_ascii=False, indent=2)
-            logging.info(f"❗ 실패 항목 기록 완료: {FAILED_PATH}")
+            logging.info(f"❗ 실패 항목 기록 완료: {REPARSED_OUTPUT_PATH}")
         except Exception as e:
             logging.warning(f"⚠️ 실패 로그 저장 실패: {e}")
 

--- a/scripts/retry_failed_uploads.py
+++ b/scripts/retry_failed_uploads.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 load_dotenv()
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
-FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_keywords.json")
+FAILED_HOOK_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_keywords.json")
 RETRY_DELAY = float(os.getenv("RETRY_DELAY", "0.5"))
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
@@ -27,10 +27,10 @@ def truncate_text(text, max_length=2000):
 
 # ---------------------- 실패 키워드 로딩 ----------------------
 def load_failed_items():
-    if not os.path.exists(FAILED_PATH):
-        logging.warning(f"❗ 실패 항목 파일이 존재하지 않습니다: {FAILED_PATH}")
+    if not os.path.exists(FAILED_HOOK_PATH):
+        logging.warning(f"❗ 실패 항목 파일이 존재하지 않습니다: {FAILED_HOOK_PATH}")
         return []
-    with open(FAILED_PATH, 'r', encoding='utf-8') as f:
+    with open(FAILED_HOOK_PATH, 'r', encoding='utf-8') as f:
         return json.load(f)
 
 # ---------------------- Notion 페이지 재생성 ----------------------
@@ -88,7 +88,7 @@ def retry_failed_uploads():
 
     # 실패 파일 덮어쓰기
     if still_failed:
-        with open(FAILED_PATH, 'w', encoding='utf-8') as f:
+        with open(FAILED_HOOK_PATH, 'w', encoding='utf-8') as f:
             json.dump(still_failed, f, ensure_ascii=False, indent=2)
         logging.warning(f"🔁 여전히 실패한 항목 {len(still_failed)}개가 남아 있습니다.")
 
@@ -98,3 +98,4 @@ def retry_failed_uploads():
 
 if __name__ == "__main__":
     retry_failed_uploads()
+


### PR DESCRIPTION
## Summary
- synchronize environment variable names across scripts
- document available environment variables

## Testing
- `python -m py_compile retry_failed_uploads.py scripts/retry_failed_uploads.py scripts/notion_uploader.py retry_dashboard_notifier.py hook_generator.py notion_hook_uploader.py`

------
https://chatgpt.com/codex/tasks/task_e_684be3a30e1c832e913ecf7b9cc02b22