### PR TITLE
Centralize logging setup

### DIFF
--- a/hook_generator.py
+++ b/hook_generator.py
@@ -1,14 +1,19 @@
-import os
 import json
-import time
 import logging
+import os
+import time
 from datetime import datetime
-from dotenv import load_dotenv
+
 import openai
+from dotenv import load_dotenv
+
+from utils.logger import setup_logging
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
-KEYWORD_JSON_PATH = os.getenv("KEYWORD_OUTPUT_PATH", "data/keyword_output_with_cpc.json")
+KEYWORD_JSON_PATH = os.getenv(
+    "KEYWORD_OUTPUT_PATH", "data/keyword_output_with_cpc.json"
+)
 HOOK_OUTPUT_PATH = os.getenv("HOOK_OUTPUT_PATH", "data/generated_hooks.json")
 FAILED_HOOK_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
@@ -17,7 +22,8 @@ API_DELAY = float(os.getenv("API_DELAY", "1.0"))
 openai.api_key = OPENAI_API_KEY
 
 # ---------------------- 로깅 설정 ----------------------
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+setup_logging()
+
 
 # ---------------------- GPT 프롬프트 생성 함수 ----------------------
 def generate_hook_prompt(keyword, topic, source, score, growth, mentions):
@@ -33,6 +39,7 @@ def generate_hook_prompt(keyword, topic, source, score, growth, mentions):
     """
     return base.strip()
 
+
 # ---------------------- GPT 호출 함수 (재시도 포함) ----------------------
 def get_gpt_response(prompt, retries=3):
     for attempt in range(retries):
@@ -40,13 +47,14 @@ def get_gpt_response(prompt, retries=3):
             response = openai.ChatCompletion.create(
                 model="gpt-4",
                 messages=[{"role": "user", "content": prompt}],
-                temperature=0.7
+                temperature=0.7,
             )
-            return response.choices[0].message['content']
+            return response.choices[0].message["content"]
         except Exception as e:
             logging.warning(f"GPT 호출 실패 {attempt + 1}/{retries}: {e}")
             time.sleep(2)
     return None
+
 
 # ---------------------- 메인 실행 함수 ----------------------
 def generate_hooks():
@@ -55,7 +63,7 @@ def generate_hooks():
         return
 
     try:
-        with open(KEYWORD_JSON_PATH, 'r', encoding='utf-8') as f:
+        with open(KEYWORD_JSON_PATH, "r", encoding="utf-8") as f:
             data = json.load(f)
             keywords = data.get("filtered_keywords", [])
     except Exception as e:
@@ -65,10 +73,10 @@ def generate_hooks():
     existing = {}
     if os.path.exists(HOOK_OUTPUT_PATH):
         try:
-            with open(HOOK_OUTPUT_PATH, 'r', encoding='utf-8') as f:
+            with open(HOOK_OUTPUT_PATH, "r", encoding="utf-8") as f:
                 existing_data = json.load(f)
                 for entry in existing_data:
-                    existing[entry['keyword']] = entry
+                    existing[entry["keyword"]] = entry
         except Exception as e:
             logging.warning(f"기존 결과 로딩 실패: {e}")
 
@@ -77,7 +85,7 @@ def generate_hooks():
     skipped, success, failed = 0, 0, 0
 
     for item in keywords:
-        keyword = item.get('keyword')
+        keyword = item.get("keyword")
         if not keyword:
             logging.warning("⛔ 빈 키워드 항목, 건너뜁니다.")
             continue
@@ -90,27 +98,29 @@ def generate_hooks():
         prompt = generate_hook_prompt(
             keyword=keyword,
             topic=keyword.split()[0],
-            source=item.get('source'),
-            score=item.get('score', 0),
-            growth=item.get('growth', 0),
-            mentions=item.get('mentions', 0)
+            source=item.get("source"),
+            score=item.get("score", 0),
+            growth=item.get("growth", 0),
+            mentions=item.get("mentions", 0),
         )
         response = get_gpt_response(prompt)
 
         result = {
             "keyword": keyword,
             "hook_prompt": prompt,
-            "timestamp": datetime.utcnow().isoformat() + 'Z'
+            "timestamp": datetime.utcnow().isoformat() + "Z",
         }
 
         if response:
-            lines = response.split('\n')
-            result.update({
-                "hook_lines": lines[0:2],
-                "blog_paragraphs": lines[2:5],
-                "video_titles": lines[5:],
-                "generated_text": response
-            })
+            lines = response.split("\n")
+            result.update(
+                {
+                    "hook_lines": lines[0:2],
+                    "blog_paragraphs": lines[2:5],
+                    "video_titles": lines[5:],
+                    "generated_text": response,
+                }
+            )
             new_output.append(result)
             logging.info(f"✅ 생성 완료: {keyword}")
             success += 1
@@ -125,18 +135,21 @@ def generate_hooks():
 
     full_output = list(existing.values()) + new_output
     os.makedirs(os.path.dirname(HOOK_OUTPUT_PATH), exist_ok=True)
-    with open(HOOK_OUTPUT_PATH, 'w', encoding='utf-8') as f:
+    with open(HOOK_OUTPUT_PATH, "w", encoding="utf-8") as f:
         json.dump(full_output, f, ensure_ascii=False, indent=2)
 
     if failed_output:
         os.makedirs(os.path.dirname(FAILED_HOOK_PATH), exist_ok=True)
-        with open(FAILED_HOOK_PATH, 'w', encoding='utf-8') as f:
+        with open(FAILED_HOOK_PATH, "w", encoding="utf-8") as f:
             json.dump(failed_output, f, ensure_ascii=False, indent=2)
         logging.warning(f"⚠️ 실패 후킹 저장 완료: {FAILED_HOOK_PATH}")
 
     logging.info("📊 생성 작업 요약")
-    logging.info(f"총 키워드: {len(keywords)} | 성공: {success} | 중복스킵: {skipped} | 실패: {failed}")
+    logging.info(
+        f"총 키워드: {len(keywords)} | 성공: {success} | 중복스킵: {skipped} | 실패: {failed}"
+    )
     logging.info(f"🎉 후킹 문장 저장 완료: {HOOK_OUTPUT_PATH}")
+
 
 if __name__ == "__main__":
     generate_hooks()

--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -1,11 +1,14 @@
-import os
 import json
-import time
 import logging
+import os
 import re
+import time
 from datetime import datetime
-from notion_client import Client
+
 from dotenv import load_dotenv
+from notion_client import Client
+
+from utils.logger import setup_logging
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -16,18 +19,13 @@ FAILED_OUTPUT_PATH = "data/upload_failed_hooks.json"
 UPLOAD_DELAY = float(os.getenv("UPLOAD_DELAY", "0.5"))
 
 notion = Client(auth=NOTION_TOKEN)
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s %(levelname)s:%(message)s',
-    handlers=[
-        logging.FileHandler("logs/notion_upload.log"),
-        logging.StreamHandler()
-    ]
-)
+setup_logging()
+
 
 # ---------------------- 유틸: Notion rich_text 제한 처리 ----------------------
 def truncate_text(text, max_length=2000):
     return text if len(text) <= max_length else text[:max_length]
+
 
 # ---------------------- 중복 키워드 확인 함수 ----------------------
 def page_exists(keyword):
@@ -35,25 +33,37 @@ def page_exists(keyword):
         query = notion.databases.query(
             database_id=NOTION_HOOK_DB_ID,
             filter={"property": "키워드", "title": {"equals": keyword}},
-            page_size=1
+            page_size=1,
         )
         return len(query.get("results", [])) > 0
     except Exception as e:
         logging.warning(f"⚠️ 중복 확인 실패: {keyword} - {e}")
         return False
 
+
 # ---------------------- GPT 결과 파싱 함수 ----------------------
 def parse_generated_text(text):
     hook_lines = re.findall(r"후킹 ?문장[0-9]?[\s:：\-\)]*([^\n]+)", text)
-    blog_match = re.search(r"블로그(?:\s*초안)?[\s:：\-\)]*(.*?)\n+\s*(.*?\n+.*?\n+.*?)(?:\n|$)", text, re.DOTALL)
-    video_titles = re.findall(r"(?:영상 제목|YouTube 제목)[\s:：\-\)]*[^\n]*\n?-\s*(.+)", text)
+    blog_match = re.search(
+        r"블로그(?:\s*초안)?[\s:：\-\)]*(.*?)\n+\s*(.*?\n+.*?\n+.*?)(?:\n|$)",
+        text,
+        re.DOTALL,
+    )
+    video_titles = re.findall(
+        r"(?:영상 제목|YouTube 제목)[\s:：\-\)]*[^\n]*\n?-\s*(.+)", text
+    )
 
-    blog_paragraphs = [p.strip() for p in blog_match[1].strip().split('\n')[:3]] if blog_match else ["", "", ""]
+    blog_paragraphs = (
+        [p.strip() for p in blog_match[1].strip().split("\n")[:3]]
+        if blog_match
+        else ["", "", ""]
+    )
     return {
         "hook_lines": hook_lines[:2] if len(hook_lines) >= 2 else ["", ""],
         "blog_paragraphs": blog_paragraphs,
-        "video_titles": video_titles[:2] if video_titles else ["", ""]
+        "video_titles": video_titles[:2] if video_titles else ["", ""],
     }
+
 
 # ---------------------- Notion 페이지 생성 함수 ----------------------
 def create_notion_page(item):
@@ -66,22 +76,51 @@ def create_notion_page(item):
         properties={
             "키워드": {"title": [{"text": {"content": keyword}}]},
             "채널": {"select": {"name": topic}},
-            "등록일": {"date": {"start": datetime.utcnow().isoformat() + 'Z'}},
-            "후킹문1": {"rich_text": [{"text": {"content": truncate_text(parsed["hook_lines"][0])}}]},
-            "후킹문2": {"rich_text": [{"text": {"content": truncate_text(parsed["hook_lines"][1])}}]},
-            "블로그초안": {"rich_text": [{"text": {"content": truncate_text('\n'.join(parsed["blog_paragraphs"]))}}]},
-            "영상제목": {"rich_text": [{"text": {"content": truncate_text('\n'.join(parsed["video_titles"]))}}]}
-        }
+            "등록일": {"date": {"start": datetime.utcnow().isoformat() + "Z"}},
+            "후킹문1": {
+                "rich_text": [
+                    {"text": {"content": truncate_text(parsed["hook_lines"][0])}}
+                ]
+            },
+            "후킹문2": {
+                "rich_text": [
+                    {"text": {"content": truncate_text(parsed["hook_lines"][1])}}
+                ]
+            },
+            "블로그초안": {
+                "rich_text": [
+                    {
+                        "text": {
+                            "content": truncate_text(
+                                "\n".join(parsed["blog_paragraphs"])
+                            )
+                        }
+                    }
+                ]
+            },
+            "영상제목": {
+                "rich_text": [
+                    {
+                        "text": {
+                            "content": truncate_text("\n".join(parsed["video_titles"]))
+                        }
+                    }
+                ]
+            },
+        },
     )
+
 
 # ---------------------- 업로드 실행 함수 ----------------------
 def upload_all_hooks():
     if not NOTION_TOKEN or not NOTION_HOOK_DB_ID:
-        logging.error("❗ 환경 변수(NOTION_API_TOKEN, NOTION_HOOK_DB_ID)가 누락되었습니다.")
+        logging.error(
+            "❗ 환경 변수(NOTION_API_TOKEN, NOTION_HOOK_DB_ID)가 누락되었습니다."
+        )
         return
 
     try:
-        with open(HOOK_JSON_PATH, 'r', encoding='utf-8') as f:
+        with open(HOOK_JSON_PATH, "r", encoding="utf-8") as f:
             hooks = json.load(f)
     except Exception as e:
         logging.error(f"❗ 후킹 JSON 파일 읽기 오류: {e}")
@@ -120,12 +159,15 @@ def upload_all_hooks():
 
     if failed_items:
         os.makedirs(os.path.dirname(FAILED_OUTPUT_PATH), exist_ok=True)
-        with open(FAILED_OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        with open(FAILED_OUTPUT_PATH, "w", encoding="utf-8") as f:
             json.dump(failed_items, f, ensure_ascii=False, indent=2)
         logging.info(f"❗ 실패 항목 저장됨: {FAILED_OUTPUT_PATH}")
 
     logging.info("📊 후킹 업로드 요약")
-    logging.info(f"총 항목: {total} | 성공: {success} | 중복스킵: {skipped} | 실패: {failed}")
+    logging.info(
+        f"총 항목: {total} | 성공: {success} | 중복스킵: {skipped} | 실패: {failed}"
+    )
+
 
 if __name__ == "__main__":
     upload_all_hooks()

--- a/retry_dashboard_notifier.py
+++ b/retry_dashboard_notifier.py
@@ -1,9 +1,12 @@
-import os
 import json
 import logging
+import os
 from datetime import datetime
-from notion_client import Client
+
 from dotenv import load_dotenv
+from notion_client import Client
+
+from utils.logger import setup_logging
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -11,7 +14,7 @@ NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_KPI_DB_ID = os.getenv("NOTION_KPI_DB_ID")
 SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+setup_logging()
 
 # ---------------------- Notion 클라이언트 ----------------------
 if not NOTION_TOKEN or not NOTION_KPI_DB_ID:
@@ -19,13 +22,14 @@ if not NOTION_TOKEN or not NOTION_KPI_DB_ID:
     exit(1)
 notion = Client(auth=NOTION_TOKEN)
 
+
 # ---------------------- KPI 데이터 수집 ----------------------
 def get_retry_stats():
     if not os.path.exists(SUMMARY_PATH):
         logging.error(f"❌ 재시도 데이터 파일이 없습니다: {SUMMARY_PATH}")
         return None
 
-    with open(SUMMARY_PATH, 'r', encoding='utf-8') as f:
+    with open(SUMMARY_PATH, "r", encoding="utf-8") as f:
         data = json.load(f)
 
     total = len(data)
@@ -39,8 +43,9 @@ def get_retry_stats():
         "total": total,
         "success": success,
         "failed": failed,
-        "rate": rate
+        "rate": rate,
     }
+
 
 # ---------------------- Notion KPI 행 추가 ----------------------
 def push_kpi_to_notion(kpi):
@@ -52,12 +57,13 @@ def push_kpi_to_notion(kpi):
                 "전체 시도": {"number": kpi["total"]},
                 "성공": {"number": kpi["success"]},
                 "실패": {"number": kpi["failed"]},
-                "성공률(%)": {"number": kpi["rate"]}
-            }
+                "성공률(%)": {"number": kpi["rate"]},
+            },
         )
         logging.info("📊 Notion KPI 업데이트 완료")
     except Exception as e:
         logging.error(f"❌ Notion KPI 전송 실패: {e}")
+
 
 # ---------------------- 실행 진입점 ----------------------
 if __name__ == "__main__":

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,14 +1,13 @@
 import logging
+import os
 import subprocess
 import sys
-import os
 from datetime import datetime
 
+from utils.logger import setup_logging
+
 # ---------------------- 로깅 설정 ----------------------
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s %(levelname)s:%(message)s'
-)
+setup_logging()
 
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
@@ -16,8 +15,9 @@ PIPELINE_SEQUENCE = [
     "parse_failed_gpt.py",
     "retry_failed_uploads.py",
     "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    "retry_dashboard_notifier.py",
 ]
+
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
@@ -38,6 +38,7 @@ def run_script(script):
             print(result.stdout)
         return True
 
+
 # ---------------------- 전체 파이프라인 실행 ----------------------
 def run_pipeline():
     logging.info(f"🧩 파이프라인 시작: {datetime.now().strftime('%Y-%m-%d %H:%M')}")
@@ -55,6 +56,7 @@ def run_pipeline():
         logging.info("✅ 모든 단계 성공적으로 완료")
     else:
         logging.warning("⚠️ 일부 단계에서 실패 발생")
+
 
 # ---------------------- 진입점 ----------------------
 if __name__ == "__main__":

--- a/scripts/notion_uploader.py
+++ b/scripts/notion_uploader.py
@@ -1,34 +1,40 @@
-import os
 import json
-import time
 import logging
+import os
+import time
 from datetime import datetime
-from notion_client import Client
+
 from dotenv import load_dotenv
+from notion_client import Client
+
+from utils.logger import setup_logging
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_DB_ID = os.getenv("NOTION_DB_ID")
-KEYWORD_JSON_PATH = os.getenv("KEYWORD_OUTPUT_PATH", "data/keyword_output_with_cpc.json")
+KEYWORD_JSON_PATH = os.getenv(
+    "KEYWORD_OUTPUT_PATH", "data/keyword_output_with_cpc.json"
+)
 UPLOAD_DELAY = float(os.getenv("UPLOAD_DELAY", "0.5"))
 CACHE_PATH = os.getenv("UPLOADED_CACHE_PATH", "data/uploaded_keywords_cache.json")
 FAILED_PATH = os.getenv("FAILED_UPLOADS_PATH", "logs/failed_uploads.json")
 
 # ---------------------- 로깅 설정 ----------------------
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+setup_logging()
 
 # ---------------------- Notion 클라이언트 ----------------------
 notion = Client(auth=NOTION_TOKEN)
 
 # ---------------------- 캐시 로딩 ----------------------
 if os.path.exists(CACHE_PATH):
-    with open(CACHE_PATH, 'r', encoding='utf-8') as f:
+    with open(CACHE_PATH, "r", encoding="utf-8") as f:
         uploaded_cache = set(json.load(f))
 else:
     uploaded_cache = set()
 
 failed_uploads = []
+
 
 # ---------------------- 중복 키워드 확인 함수 ----------------------
 def page_exists(keyword):
@@ -38,31 +44,33 @@ def page_exists(keyword):
         query = notion.databases.query(
             database_id=NOTION_DB_ID,
             filter={"property": "키워드", "title": {"equals": keyword}},
-            page_size=1
+            page_size=1,
         )
         return len(query.get("results", [])) > 0
     except Exception as e:
         logging.warning(f"⚠️ 중복 확인 실패: {keyword} - {e}")
         return False
 
+
 # ---------------------- Notion 페이지 생성 함수 ----------------------
 def create_notion_page(item):
-    topic = item['keyword'].split()[0]  # 첫 단어를 주제 채널로 활용
+    topic = item["keyword"].split()[0]  # 첫 단어를 주제 채널로 활용
 
     notion.pages.create(
         parent={"database_id": NOTION_DB_ID},
         properties={
-            "키워드": {"title": [{"text": {"content": item['keyword']}}]},
-            "출처": {"select": {"name": item['source']}},
+            "키워드": {"title": [{"text": {"content": item["keyword"]}}]},
+            "출처": {"select": {"name": item["source"]}},
             "채널": {"select": {"name": topic}},
             "검색량": {"number": item.get("score", 0)},
             "성장률": {"number": item.get("growth", 0)},
             "멘션수": {"number": item.get("mentions", 0)},
             "최대리트윗": {"number": item.get("top_retweet", 0)},
             "CPC(원)": {"number": item.get("cpc", 0)},
-            "등록일": {"date": {"start": datetime.utcnow().isoformat() + 'Z'}}
-        }
+            "등록일": {"date": {"start": datetime.utcnow().isoformat() + "Z"}},
+        },
     )
+
 
 # ---------------------- 업로드 메인 함수 ----------------------
 def upload_all_keywords():
@@ -71,7 +79,7 @@ def upload_all_keywords():
         return
 
     try:
-        with open(KEYWORD_JSON_PATH, 'r', encoding='utf-8') as f:
+        with open(KEYWORD_JSON_PATH, "r", encoding="utf-8") as f:
             data = json.load(f)
             keywords = data.get("filtered_keywords", [])
     except Exception as e:
@@ -82,7 +90,7 @@ def upload_all_keywords():
     success, skipped, failed = 0, 0, 0
 
     for item in keywords:
-        keyword = item.get('keyword')
+        keyword = item.get("keyword")
         if not keyword:
             logging.warning("⛔ 빈 키워드 항목 발견, 건너뜁니다.")
             continue
@@ -111,7 +119,7 @@ def upload_all_keywords():
     # 캐시 저장
     try:
         os.makedirs(os.path.dirname(CACHE_PATH), exist_ok=True)
-        with open(CACHE_PATH, 'w', encoding='utf-8') as f:
+        with open(CACHE_PATH, "w", encoding="utf-8") as f:
             json.dump(list(uploaded_cache), f, ensure_ascii=False, indent=2)
         logging.info(f"📦 업로드 캐시 저장 완료: {CACHE_PATH}")
     except Exception as e:
@@ -121,7 +129,7 @@ def upload_all_keywords():
     if failed_uploads:
         try:
             os.makedirs(os.path.dirname(FAILED_PATH), exist_ok=True)
-            with open(FAILED_PATH, 'w', encoding='utf-8') as f:
+            with open(FAILED_PATH, "w", encoding="utf-8") as f:
                 json.dump(failed_uploads, f, ensure_ascii=False, indent=2)
             logging.info(f"❗ 실패 항목 기록 완료: {FAILED_PATH}")
         except Exception as e:
@@ -129,7 +137,10 @@ def upload_all_keywords():
 
     # ---------------------- 요약 결과 출력 ----------------------
     logging.info("🎯 업로드 완료 요약")
-    logging.info(f"총 키워드: {total} | 성공: {success} | 중복스킵: {skipped} | 실패: {failed}")
+    logging.info(
+        f"총 키워드: {total} | 성공: {success} | 중복스킵: {skipped} | 실패: {failed}"
+    )
+
 
 # ---------------------- 메인 진입점 ----------------------
 if __name__ == "__main__":

--- a/scripts/retry_failed_uploads.py
+++ b/scripts/retry_failed_uploads.py
@@ -1,10 +1,13 @@
-import os
 import json
-import time
 import logging
+import os
+import time
 from datetime import datetime
-from notion_client import Client
+
 from dotenv import load_dotenv
+from notion_client import Client
+
+from utils.logger import setup_logging
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -13,7 +16,7 @@ NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
 FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_keywords.json")
 RETRY_DELAY = float(os.getenv("RETRY_DELAY", "0.5"))
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+setup_logging()
 
 # ---------------------- Notion 클라이언트 ----------------------
 if not NOTION_TOKEN or not NOTION_HOOK_DB_ID:
@@ -21,21 +24,24 @@ if not NOTION_TOKEN or not NOTION_HOOK_DB_ID:
     exit(1)
 notion = Client(auth=NOTION_TOKEN)
 
+
 # ---------------------- 유틸: rich_text 길이 제한 ----------------------
 def truncate_text(text, max_length=2000):
     return text if len(text) <= max_length else text[:max_length]
+
 
 # ---------------------- 실패 키워드 로딩 ----------------------
 def load_failed_items():
     if not os.path.exists(FAILED_PATH):
         logging.warning(f"❗ 실패 항목 파일이 존재하지 않습니다: {FAILED_PATH}")
         return []
-    with open(FAILED_PATH, 'r', encoding='utf-8') as f:
+    with open(FAILED_PATH, "r", encoding="utf-8") as f:
         return json.load(f)
+
 
 # ---------------------- Notion 페이지 재생성 ----------------------
 def create_retry_page(item):
-    keyword = item.get('keyword')
+    keyword = item.get("keyword")
     if not keyword:
         raise ValueError("keyword 누락됨")
 
@@ -44,7 +50,7 @@ def create_retry_page(item):
     parsed = item.get("parsed") or {
         "hook_lines": item.get("hook_lines", ["", ""]),
         "blog_paragraphs": item.get("blog_paragraphs", ["", "", ""]),
-        "video_titles": item.get("video_titles", ["", ""])
+        "video_titles": item.get("video_titles", ["", ""]),
     }
 
     notion.pages.create(
@@ -52,13 +58,40 @@ def create_retry_page(item):
         properties={
             "키워드": {"title": [{"text": {"content": keyword}}]},
             "채널": {"select": {"name": topic}},
-            "등록일": {"date": {"start": datetime.utcnow().isoformat() + 'Z'}},
-            "후킹문1": {"rich_text": [{"text": {"content": truncate_text(parsed["hook_lines"][0])}}]},
-            "후킹문2": {"rich_text": [{"text": {"content": truncate_text(parsed["hook_lines"][1])}}]},
-            "블로그초안": {"rich_text": [{"text": {"content": truncate_text('\n'.join(parsed["blog_paragraphs"]))}}]},
-            "영상제목": {"rich_text": [{"text": {"content": truncate_text('\n'.join(parsed["video_titles"]))}}]}
-        }
+            "등록일": {"date": {"start": datetime.utcnow().isoformat() + "Z"}},
+            "후킹문1": {
+                "rich_text": [
+                    {"text": {"content": truncate_text(parsed["hook_lines"][0])}}
+                ]
+            },
+            "후킹문2": {
+                "rich_text": [
+                    {"text": {"content": truncate_text(parsed["hook_lines"][1])}}
+                ]
+            },
+            "블로그초안": {
+                "rich_text": [
+                    {
+                        "text": {
+                            "content": truncate_text(
+                                "\n".join(parsed["blog_paragraphs"])
+                            )
+                        }
+                    }
+                ]
+            },
+            "영상제목": {
+                "rich_text": [
+                    {
+                        "text": {
+                            "content": truncate_text("\n".join(parsed["video_titles"]))
+                        }
+                    }
+                ]
+            },
+        },
     )
+
 
 # ---------------------- 실행 함수 ----------------------
 def retry_failed_uploads():
@@ -88,13 +121,14 @@ def retry_failed_uploads():
 
     # 실패 파일 덮어쓰기
     if still_failed:
-        with open(FAILED_PATH, 'w', encoding='utf-8') as f:
+        with open(FAILED_PATH, "w", encoding="utf-8") as f:
             json.dump(still_failed, f, ensure_ascii=False, indent=2)
         logging.warning(f"🔁 여전히 실패한 항목 {len(still_failed)}개가 남아 있습니다.")
 
     # 요약
     logging.info("📦 재시도 업로드 요약")
     logging.info(f"성공: {success} | 실패 유지: {failed}")
+
 
 if __name__ == "__main__":
     retry_failed_uploads()

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,0 +1,18 @@
+import logging
+import os
+
+
+def setup_logging():
+    """Configure logging using environment variables."""
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+
+    log_file = os.getenv("LOG_FILE")
+    handlers = [logging.StreamHandler()]
+    if log_file:
+        os.makedirs(os.path.dirname(log_file), exist_ok=True)
+        handlers.append(logging.FileHandler(log_file))
+
+    logging.basicConfig(
+        level=level, format="%(asctime)s %(levelname)s:%(message)s", handlers=handlers
+    )


### PR DESCRIPTION
## Summary
- add `utils/logger.py` for shared configuration
- use `setup_logging` in all pipeline scripts
- configure level and log file via `LOG_LEVEL` and `LOG_FILE`

## Testing
- `pylint utils/logger.py run_pipeline.py keyword_auto_pipeline.py notion_hook_uploader.py retry_dashboard_notifier.py retry_failed_uploads.py hook_generator.py scripts/retry_failed_uploads.py scripts/notion_uploader.py`
- `mypy utils/logger.py run_pipeline.py keyword_auto_pipeline.py notion_hook_uploader.py retry_dashboard_notifier.py retry_failed_uploads.py hook_generator.py scripts/retry_failed_uploads.py scripts/notion_uploader.py` *(fails: Duplicate module named "retry_failed_uploads")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_684e18ed29e0832eb0c05f8ee46d415e