### PR TITLE
Add CI config and SEO test skeleton

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 100
+exclude = .git,__pycache__,.venv,build
+ignore = E203,W503

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: pip install -r requirements-dev.txt
+      - run: flake8
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: pip install -r requirements-dev.txt
+      - run: mypy .
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: pip install -r requirements-dev.txt
+      - run: pytest -q
+  seo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: pip install -r requirements-dev.txt
+      - run: |
+          python - <<'PY'
+          from seo import check_seo
+          check_seo(['docs/README.md'])
+          PY
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# v-Infinity Repository – Developer Docs
+
+## Quick Start
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt -r requirements-dev.txt
+pytest -q
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+line-length = 100
+skip-string-normalization = true
+
+[tool.isort]
+profile = "black"
+line_length = 100

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+flake8
+black
+isort
+pytest
+pytest-cov
+mypy

--- a/seo/__init__.py
+++ b/seo/__init__.py
@@ -1,0 +1,5 @@
+"""SEO utilities package."""
+
+from .seo_checker import check_seo
+
+__all__ = ["check_seo"]

--- a/seo/seo_checker.py
+++ b/seo/seo_checker.py
@@ -1,0 +1,16 @@
+"""SEO checker stub."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+
+def check_seo(paths: List[str]) -> None:
+    """Pretend to check SEO rules on the given paths."""
+    for path in paths:
+        path_obj = Path(path)
+        if not path_obj.exists():
+            raise FileNotFoundError(f"Path does not exist: {path}")
+        # Placeholder for SEO checks
+        print(f"Checking SEO for {path}")

--- a/tests/test_seo_checker.py
+++ b/tests/test_seo_checker.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from seo import check_seo
+
+
+def test_check_seo(tmp_path):
+    file_a = tmp_path / "a.txt"
+    file_a.write_text("content")
+    check_seo([str(file_a)])


### PR DESCRIPTION
## Summary
- set up code style with `.flake8` and `pyproject.toml`
- add developer requirements
- document quickstart instructions
- create SEO checker stub and simple test
- enable CI workflow with lint, mypy, tests and SEO check

## Testing
- `flake8` *(fails: various style violations)*
- `pytest -q`
- `mypy seo`

------
https://chatgpt.com/codex/tasks/task_e_684e912c7c8c832e91da243ee22f596c