### PR TITLE
Fix final invocation call

### DIFF
--- a/retry_failed_uploads.py
+++ b/retry_failed_uploads.py
@@ -95,6 +95,4 @@ def retry_failed_uploads():
     # 요약
     logging.info("📦 재시도 업로드 요약")
     logging.info(f"성공: {success} | 실패 유지: {failed}")
-
-if __name__ == "__main__":
-    retry_failed_uploads()
+retry_failed_uploads()


### PR DESCRIPTION
## Summary
- simplify retry_failed_uploads.py to call `retry_failed_uploads()` directly

## Testing
- `python3 -m py_compile retry_failed_uploads.py`
- `pylint retry_failed_uploads.py` *(fails: import-error)*
- `mypy retry_failed_uploads.py` *(fails: import-not-found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684e3180ed04832eaf72984b94c733c9