### PR TITLE
Implement retry parsing and notification scripts

### DIFF
--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,55 @@
+"""Send Slack notifications about retry upload results."""
+
+import json
+import logging
+import os
+import requests
+
+FAILED_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s:%(message)s",
+)
+
+
+def send_slack_message(text: str) -> None:
+    """Post a simple text message to the configured Slack webhook."""
+
+    if not WEBHOOK_URL:
+        logging.error("\u274c SLACK_WEBHOOK_URL 환경 변수가 설정되지 않았습니다.")
+        return
+
+    try:
+        resp = requests.post(WEBHOOK_URL, json={"text": text}, timeout=10)
+        if resp.status_code == 200:
+            logging.info("\u2705 Slack 알림 전송 완료")
+        else:
+            logging.error(
+                "\u274c Slack 전송 실패: %s %s", resp.status_code, resp.text
+            )
+    except requests.RequestException as exc:
+        logging.error("\u274c Slack 전송 예외: %s", exc)
+
+
+def notify_retry_result() -> None:
+    """Read retry results and notify via Slack."""
+
+    if not os.path.exists(FAILED_PATH):
+        send_slack_message("✅ 모든 항목이 성공적으로 업로드되었습니다.")
+        return
+
+    with open(FAILED_PATH, 'r', encoding='utf-8') as f:
+        items = json.load(f)
+
+    if not items:
+        send_slack_message("✅ 모든 항목이 성공적으로 업로드되었습니다.")
+    else:
+        keywords = [item.get("keyword", "") for item in items]
+        message = f"❌ {len(keywords)}개 항목 업로드 실패\n" + ", ".join(keywords)
+        send_slack_message(message)
+
+
+if __name__ == "__main__":
+    notify_retry_result()

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,67 @@
+"""Utility script to reparse failed GPT outputs."""
+
+import json
+import logging
+import os
+import re
+
+FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s:%(message)s",
+)
+
+
+def parse_generated_text(text: str) -> dict:
+    """Extract structured fields from a GPT output text."""
+
+    hook_lines = re.findall(r"후킹 ?문장[0-9]?[\s:：\-\)]*([^\n]+)", text)
+    blog_match = re.search(
+        r"블로그(?:\s*초안)?[\s:：\-\)]*(.*?)\n+\s*(.*?\n+.*?\n+.*?)(?:\n|$)",
+        text,
+        re.DOTALL,
+    )
+    video_titles = re.findall(
+        r"(?:영상 제목|YouTube 제목)[\s:：\-\)]*[^\n]*\n?-\s*(.+)",
+        text,
+    )
+
+    blog_paragraphs = (
+        [p.strip() for p in blog_match[1].strip().split("\n")[:3]]
+        if blog_match
+        else ["", "", ""]
+    )
+    return {
+        "hook_lines": hook_lines[:2] if len(hook_lines) >= 2 else ["", ""],
+        "blog_paragraphs": blog_paragraphs,
+        "video_titles": video_titles[:2] if video_titles else ["", ""],
+    }
+
+
+def parse_failed_gpt() -> None:
+    """Parse failed GPT outputs and save structured data for retry."""
+
+    if not os.path.exists(FAILED_PATH):
+        logging.error("\u274c 실패 데이터 파일이 없습니다: %s", FAILED_PATH)
+        return
+
+    with open(FAILED_PATH, 'r', encoding='utf-8') as f:
+        items = json.load(f)
+
+    reparsed = []
+    for item in items:
+        text = item.get("generated_text", "")
+        item["parsed"] = parse_generated_text(text)
+        reparsed.append(item)
+
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        json.dump(reparsed, f, ensure_ascii=False, indent=2)
+
+    logging.info("\u2705 재파싱 결과 저장: %s", OUTPUT_PATH)
+
+
+if __name__ == "__main__":
+    parse_failed_gpt()

--- a/tests/test_notify_retry_result.py
+++ b/tests/test_notify_retry_result.py
@@ -1,0 +1,41 @@
+import json
+import importlib
+import sys
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_notify_retry_result_success(tmp_path, monkeypatch):
+    path = tmp_path / "reparsed.json"
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump([], f)
+    monkeypatch.setenv("REPARSED_OUTPUT_PATH", str(path))
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "http://example.com/webhook")
+    with mock.patch("scripts.notify_retry_result.requests.post") as post:
+        module = importlib.import_module("scripts.notify_retry_result")
+        importlib.reload(module)
+        module.notify_retry_result()
+        post.assert_called_once()
+        args, kwargs = post.call_args
+        assert kwargs["json"]["text"].startswith("✅")
+
+
+def test_notify_retry_result_failures(tmp_path, monkeypatch):
+    path = tmp_path / "reparsed.json"
+    data = [
+        {"keyword": "kw1"},
+        {"keyword": "kw2"}
+    ]
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+    monkeypatch.setenv("REPARSED_OUTPUT_PATH", str(path))
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "http://example.com/webhook")
+    with mock.patch("scripts.notify_retry_result.requests.post") as post:
+        module = importlib.import_module("scripts.notify_retry_result")
+        importlib.reload(module)
+        module.notify_retry_result()
+        post.assert_called_once()
+        text = post.call_args[1]["json"]["text"]
+        assert "2개" in text and "kw1" in text

--- a/tests/test_parse_failed_gpt.py
+++ b/tests/test_parse_failed_gpt.py
@@ -1,0 +1,34 @@
+import json
+import importlib
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_parse_failed_gpt(tmp_path, monkeypatch):
+    failed_path = tmp_path / "failed.json"
+    output_path = tmp_path / "reparsed.json"
+    sample_text = (
+        "후킹 문장1: a\n"
+        "후킹 문장2: b\n"
+        "블로그 초안:\n문단1\n문단2\n문단3\n"
+        "영상 제목:\n- 제목1\n- 제목2\n"
+    )
+    with open(failed_path, "w", encoding="utf-8") as f:
+        json.dump([{"keyword": "test", "generated_text": sample_text}], f, ensure_ascii=False)
+
+    monkeypatch.setenv("FAILED_HOOK_PATH", str(failed_path))
+    monkeypatch.setenv("REPARSED_OUTPUT_PATH", str(output_path))
+
+    module = importlib.import_module("scripts.parse_failed_gpt")
+    importlib.reload(module)
+    module.parse_failed_gpt()
+
+    with open(output_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert data[0]["parsed"]["hook_lines"] == ["a", "b"]
+    assert data[0]["parsed"]["blog_paragraphs"][0] == "문단1"
+    assert data[0]["parsed"]["video_titles"]


### PR DESCRIPTION
## Summary
- add scripts to reparse failed GPT results and notify Slack
- include minimal tests for new scripts

## Testing
- `pylint scripts/parse_failed_gpt.py scripts/notify_retry_result.py`
- `mypy scripts/parse_failed_gpt.py scripts/notify_retry_result.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e170f56d0832eb511b23e6deda4c9