### PR TITLE
Fix run_script search path

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -21,9 +21,18 @@ PIPELINE_SEQUENCE = [
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    """Run a script from ``scripts/`` or repository root."""
+
+    # search order: scripts/ then repository root
+    search_paths = [os.path.join("scripts", script), script]
+    full_path = None
+    for path in search_paths:
+        if os.path.exists(path):
+            full_path = path
+            break
+
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- allow `run_script()` to locate scripts in repo root or `scripts/`

## Testing
- `python -m py_compile run_pipeline.py`
- `python run_pipeline.py` *(fails: ModuleNotFoundError: no module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684be7a870a0832ea3172f8be8be46b4