### PR TITLE
Implement YouTube adapter utils with tests

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+# Package initialization for core

--- a/core/ops_log_model.py
+++ b/core/ops_log_model.py
@@ -1,0 +1,27 @@
+import datetime
+
+class OpsLogModel:
+    """Minimal stub for OpsLogModel used in tests."""
+
+    @staticmethod
+    def build_payload(
+        log_type: str,
+        operator: str,
+        module: str,
+        environment: str,
+        task_summary: str,
+        action_details: str,
+    ) -> dict:
+        now = datetime.datetime.utcnow().isoformat()
+        return {
+            "parent": {"database_id": "DUMMY"},
+            "properties": {
+                "Log Type": {"select": {"name": log_type}},
+                "Date": {"date": {"start": now}},
+                "Operator": {"title": [{"text": {"content": operator}}]},
+                "Module": {"rich_text": [{"text": {"content": module}}]},
+                "Environment": {"select": {"name": environment}},
+                "Task Summary": {"rich_text": [{"text": {"content": task_summary}}]},
+                "Action Details": {"rich_text": [{"text": {"content": action_details}}]},
+            },
+        }

--- a/publishers/__init__.py
+++ b/publishers/__init__.py
@@ -1,0 +1,1 @@
+# Package initialization for publishers

--- a/publishers/base_adapter.py
+++ b/publishers/base_adapter.py
@@ -1,0 +1,20 @@
+"""Base classes for publishing adapters."""
+import os
+from abc import ABC, abstractmethod
+
+DRYRUN = os.getenv("DRYRUN", "false").lower() == "true"
+
+class PublisherAdapter(ABC):
+    """Base interface for publisher adapters."""
+
+    @abstractmethod
+    def _real_publish(self, content: dict) -> str:
+        """Perform the real publish action and return a URL."""
+        raise NotImplementedError
+
+    def publish(self, content: dict) -> str:
+        """Publish content if not in DRYRUN mode."""
+        if DRYRUN:
+            print(f"🔄 DRYRUN – {self.__class__.__name__} skip upload")
+            return "DRYRUN_URL"
+        return self._real_publish(content)

--- a/publishers/youtube_adapter.py
+++ b/publishers/youtube_adapter.py
@@ -1,0 +1,47 @@
+"""YouTube adapter utilities and helpers."""
+from __future__ import annotations
+
+import requests
+
+from publishers.base_adapter import PublisherAdapter
+
+
+class YouTubeAdapter(PublisherAdapter):
+    """Simple stub for YouTube publishing."""
+
+    def _real_publish(self, content: dict) -> str:
+        # Stubbed publish method for testing
+        return "https://youtu.be/dummy123"
+
+
+def get_recent_videos(channel_id: str, api_key: str, limit: int = 5) -> list:
+    """Fetch recent videos from a channel via YouTube Data API.
+
+    Parameters
+    ----------
+    channel_id: str
+        The channel ID to query.
+    api_key: str
+        API key for authenticating with YouTube Data API.
+    limit: int, default 5
+        Maximum number of results to return.
+
+    Returns
+    -------
+    list
+        List of video items returned by the API.
+    """
+
+    url = "https://www.googleapis.com/youtube/v3/search"
+    params: dict[str, str | int] = {
+        "part": "snippet",
+        "channelId": channel_id,
+        "maxResults": limit,
+        "order": "date",
+        "type": "video",
+        "key": api_key,
+    }
+    response = requests.get(url, params=params, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    return data.get("items", [])

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -vv

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+pytest
+pylint
+mypy
+requests

--- a/tests/test_youtube_adapter.py
+++ b/tests/test_youtube_adapter.py
@@ -1,0 +1,40 @@
+"""Tests for YouTube adapter."""
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from unittest.mock import Mock
+
+import requests
+
+from publishers.youtube_adapter import get_recent_videos, YouTubeAdapter
+
+
+def test_get_recent_videos(monkeypatch):
+    """Ensure recent videos are fetched correctly."""
+    dummy_items = [{"id": {"videoId": "abc"}}, {"id": {"videoId": "def"}}]
+
+    mock_response = Mock()
+    mock_response.json.return_value = {"items": dummy_items}
+    mock_response.raise_for_status = Mock()
+
+    def fake_get(url, params=None, timeout=10):
+        assert params["channelId"] == "chan123"
+        assert params["key"] == "apikey"
+        return mock_response
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    result = get_recent_videos("chan123", "apikey", limit=2)
+    assert result == dummy_items
+
+
+def test_publish_dryrun(monkeypatch, capsys):
+    """Validate DRYRUN publishes no content."""
+    monkeypatch.setenv("DRYRUN", "true")
+    import publishers.base_adapter as base_adapter
+    monkeypatch.setattr(base_adapter, "DRYRUN", True)
+    adapter = YouTubeAdapter()
+    result = adapter.publish({"dummy": "data"})
+    assert result == "DRYRUN_URL"
+    captured = capsys.readouterr()
+    assert "skip upload" in captured.out


### PR DESCRIPTION
## Summary
- add stub `core` package for OpsLogModel
- add publisher base class and YouTube adapter with recent video fetching
- configure pytest
- add tests for the YouTube adapter

## Testing
- `pytest -q`
- `mypy core publishers tests/test_youtube_adapter.py`
- `pylint core publishers tests/test_youtube_adapter.py > /tmp/pylint.log`

------
https://chatgpt.com/codex/tasks/task_e_684e900dae2c832e95a38a77943d24db