### PR TITLE
Centralize truncate text utility

### DIFF
--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -6,6 +6,7 @@ import re
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from utils import truncate_text
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -24,10 +25,6 @@ logging.basicConfig(
         logging.StreamHandler()
     ]
 )
-
-# ---------------------- 유틸: Notion rich_text 제한 처리 ----------------------
-def truncate_text(text, max_length=2000):
-    return text if len(text) <= max_length else text[:max_length]
 
 # ---------------------- 중복 키워드 확인 함수 ----------------------
 def page_exists(keyword):

--- a/retry_failed_uploads.py
+++ b/retry_failed_uploads.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from utils import truncate_text
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -20,10 +21,6 @@ if not NOTION_TOKEN or not NOTION_HOOK_DB_ID:
     logging.error("❗ 환경 변수(NOTION_API_TOKEN, NOTION_HOOK_DB_ID)가 누락되었습니다.")
     exit(1)
 notion = Client(auth=NOTION_TOKEN)
-
-# ---------------------- 유틸: rich_text 길이 제한 ----------------------
-def truncate_text(text, max_length=2000):
-    return text if len(text) <= max_length else text[:max_length]
 
 # ---------------------- 실패 키워드 로딩 ----------------------
 def load_failed_items():

--- a/scripts/retry_failed_uploads.py
+++ b/scripts/retry_failed_uploads.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from utils import truncate_text
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -20,10 +21,6 @@ if not NOTION_TOKEN or not NOTION_HOOK_DB_ID:
     logging.error("❗ 환경 변수(NOTION_API_TOKEN, NOTION_HOOK_DB_ID)가 누락되었습니다.")
     exit(1)
 notion = Client(auth=NOTION_TOKEN)
-
-# ---------------------- 유틸: rich_text 길이 제한 ----------------------
-def truncate_text(text, max_length=2000):
-    return text if len(text) <= max_length else text[:max_length]
 
 # ---------------------- 실패 키워드 로딩 ----------------------
 def load_failed_items():

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,8 @@
+"""Utility functions for the Auto_Pipeline project."""
+
+from typing import Any
+
+
+def truncate_text(text: str, max_length: int = 2000) -> str:
+    """Truncate text to fit within Notion's rich_text length limit."""
+    return text if len(text) <= max_length else text[:max_length]


### PR DESCRIPTION
## Summary
- add a `utils` module with `truncate_text`
- reuse `truncate_text` in notion and retry scripts

## Testing
- `pylint utils.py notion_hook_uploader.py retry_failed_uploads.py scripts/retry_failed_uploads.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684e37e35bc0832e9ab7aeb926e81517