### PR TITLE
Add asyncio support to hook generation

### DIFF
--- a/hook_generator.py
+++ b/hook_generator.py
@@ -1,6 +1,6 @@
 import os
 import json
-import time
+import asyncio
 import logging
 from datetime import datetime
 from dotenv import load_dotenv
@@ -13,6 +13,7 @@ HOOK_OUTPUT_PATH = os.getenv("HOOK_OUTPUT_PATH", "data/generated_hooks.json")
 FAILED_HOOK_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 API_DELAY = float(os.getenv("API_DELAY", "1.0"))
+MAX_CONCURRENT = int(os.getenv("MAX_CONCURRENT", "5"))
 
 openai.api_key = OPENAI_API_KEY
 
@@ -34,22 +35,72 @@ def generate_hook_prompt(keyword, topic, source, score, growth, mentions):
     return base.strip()
 
 # ---------------------- GPT 호출 함수 (재시도 포함) ----------------------
-def get_gpt_response(prompt, retries=3):
+async def get_gpt_response(prompt, retries=3):
     for attempt in range(retries):
         try:
-            response = openai.ChatCompletion.create(
+            response = await openai.ChatCompletion.acreate(
                 model="gpt-4",
                 messages=[{"role": "user", "content": prompt}],
-                temperature=0.7
+                temperature=0.7,
             )
-            return response.choices[0].message['content']
+            return response.choices[0].message["content"]
         except Exception as e:
             logging.warning(f"GPT 호출 실패 {attempt + 1}/{retries}: {e}")
-            time.sleep(2)
+            await asyncio.sleep(2)
     return None
 
 # ---------------------- 메인 실행 함수 ----------------------
-def generate_hooks():
+async def process_keyword(item, existing, sem, new_output, failed_output):
+    keyword = item.get("keyword")
+    if not keyword:
+        logging.warning("⛔ 빈 키워드 항목, 건너뜁니다.")
+        return "skipped"
+
+    if keyword in existing:
+        logging.info(f"⏭️ 중복 스킵: {keyword}")
+        return "skipped"
+
+    prompt = generate_hook_prompt(
+        keyword=keyword,
+        topic=keyword.split()[0],
+        source=item.get("source"),
+        score=item.get("score", 0),
+        growth=item.get("growth", 0),
+        mentions=item.get("mentions", 0),
+    )
+
+    async with sem:
+        response = await get_gpt_response(prompt)
+        await asyncio.sleep(API_DELAY)
+
+    result = {
+        "keyword": keyword,
+        "hook_prompt": prompt,
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+    }
+
+    if response:
+        lines = response.split("\n")
+        result.update(
+            {
+                "hook_lines": lines[0:2],
+                "blog_paragraphs": lines[2:5],
+                "video_titles": lines[5:],
+                "generated_text": response,
+            }
+        )
+        new_output.append(result)
+        logging.info(f"✅ 생성 완료: {keyword}")
+        return "success"
+    else:
+        result["generated_text"] = None
+        result["error"] = "GPT 응답 실패"
+        failed_output.append(result)
+        logging.error(f"❌ 생성 실패: {keyword}")
+        return "failed"
+
+
+async def generate_hooks():
     if not OPENAI_API_KEY:
         logging.error("❗ OpenAI API 키가 누락되었습니다. .env 파일 확인 필요")
         return
@@ -74,54 +125,13 @@ def generate_hooks():
 
     new_output = []
     failed_output = []
-    skipped, success, failed = 0, 0, 0
+    sem = asyncio.Semaphore(MAX_CONCURRENT)
 
-    for item in keywords:
-        keyword = item.get('keyword')
-        if not keyword:
-            logging.warning("⛔ 빈 키워드 항목, 건너뜁니다.")
-            continue
-
-        if keyword in existing:
-            logging.info(f"⏭️ 중복 스킵: {keyword}")
-            skipped += 1
-            continue
-
-        prompt = generate_hook_prompt(
-            keyword=keyword,
-            topic=keyword.split()[0],
-            source=item.get('source'),
-            score=item.get('score', 0),
-            growth=item.get('growth', 0),
-            mentions=item.get('mentions', 0)
-        )
-        response = get_gpt_response(prompt)
-
-        result = {
-            "keyword": keyword,
-            "hook_prompt": prompt,
-            "timestamp": datetime.utcnow().isoformat() + 'Z'
-        }
-
-        if response:
-            lines = response.split('\n')
-            result.update({
-                "hook_lines": lines[0:2],
-                "blog_paragraphs": lines[2:5],
-                "video_titles": lines[5:],
-                "generated_text": response
-            })
-            new_output.append(result)
-            logging.info(f"✅ 생성 완료: {keyword}")
-            success += 1
-        else:
-            result["generated_text"] = None
-            result["error"] = "GPT 응답 실패"
-            failed_output.append(result)
-            logging.error(f"❌ 생성 실패: {keyword}")
-            failed += 1
-
-        time.sleep(API_DELAY)
+    tasks = [process_keyword(item, existing, sem, new_output, failed_output) for item in keywords]
+    statuses = await asyncio.gather(*tasks)
+    skipped = statuses.count("skipped")
+    success = statuses.count("success")
+    failed = statuses.count("failed")
 
     full_output = list(existing.values()) + new_output
     os.makedirs(os.path.dirname(HOOK_OUTPUT_PATH), exist_ok=True)
@@ -139,4 +149,5 @@ def generate_hooks():
     logging.info(f"🎉 후킹 문장 저장 완료: {HOOK_OUTPUT_PATH}")
 
 if __name__ == "__main__":
-    generate_hooks()
+    asyncio.run(generate_hooks())
+


### PR DESCRIPTION
## Summary
- make OpenAI calls concurrently with asyncio
- keep retry logic and per-call API delay

## Testing
- `python -m py_compile hook_generator.py`
- `python hook_generator.py` *(fails: OpenAI key missing)*

------
https://chatgpt.com/codex/tasks/task_e_684be7ab963c832ea522c41c27a4e552