### PR TITLE
Add example env file and extend gitignore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Example environment variables for Auto Pipeline
+API_DELAY=1.0
+FAILED_HOOK_PATH=logs/failed_hooks.json
+FAILED_UPLOADS_PATH=logs/failed_uploads.json
+HOOK_OUTPUT_PATH=data/generated_hooks.json
+KEYWORD_OUTPUT_PATH=data/keyword_output_with_cpc.json
+NOTION_API_TOKEN=
+NOTION_DB_ID=
+NOTION_HOOK_DB_ID=
+NOTION_KPI_DB_ID=
+OPENAI_API_KEY=
+REPARSED_OUTPUT_PATH=logs/failed_keywords_reparsed.json
+RETRY_DELAY=0.5
+TOPIC_CHANNELS_PATH=config/topic_channels.json
+UPLOADED_CACHE_PATH=data/uploaded_keywords_cache.json
+UPLOAD_DELAY=0.5

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,13 @@
+# Python artifacts
+__pycache__/
+*.pyc
+
+# Environment files
 .env
+
+# Generated data and logs
+data/
 logs/
+
+# OS artifacts
+.DS_Store


### PR DESCRIPTION
## Summary
- track required environment variables in `.env.example`
- expand `.gitignore` to exclude common generated files

## Testing
- `python -m py_compile hook_generator.py keyword_auto_pipeline.py retry_failed_uploads.py retry_dashboard_notifier.py notion_hook_uploader.py scripts/notion_uploader.py scripts/retry_failed_uploads.py run_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684bf1e335e0832e89551fc30587a2b9