### PR TITLE
Add retry utility scripts

### DIFF
--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,50 @@
+import os
+import json
+import logging
+from dotenv import load_dotenv
+import requests
+
+load_dotenv()
+WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def load_summary():
+    if not os.path.exists(SUMMARY_PATH):
+        logging.info(f"❗ 요약 파일이 존재하지 않습니다: {SUMMARY_PATH}")
+        return None
+    with open(SUMMARY_PATH, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    total = len(data)
+    failed = len([i for i in data if i.get("retry_error")])
+    success = total - failed
+    return {"total": total, "success": success, "failed": failed}
+
+
+def send_slack(summary):
+    if not WEBHOOK_URL:
+        logging.error("SLACK_WEBHOOK_URL 환경 변수가 설정되지 않았습니다.")
+        return
+    msg = f"재업로드 결과: 성공 {summary['success']}개, 실패 {summary['failed']}개"
+    try:
+        response = requests.post(WEBHOOK_URL, json={"text": msg})
+        if response.status_code != 200:
+            logging.error(f"Slack 전송 실패: {response.status_code} {response.text}")
+        else:
+            logging.info("📣 Slack 알림 전송 완료")
+    except Exception as e:
+        logging.error(f"Slack 요청 중 오류: {e}")
+
+
+def main():
+    summary = load_summary()
+    if summary is None:
+        return
+    send_slack(summary)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,55 @@
+import os
+import json
+import logging
+from dotenv import load_dotenv
+from notion_hook_uploader import parse_generated_text
+
+load_dotenv()
+FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def load_failed_items():
+    if not os.path.exists(FAILED_PATH):
+        logging.info(f"❗ 실패 항목 파일이 존재하지 않습니다: {FAILED_PATH}")
+        return []
+    with open(FAILED_PATH, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def parse_items(items):
+    parsed = []
+    for item in items:
+        text = item.get("generated_text")
+        if not text:
+            logging.warning(f"⛔ generated_text 누락: {item.get('keyword')}")
+            continue
+        try:
+            item["parsed"] = parse_generated_text(text)
+            parsed.append(item)
+        except Exception as e:
+            logging.error(f"❌ 파싱 실패: {item.get('keyword')} - {e}")
+    return parsed
+
+
+def save_parsed(items):
+    if not items:
+        logging.info("✅ 파싱할 항목이 없습니다.")
+        return
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        json.dump(items, f, ensure_ascii=False, indent=2)
+    logging.info(f"📦 파싱 결과 저장: {OUTPUT_PATH} ({len(items)} items)")
+
+
+def main():
+    items = load_failed_items()
+    parsed = parse_items(items)
+    save_parsed(parsed)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add `scripts/parse_failed_gpt.py` to reparse failed GPT results
- add `scripts/notify_retry_result.py` to send Slack notifications about retry summary

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e317fcde0832e9c212769651b0de6