### PR TITLE
Unify failed items path variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+NOTION_API_TOKEN=your-notion-token
+NOTION_DB_ID=your-keyword-db-id
+NOTION_HOOK_DB_ID=your-hook-db-id
+OPENAI_API_KEY=your-openai-key
+FAILED_ITEMS_PATH=logs/failed_items.json

--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -15,7 +15,7 @@ jobs:
       NOTION_HOOK_DB_ID: ${{ secrets.NOTION_HOOK_DB_ID }}
       NOTION_KPI_DB_ID: ${{ secrets.NOTION_KPI_DB_ID }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      REPARSED_OUTPUT_PATH: logs/failed_keywords_reparsed.json
+      FAILED_ITEMS_PATH: logs/failed_items.json
 
     steps:
       - name: 📂 Checkout repository
@@ -38,12 +38,12 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: failed-keywords
-          path: logs/failed_keywords_reparsed.json
+          name: failed-items
+          path: logs/failed_items.json
 
       - name: ✍️ Append workflow summary
         if: always()
         run: |
           echo "## 🌐 Notion Hook 파이프라인 실행 완료" >> $GITHUB_STEP_SUMMARY
           echo "- 실행 시각: $(date '+%Y-%m-%d %H:%M:%S')" >> $GITHUB_STEP_SUMMARY
-          echo "- 실패 항목 JSON: logs/failed_keywords_reparsed.json" >> $GITHUB_STEP_SUMMARY
+          echo "- 실패 항목 JSON: logs/failed_items.json" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Auto Pipeline
+
+This repository contains scripts that generate marketing hooks and upload them to Notion. Environment variables can be defined in a `.env` file or via the environment.
+
+## Key Environment Variables
+
+- `NOTION_API_TOKEN` – token used to access the Notion API.
+- `NOTION_DB_ID` – ID of the keywords database.
+- `NOTION_HOOK_DB_ID` – ID of the hooks database.
+- `OPENAI_API_KEY` – API key for OpenAI calls.
+- `FAILED_ITEMS_PATH` – path used by all scripts to store items that failed during processing. Defaults to `logs/failed_items.json`.
+
+Copy `.env.example` to `.env` and fill in your values before running the pipeline.

--- a/hook_generator.py
+++ b/hook_generator.py
@@ -10,7 +10,7 @@ import openai
 load_dotenv()
 KEYWORD_JSON_PATH = os.getenv("KEYWORD_OUTPUT_PATH", "data/keyword_output_with_cpc.json")
 HOOK_OUTPUT_PATH = os.getenv("HOOK_OUTPUT_PATH", "data/generated_hooks.json")
-FAILED_HOOK_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+FAILED_ITEMS_PATH = os.getenv("FAILED_ITEMS_PATH", "logs/failed_items.json")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 API_DELAY = float(os.getenv("API_DELAY", "1.0"))
 
@@ -129,10 +129,10 @@ def generate_hooks():
         json.dump(full_output, f, ensure_ascii=False, indent=2)
 
     if failed_output:
-        os.makedirs(os.path.dirname(FAILED_HOOK_PATH), exist_ok=True)
-        with open(FAILED_HOOK_PATH, 'w', encoding='utf-8') as f:
+        os.makedirs(os.path.dirname(FAILED_ITEMS_PATH), exist_ok=True)
+        with open(FAILED_ITEMS_PATH, 'w', encoding='utf-8') as f:
             json.dump(failed_output, f, ensure_ascii=False, indent=2)
-        logging.warning(f"⚠️ 실패 후킹 저장 완료: {FAILED_HOOK_PATH}")
+        logging.warning(f"⚠️ 실패 후킹 저장 완료: {FAILED_ITEMS_PATH}")
 
     logging.info("📊 생성 작업 요약")
     logging.info(f"총 키워드: {len(keywords)} | 성공: {success} | 중복스킵: {skipped} | 실패: {failed}")

--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -12,7 +12,7 @@ load_dotenv()
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
 HOOK_JSON_PATH = os.getenv("HOOK_OUTPUT_PATH", "data/generated_hooks.json")
-FAILED_OUTPUT_PATH = "data/upload_failed_hooks.json"
+FAILED_ITEMS_PATH = os.getenv("FAILED_ITEMS_PATH", "logs/failed_items.json")
 UPLOAD_DELAY = float(os.getenv("UPLOAD_DELAY", "0.5"))
 
 notion = Client(auth=NOTION_TOKEN)
@@ -119,13 +119,14 @@ def upload_all_hooks():
         time.sleep(UPLOAD_DELAY)
 
     if failed_items:
-        os.makedirs(os.path.dirname(FAILED_OUTPUT_PATH), exist_ok=True)
-        with open(FAILED_OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        os.makedirs(os.path.dirname(FAILED_ITEMS_PATH), exist_ok=True)
+        with open(FAILED_ITEMS_PATH, 'w', encoding='utf-8') as f:
             json.dump(failed_items, f, ensure_ascii=False, indent=2)
-        logging.info(f"❗ 실패 항목 저장됨: {FAILED_OUTPUT_PATH}")
+        logging.info(f"❗ 실패 항목 저장됨: {FAILED_ITEMS_PATH}")
 
     logging.info("📊 후킹 업로드 요약")
     logging.info(f"총 항목: {total} | 성공: {success} | 중복스킵: {skipped} | 실패: {failed}")
 
 if __name__ == "__main__":
     upload_all_hooks()
+

--- a/retry_dashboard_notifier.py
+++ b/retry_dashboard_notifier.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 load_dotenv()
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_KPI_DB_ID = os.getenv("NOTION_KPI_DB_ID")
-SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+FAILED_ITEMS_PATH = os.getenv("FAILED_ITEMS_PATH", "logs/failed_items.json")
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
 
@@ -21,11 +21,11 @@ notion = Client(auth=NOTION_TOKEN)
 
 # ---------------------- KPI 데이터 수집 ----------------------
 def get_retry_stats():
-    if not os.path.exists(SUMMARY_PATH):
-        logging.error(f"❌ 재시도 데이터 파일이 없습니다: {SUMMARY_PATH}")
+    if not os.path.exists(FAILED_ITEMS_PATH):
+        logging.error(f"❌ 재시도 데이터 파일이 없습니다: {FAILED_ITEMS_PATH}")
         return None
 
-    with open(SUMMARY_PATH, 'r', encoding='utf-8') as f:
+    with open(FAILED_ITEMS_PATH, 'r', encoding='utf-8') as f:
         data = json.load(f)
 
     total = len(data)

--- a/retry_failed_uploads.py
+++ b/retry_failed_uploads.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 load_dotenv()
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
-FAILED_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+FAILED_ITEMS_PATH = os.getenv("FAILED_ITEMS_PATH", "logs/failed_items.json")
 RETRY_DELAY = float(os.getenv("RETRY_DELAY", "0.5"))
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
@@ -27,10 +27,10 @@ def truncate_text(text, max_length=2000):
 
 # ---------------------- 실패 키워드 로딩 ----------------------
 def load_failed_items():
-    if not os.path.exists(FAILED_PATH):
-        logging.warning(f"❗ 실패 항목 파일이 존재하지 않습니다: {FAILED_PATH}")
+    if not os.path.exists(FAILED_ITEMS_PATH):
+        logging.warning(f"❗ 실패 항목 파일이 존재하지 않습니다: {FAILED_ITEMS_PATH}")
         return []
-    with open(FAILED_PATH, 'r', encoding='utf-8') as f:
+    with open(FAILED_ITEMS_PATH, 'r', encoding='utf-8') as f:
         return json.load(f)
 
 # ---------------------- Notion 페이지 재생성 ----------------------
@@ -88,7 +88,7 @@ def retry_failed_uploads():
 
     # 실패 파일 덮어쓰기
     if still_failed:
-        with open(FAILED_PATH, 'w', encoding='utf-8') as f:
+        with open(FAILED_ITEMS_PATH, 'w', encoding='utf-8') as f:
             json.dump(still_failed, f, ensure_ascii=False, indent=2)
         logging.warning(f"🔁 여전히 실패한 항목 {len(still_failed)}개가 남아 있습니다.")
 

--- a/scripts/notion_uploader.py
+++ b/scripts/notion_uploader.py
@@ -13,7 +13,7 @@ NOTION_DB_ID = os.getenv("NOTION_DB_ID")
 KEYWORD_JSON_PATH = os.getenv("KEYWORD_OUTPUT_PATH", "data/keyword_output_with_cpc.json")
 UPLOAD_DELAY = float(os.getenv("UPLOAD_DELAY", "0.5"))
 CACHE_PATH = os.getenv("UPLOADED_CACHE_PATH", "data/uploaded_keywords_cache.json")
-FAILED_PATH = os.getenv("FAILED_UPLOADS_PATH", "logs/failed_uploads.json")
+FAILED_ITEMS_PATH = os.getenv("FAILED_ITEMS_PATH", "logs/failed_items.json")
 
 # ---------------------- 로깅 설정 ----------------------
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
@@ -120,10 +120,10 @@ def upload_all_keywords():
     # 실패 로그 저장
     if failed_uploads:
         try:
-            os.makedirs(os.path.dirname(FAILED_PATH), exist_ok=True)
-            with open(FAILED_PATH, 'w', encoding='utf-8') as f:
+            os.makedirs(os.path.dirname(FAILED_ITEMS_PATH), exist_ok=True)
+            with open(FAILED_ITEMS_PATH, 'w', encoding='utf-8') as f:
                 json.dump(failed_uploads, f, ensure_ascii=False, indent=2)
-            logging.info(f"❗ 실패 항목 기록 완료: {FAILED_PATH}")
+            logging.info(f"❗ 실패 항목 기록 완료: {FAILED_ITEMS_PATH}")
         except Exception as e:
             logging.warning(f"⚠️ 실패 로그 저장 실패: {e}")
 

--- a/scripts/retry_failed_uploads.py
+++ b/scripts/retry_failed_uploads.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 load_dotenv()
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
-FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_keywords.json")
+FAILED_ITEMS_PATH = os.getenv("FAILED_ITEMS_PATH", "logs/failed_items.json")
 RETRY_DELAY = float(os.getenv("RETRY_DELAY", "0.5"))
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
@@ -27,10 +27,10 @@ def truncate_text(text, max_length=2000):
 
 # ---------------------- 실패 키워드 로딩 ----------------------
 def load_failed_items():
-    if not os.path.exists(FAILED_PATH):
-        logging.warning(f"❗ 실패 항목 파일이 존재하지 않습니다: {FAILED_PATH}")
+    if not os.path.exists(FAILED_ITEMS_PATH):
+        logging.warning(f"❗ 실패 항목 파일이 존재하지 않습니다: {FAILED_ITEMS_PATH}")
         return []
-    with open(FAILED_PATH, 'r', encoding='utf-8') as f:
+    with open(FAILED_ITEMS_PATH, 'r', encoding='utf-8') as f:
         return json.load(f)
 
 # ---------------------- Notion 페이지 재생성 ----------------------
@@ -88,7 +88,7 @@ def retry_failed_uploads():
 
     # 실패 파일 덮어쓰기
     if still_failed:
-        with open(FAILED_PATH, 'w', encoding='utf-8') as f:
+        with open(FAILED_ITEMS_PATH, 'w', encoding='utf-8') as f:
             json.dump(still_failed, f, ensure_ascii=False, indent=2)
         logging.warning(f"🔁 여전히 실패한 항목 {len(still_failed)}개가 남아 있습니다.")
 


### PR DESCRIPTION
## Summary
- standardize environment variable name `FAILED_ITEMS_PATH`
- use unified variable in all scripts
- update CI workflow paths
- add README and `.env.example` with new variable

## Testing
- `python -m compileall -q .`
- `pylint hook_generator.py notion_hook_uploader.py retry_dashboard_notifier.py retry_failed_uploads.py scripts/notion_uploader.py scripts/retry_failed_uploads.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684e318661bc832eae1a278ead082905