### PR TITLE
Fix Notion uploader log setup

### DIFF
--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -16,6 +16,7 @@ FAILED_OUTPUT_PATH = "data/upload_failed_hooks.json"
 UPLOAD_DELAY = float(os.getenv("UPLOAD_DELAY", "0.5"))
 
 notion = Client(auth=NOTION_TOKEN)
+os.makedirs("logs", exist_ok=True)
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s %(levelname)s:%(message)s',


### PR DESCRIPTION
## Summary
- ensure `logs/` directory exists for notion uploader so file logging works
- verify logging setup from a clean checkout

## Testing
- `pylint notion_hook_uploader.py`
- `mypy notion_hook_uploader.py`
- `pytest`
- `python notion_hook_uploader.py`

------
https://chatgpt.com/codex/tasks/task_e_684e37e1c4a8832e97593521f0602263