### PR TITLE
Add scripts to prune obsolete codex branches

### DIFF
--- a/.github/workflows/codex-cleanup.yml
+++ b/.github/workflows/codex-cleanup.yml
@@ -1,0 +1,38 @@
+name: Codex Branch Cleanup
+
+on:
+  schedule:
+    - cron: "30 0 * * *"  # daily at 00:30 UTC
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete stale codex branches
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          DAYS=7
+          api() { curl -s -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "$@"; }
+
+          mapfile -t branches < <(
+            api "https://api.github.com/repos/$OWNER/$REPO/branches?per_page=100" \
+            | jq -r '.[].name' | grep '-codex/'
+          )
+          for br in "${branches[@]}"; do
+            pr_state=$(api "https://api.github.com/repos/$OWNER/$REPO/pulls?state=all&head=$OWNER:$br" \
+                       | jq -r '.[0].state // empty')
+            last_date=$(api "https://api.github.com/repos/$OWNER/$REPO/commits/$br" \
+                       | jq -r '.commit.author.date')
+            last_ts=$(date -d "$last_date" +%s)
+            if [[ "$pr_state" == "closed" || "$last_ts" -lt $(date -d "$DAYS days ago" +%s) ]]; then
+              echo "Deleting $br"
+              api -X DELETE "https://api.github.com/repos/$OWNER/$REPO/git/refs/heads/$br"
+            fi
+          done
+

--- a/cleanup_codex_branches.sh
+++ b/cleanup_codex_branches.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OWNER="sunwoopark0512"          # repository owner
+REPO="Auto_Pipeline"            # repository name
+DAYS=7                           # prune branches unused for this many days
+TOKEN="${GITHUB_TOKEN:-}"       # GitHub token, required for API calls
+
+api() {
+  curl -s -H "Authorization: Bearer $TOKEN" \
+       -H "Accept: application/vnd.github+json" "$@"
+}
+
+# Fetch codex branches
+mapfile -t branches < <(
+  api "https://api.github.com/repos/$OWNER/$REPO/branches?per_page=100" \
+  | jq -r '.[].name' | grep '-codex/'
+)
+
+echo "Found ${#branches[@]} codex branches."
+
+# Check each branch
+for br in "${branches[@]}"; do
+  # Determine pull request state if exists
+  pr_state=$(api \
+      "https://api.github.com/repos/$OWNER/$REPO/pulls?state=all&head=$OWNER:$br" \
+      | jq -r '.[0].state // empty')
+
+  # Get date of last commit
+  last_date=$(api "https://api.github.com/repos/$OWNER/$REPO/commits/$br" \
+      | jq -r '.commit.author.date')
+  last_ts=$(date -d "$last_date" +%s)
+  threshold_ts=$(date -d "$DAYS days ago" +%s)
+
+  if [[ "$pr_state" == "closed" || "$last_ts" -lt "$threshold_ts" ]]; then
+    echo "🗑  Deleting $br  (PR:$pr_state  last:$last_date)"
+    api -X DELETE "https://api.github.com/repos/$OWNER/$REPO/git/refs/heads/$br"
+  fi
+ done
+
+echo "✅  Cleanup done."


### PR DESCRIPTION
## Summary
- add `cleanup_codex_branches.sh` for one-off branch cleanup
- schedule nightly cleanup via `codex-cleanup.yml`

## Testing
- `pytest -q`
- `flake8` *(fails: E501, E302, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684e93313e9c832eaa7cc362f7601bc9