### PR TITLE
Add async OpenAI batch helper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+openai>=1.0
+python-dotenv
+notion-client
+pytrends
+snscrape
+aiolimiter>=1.1
+tenacity
+pytest
+pytest-asyncio

--- a/scripts/ai_async.py
+++ b/scripts/ai_async.py
@@ -1,0 +1,77 @@
+"""Async OpenAI helper functions.
+
+Usage::
+
+    from scripts.ai_async import batch_generate
+    import asyncio, os
+
+    prompts = ["Give me a viral hook about AI", ...]
+    hooks = asyncio.run(batch_generate(prompts))
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import logging
+from typing import Sequence, List
+
+try:
+    from openai import AsyncOpenAI
+except ImportError:  # pragma: no cover
+    AsyncOpenAI = None  # type: ignore
+
+from tenacity import retry, stop_after_attempt, wait_random_exponential
+from aiolimiter import AsyncLimiter
+
+_logger = logging.getLogger(__name__)
+
+# OpenAI rate-limit: 3K TPM & 200 RPM on GPT-4o (example) → 3 req/sec conservative
+_limiter = AsyncLimiter(max_rate=3, time_period=1.0)
+
+_client: AsyncOpenAI | None = None
+
+
+def _get_client() -> AsyncOpenAI:
+    global _client
+    if _client is None:
+        if AsyncOpenAI is None:  # pragma: no cover
+            raise RuntimeError("openai package with async support is required")
+        _client = AsyncOpenAI()
+    return _client
+
+
+@retry(stop=stop_after_attempt(5), wait=wait_random_exponential(multiplier=2, max=30))
+async def _call_openai(prompt: str) -> str:
+    """Single chat completion with retry & limiter."""
+
+    async with _limiter:
+        client = _get_client()
+        resp = await client.chat.completions.create(
+            model="gpt-4o-mini",  # configurable via env if needed
+            messages=[{"role": "user", "content": prompt}],
+        )
+        content = resp.choices[0].message.content or ""
+        usage = resp.usage
+        _logger.info(
+            "openai_request_tokens=%s openai_response_tokens=%s",
+            usage.prompt_tokens,
+            usage.completion_tokens,
+        )
+        return content
+
+
+async def batch_generate(prompts: Sequence[str], concurrency: int = 5) -> List[str]:
+    """Generate completions for multiple prompts concurrently."""
+
+    if os.getenv("DRY_RUN"):
+        _logger.warning("DRY_RUN=1 → returning placeholder hooks")
+        return [f"[DRY] {p[:20]}…" for p in prompts]
+
+    sem = asyncio.Semaphore(concurrency)
+
+    async def _task(prompt: str) -> str:
+        async with sem:
+            return await _call_openai(prompt)
+
+    return await asyncio.gather(*[_task(p) for p in prompts])

--- a/tests/test_hook_generator_async.py
+++ b/tests/test_hook_generator_async.py
@@ -1,0 +1,54 @@
+import asyncio
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from scripts import ai_async
+
+
+@pytest.mark.asyncio
+async def test_batch_generate_dry_run(monkeypatch):
+    monkeypatch.setenv("DRY_RUN", "1")
+    res = await ai_async.batch_generate(["hello", "world"])
+    assert res == ["[DRY] hello…", "[DRY] world…"]
+    monkeypatch.delenv("DRY_RUN")
+
+
+@pytest.mark.asyncio
+async def test_batch_generate_concurrency(monkeypatch):
+    calls = []
+    concurrent = 0
+    max_concurrent = 0
+    lock = asyncio.Lock()
+
+    class DummyResp:
+        def __init__(self, text):
+            self.choices = [SimpleNamespace(message=SimpleNamespace(content=text))]
+            self.usage = SimpleNamespace(prompt_tokens=1, completion_tokens=1)
+
+    class DummyAsyncOpenAI:
+        def __init__(self):
+            self.chat = self
+            self.completions = self
+
+        async def create(self, model, messages):
+            nonlocal concurrent, max_concurrent
+            async with lock:
+                concurrent += 1
+                max_concurrent = max(max_concurrent, concurrent)
+            await asyncio.sleep(0.01)
+            async with lock:
+                concurrent -= 1
+            calls.append(messages[0]["content"])
+            return DummyResp(messages[0]["content"] + "_resp")
+
+    monkeypatch.setattr(ai_async, "AsyncOpenAI", DummyAsyncOpenAI)
+    ai_async._client = None
+    prompts = ["a", "b", "c", "d"]
+    res = await ai_async.batch_generate(prompts, concurrency=2)
+    assert res == [p + "_resp" for p in prompts]
+    assert max_concurrent <= 2
+    assert calls == prompts


### PR DESCRIPTION
## Summary
- implement async OpenAI helper with rate limiting and retries
- refactor `hook_generator` to use async batch generation
- add `requirements.txt`
- add tests for batch generation with asyncio

## Testing
- `mypy hook_generator.py scripts/ai_async.py`
- `pylint -E hook_generator.py scripts/ai_async.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e18b8b034832e93c165b6bbeab441