### PR TITLE
Refactor hook generator to async

### DIFF
--- a/hook_generator.py
+++ b/hook_generator.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from dotenv import load_dotenv
 import openai
+import asyncio
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -15,6 +16,8 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 API_DELAY = float(os.getenv("API_DELAY", "1.0"))
 
 openai.api_key = OPENAI_API_KEY
+rate_lock = asyncio.Lock()
+last_api_call = 0.0
 
 # ---------------------- 로깅 설정 ----------------------
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
@@ -34,22 +37,74 @@ def generate_hook_prompt(keyword, topic, source, score, growth, mentions):
     return base.strip()
 
 # ---------------------- GPT 호출 함수 (재시도 포함) ----------------------
-def get_gpt_response(prompt, retries=3):
+async def get_gpt_response(prompt, retries=3):
+    global last_api_call
     for attempt in range(retries):
-        try:
-            response = openai.ChatCompletion.create(
-                model="gpt-4",
-                messages=[{"role": "user", "content": prompt}],
-                temperature=0.7
-            )
-            return response.choices[0].message['content']
-        except Exception as e:
-            logging.warning(f"GPT 호출 실패 {attempt + 1}/{retries}: {e}")
-            time.sleep(2)
+        async with rate_lock:
+            now = time.monotonic()
+            wait_time = API_DELAY - (now - last_api_call)
+            if wait_time > 0:
+                await asyncio.sleep(wait_time)
+            try:
+                response = await openai.ChatCompletion.acreate(
+                    model="gpt-4",
+                    messages=[{"role": "user", "content": prompt}],
+                    temperature=0.7
+                )
+                last_api_call = time.monotonic()
+                return response.choices[0].message['content']
+            except Exception as e:
+                logging.warning(f"GPT 호출 실패 {attempt + 1}/{retries}: {e}")
+                last_api_call = time.monotonic()
+        await asyncio.sleep(2)
     return None
 
+# ---------------------- 개별 키워드 처리 함수 ----------------------
+async def process_keyword(item, existing):
+    keyword = item.get('keyword')
+    if not keyword:
+        logging.warning("⛔ 빈 키워드 항목, 건너뜁니다.")
+        return "skipped", None
+
+    if keyword in existing:
+        logging.info(f"⏭️ 중복 스킵: {keyword}")
+        return "skipped", None
+
+    prompt = generate_hook_prompt(
+        keyword=keyword,
+        topic=keyword.split()[0],
+        source=item.get('source'),
+        score=item.get('score', 0),
+        growth=item.get('growth', 0),
+        mentions=item.get('mentions', 0)
+    )
+
+    response = await get_gpt_response(prompt)
+
+    result = {
+        "keyword": keyword,
+        "hook_prompt": prompt,
+        "timestamp": datetime.utcnow().isoformat() + 'Z'
+    }
+
+    if response:
+        lines = response.split('\n')
+        result.update({
+            "hook_lines": lines[0:2],
+            "blog_paragraphs": lines[2:5],
+            "video_titles": lines[5:],
+            "generated_text": response
+        })
+        logging.info(f"✅ 생성 완료: {keyword}")
+        return "success", result
+    else:
+        result["generated_text"] = None
+        result["error"] = "GPT 응답 실패"
+        logging.error(f"❌ 생성 실패: {keyword}")
+        return "failed", result
+
 # ---------------------- 메인 실행 함수 ----------------------
-def generate_hooks():
+async def generate_hooks():
     if not OPENAI_API_KEY:
         logging.error("❗ OpenAI API 키가 누락되었습니다. .env 파일 확인 필요")
         return
@@ -74,54 +129,19 @@ def generate_hooks():
 
     new_output = []
     failed_output = []
-    skipped, success, failed = 0, 0, 0
+    skipped = success = failed = 0
 
-    for item in keywords:
-        keyword = item.get('keyword')
-        if not keyword:
-            logging.warning("⛔ 빈 키워드 항목, 건너뜁니다.")
-            continue
-
-        if keyword in existing:
-            logging.info(f"⏭️ 중복 스킵: {keyword}")
-            skipped += 1
-            continue
-
-        prompt = generate_hook_prompt(
-            keyword=keyword,
-            topic=keyword.split()[0],
-            source=item.get('source'),
-            score=item.get('score', 0),
-            growth=item.get('growth', 0),
-            mentions=item.get('mentions', 0)
-        )
-        response = get_gpt_response(prompt)
-
-        result = {
-            "keyword": keyword,
-            "hook_prompt": prompt,
-            "timestamp": datetime.utcnow().isoformat() + 'Z'
-        }
-
-        if response:
-            lines = response.split('\n')
-            result.update({
-                "hook_lines": lines[0:2],
-                "blog_paragraphs": lines[2:5],
-                "video_titles": lines[5:],
-                "generated_text": response
-            })
+    tasks = [process_keyword(item, existing) for item in keywords]
+    for coro in asyncio.as_completed(tasks):
+        status, result = await coro
+        if status == "success":
             new_output.append(result)
-            logging.info(f"✅ 생성 완료: {keyword}")
             success += 1
-        else:
-            result["generated_text"] = None
-            result["error"] = "GPT 응답 실패"
+        elif status == "failed":
             failed_output.append(result)
-            logging.error(f"❌ 생성 실패: {keyword}")
             failed += 1
-
-        time.sleep(API_DELAY)
+        else:
+            skipped += 1
 
     full_output = list(existing.values()) + new_output
     os.makedirs(os.path.dirname(HOOK_OUTPUT_PATH), exist_ok=True)
@@ -135,8 +155,10 @@ def generate_hooks():
         logging.warning(f"⚠️ 실패 후킹 저장 완료: {FAILED_HOOK_PATH}")
 
     logging.info("📊 생성 작업 요약")
-    logging.info(f"총 키워드: {len(keywords)} | 성공: {success} | 중복스킵: {skipped} | 실패: {failed}")
+    logging.info(
+        f"총 키워드: {len(keywords)} | 성공: {success} | 중복스킵: {skipped} | 실패: {failed}"
+    )
     logging.info(f"🎉 후킹 문장 저장 완료: {HOOK_OUTPUT_PATH}")
 
 if __name__ == "__main__":
-    generate_hooks()
+    asyncio.run(generate_hooks())


### PR DESCRIPTION
## Summary
- refactor `hook_generator.py` to process keywords asynchronously
- use `openai.ChatCompletion.acreate` with asyncio
- preserve API delay and error handling

## Testing
- `python -m py_compile hook_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_684bf36448b4832e86a4add237edcce5