### PR TITLE
Unify failed and retry path vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# API keys
+OPENAI_API_KEY=
+NOTION_API_TOKEN=
+
+# Notion database IDs
+NOTION_HOOK_DB_ID=
+NOTION_KPI_DB_ID=
+NOTION_DB_ID=
+
+# Paths
+TOPIC_CHANNELS_PATH=config/topic_channels.json
+KEYWORD_OUTPUT_PATH=data/keyword_output_with_cpc.json
+HOOK_OUTPUT_PATH=data/generated_hooks.json
+FAILED_HOOKS_PATH=logs/failed_hooks.json
+RETRY_ITEMS_PATH=logs/failed_keywords_reparsed.json
+FAILED_UPLOADS_PATH=logs/failed_uploads.json
+UPLOADED_CACHE_PATH=data/uploaded_keywords_cache.json
+
+# Timings
+API_DELAY=1.0
+UPLOAD_DELAY=0.5
+RETRY_DELAY=0.5

--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -15,7 +15,7 @@ jobs:
       NOTION_HOOK_DB_ID: ${{ secrets.NOTION_HOOK_DB_ID }}
       NOTION_KPI_DB_ID: ${{ secrets.NOTION_KPI_DB_ID }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      REPARSED_OUTPUT_PATH: logs/failed_keywords_reparsed.json
+      RETRY_ITEMS_PATH: logs/failed_keywords_reparsed.json
 
     steps:
       - name: 📂 Checkout repository

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Auto Pipeline
+
+Utilities to generate marketing hooks and upload them to Notion.
+
+## Setup
+1. Install dependencies
+```bash
+pip install -r requirements.txt
+```
+2. Create a `.env` file based on `.env.example` and fill in your credentials.
+
+## Environment Variables
+See `.env.example` for a full list. Key paths include:
+- `FAILED_HOOKS_PATH` : file to store hooks that failed to generate.
+- `RETRY_ITEMS_PATH`  : file used for retry uploads after parsing failures.
+
+## Running
+Execute individual scripts or run the pipeline:
+```bash
+python run_pipeline.py
+```

--- a/hook_generator.py
+++ b/hook_generator.py
@@ -10,7 +10,7 @@ import openai
 load_dotenv()
 KEYWORD_JSON_PATH = os.getenv("KEYWORD_OUTPUT_PATH", "data/keyword_output_with_cpc.json")
 HOOK_OUTPUT_PATH = os.getenv("HOOK_OUTPUT_PATH", "data/generated_hooks.json")
-FAILED_HOOK_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+FAILED_HOOKS_PATH = os.getenv("FAILED_HOOKS_PATH", "logs/failed_hooks.json")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 API_DELAY = float(os.getenv("API_DELAY", "1.0"))
 
@@ -129,10 +129,10 @@ def generate_hooks():
         json.dump(full_output, f, ensure_ascii=False, indent=2)
 
     if failed_output:
-        os.makedirs(os.path.dirname(FAILED_HOOK_PATH), exist_ok=True)
-        with open(FAILED_HOOK_PATH, 'w', encoding='utf-8') as f:
+        os.makedirs(os.path.dirname(FAILED_HOOKS_PATH), exist_ok=True)
+        with open(FAILED_HOOKS_PATH, 'w', encoding='utf-8') as f:
             json.dump(failed_output, f, ensure_ascii=False, indent=2)
-        logging.warning(f"⚠️ 실패 후킹 저장 완료: {FAILED_HOOK_PATH}")
+        logging.warning(f"⚠️ 실패 후킹 저장 완료: {FAILED_HOOKS_PATH}")
 
     logging.info("📊 생성 작업 요약")
     logging.info(f"총 키워드: {len(keywords)} | 성공: {success} | 중복스킵: {skipped} | 실패: {failed}")

--- a/retry_dashboard_notifier.py
+++ b/retry_dashboard_notifier.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 load_dotenv()
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_KPI_DB_ID = os.getenv("NOTION_KPI_DB_ID")
-SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+SUMMARY_PATH = os.getenv("RETRY_ITEMS_PATH", "logs/failed_keywords_reparsed.json")
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
 

--- a/retry_failed_uploads.py
+++ b/retry_failed_uploads.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 load_dotenv()
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
-FAILED_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+RETRY_ITEMS_PATH = os.getenv("RETRY_ITEMS_PATH", "logs/failed_keywords_reparsed.json")
 RETRY_DELAY = float(os.getenv("RETRY_DELAY", "0.5"))
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
@@ -27,10 +27,10 @@ def truncate_text(text, max_length=2000):
 
 # ---------------------- 실패 키워드 로딩 ----------------------
 def load_failed_items():
-    if not os.path.exists(FAILED_PATH):
-        logging.warning(f"❗ 실패 항목 파일이 존재하지 않습니다: {FAILED_PATH}")
+    if not os.path.exists(RETRY_ITEMS_PATH):
+        logging.warning(f"❗ 실패 항목 파일이 존재하지 않습니다: {RETRY_ITEMS_PATH}")
         return []
-    with open(FAILED_PATH, 'r', encoding='utf-8') as f:
+    with open(RETRY_ITEMS_PATH, 'r', encoding='utf-8') as f:
         return json.load(f)
 
 # ---------------------- Notion 페이지 재생성 ----------------------
@@ -88,7 +88,7 @@ def retry_failed_uploads():
 
     # 실패 파일 덮어쓰기
     if still_failed:
-        with open(FAILED_PATH, 'w', encoding='utf-8') as f:
+        with open(RETRY_ITEMS_PATH, 'w', encoding='utf-8') as f:
             json.dump(still_failed, f, ensure_ascii=False, indent=2)
         logging.warning(f"🔁 여전히 실패한 항목 {len(still_failed)}개가 남아 있습니다.")
 

--- a/scripts/retry_failed_uploads.py
+++ b/scripts/retry_failed_uploads.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 load_dotenv()
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
-FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_keywords.json")
+RETRY_ITEMS_PATH = os.getenv("RETRY_ITEMS_PATH", "logs/failed_keywords.json")
 RETRY_DELAY = float(os.getenv("RETRY_DELAY", "0.5"))
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
@@ -27,10 +27,10 @@ def truncate_text(text, max_length=2000):
 
 # ---------------------- 실패 키워드 로딩 ----------------------
 def load_failed_items():
-    if not os.path.exists(FAILED_PATH):
-        logging.warning(f"❗ 실패 항목 파일이 존재하지 않습니다: {FAILED_PATH}")
+    if not os.path.exists(RETRY_ITEMS_PATH):
+        logging.warning(f"❗ 실패 항목 파일이 존재하지 않습니다: {RETRY_ITEMS_PATH}")
         return []
-    with open(FAILED_PATH, 'r', encoding='utf-8') as f:
+    with open(RETRY_ITEMS_PATH, 'r', encoding='utf-8') as f:
         return json.load(f)
 
 # ---------------------- Notion 페이지 재생성 ----------------------
@@ -88,7 +88,7 @@ def retry_failed_uploads():
 
     # 실패 파일 덮어쓰기
     if still_failed:
-        with open(FAILED_PATH, 'w', encoding='utf-8') as f:
+        with open(RETRY_ITEMS_PATH, 'w', encoding='utf-8') as f:
             json.dump(still_failed, f, ensure_ascii=False, indent=2)
         logging.warning(f"🔁 여전히 실패한 항목 {len(still_failed)}개가 남아 있습니다.")
 


### PR DESCRIPTION
## Summary
- standardize path env vars for failed hooks and retry items
- add `.env.example` with the full variable list
- document variables in README
- update workflow and scripts to use the new names

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684bee37ee90832e84c0263734850533