### PR TITLE
Fix pipeline script search

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,17 +13,24 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
     "retry_dashboard_notifier.py"
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    """Run a script from the repository root or the ``scripts`` directory."""
+    root_dir = os.path.dirname(os.path.abspath(__file__))
+
+    root_path = os.path.join(root_dir, script)
+    scripts_path = os.path.join(root_dir, "scripts", script)
+
+    if os.path.exists(root_path):
+        full_path = root_path
+    elif os.path.exists(scripts_path):
+        full_path = scripts_path
+    else:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- clean pipeline sequence to remove missing scripts
- look for scripts in repo root before `scripts/`

## Testing
- `python -m py_compile run_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684bfea269c8832eb6eae1bd40c84775