### PR TITLE
Fix pipeline path resolution

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -21,9 +21,20 @@ PIPELINE_SEQUENCE = [
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    """Run a single step in the pipeline."""
+    # Determine repository root (directory of this file)
+    repo_root = os.path.dirname(os.path.abspath(__file__))
+
+    # Possible locations: repository root or scripts/ subfolder
+    candidate_paths = [
+        os.path.join(repo_root, script),
+        os.path.join(repo_root, "scripts", script),
+    ]
+
+    # Find the first existing path
+    full_path = next((p for p in candidate_paths if os.path.exists(p)), None)
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {candidate_paths[0]}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- ensure `run_pipeline.py` can find scripts in repo root or `scripts/`
- test pipeline run

## Testing
- `python -m py_compile run_pipeline.py`
- `python run_pipeline.py > pipeline_test.log` *(fails: ModuleNotFoundError: 'dotenv', 'notion_client')*

------
https://chatgpt.com/codex/tasks/task_e_684e8eff5ba8832e9cade7a46946d4da