### PR TITLE
Fix pipeline sequence and script search

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,17 +13,20 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
     "retry_dashboard_notifier.py"
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    possible_paths = [os.path.join("scripts", script), script]
+    full_path = None
+    for path in possible_paths:
+        if os.path.exists(path):
+            full_path = path
+            break
+    if full_path is None:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- remove non-existent scripts from `PIPELINE_SEQUENCE`
- allow `run_script()` to find executables in project root or `scripts/`

## Testing
- `python run_pipeline.py` *(fails: ModuleNotFoundError: 'dotenv', 'notion_client')*

------
https://chatgpt.com/codex/tasks/task_e_684bf35a5f18832eb33fb04a3e90d03f