### PR TITLE
Fix pipeline script references

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,17 +13,21 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    "retry_dashboard_notifier.py",
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    search_paths = [os.path.join(".", script), os.path.join("scripts", script)]
+    full_path = None
+    for path in search_paths:
+        if os.path.exists(path):
+            full_path = path
+            break
+
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- update `run_pipeline.py` to remove unused scripts from the pipeline
- search scripts in root and `scripts/` directories

## Testing
- `python -m py_compile run_pipeline.py`
- `python -m py_compile hook_generator.py retry_failed_uploads.py retry_dashboard_notifier.py notion_hook_uploader.py keyword_auto_pipeline.py scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684bfe909a6c832e8c30dfde737a12f3