### PR TITLE
Fix pipeline order and script lookup

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,29 +1,42 @@
 import logging
+import os
 import subprocess
 import sys
-import os
 from datetime import datetime
 
 # ---------------------- 로깅 설정 ----------------------
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s %(levelname)s:%(message)s'
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s:%(message)s")
 
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
-PIPELINE_SEQUENCE = [
-    "hook_generator.py",
-    "parse_failed_gpt.py",
-    "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+# Updated module order to reflect actual script names in scripts/
+PIPELINE_ORDER = [
+    "hook_generator",  # generates hooks
+    "notion_hook_uploader",  # uploads successful hooks to Notion
+    "retry_failed_uploads",  # retries failed uploads / dashboard notifier
+    "retry_dashboard_notifier",  # sends dashboard slack notification
 ]
 
+
 # ---------------------- 스크립트 실행 함수 ----------------------
-def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+def run_script(script: str):
+    """Run a pipeline step.
+
+    The step name can be provided with or without a ``.py`` extension. The
+    function will look for the script inside the ``scripts`` directory first
+    and then in the repository root.
+    """
+
+    if not script.endswith(".py"):
+        script += ".py"
+
+    candidate_paths = [
+        os.path.join("scripts", script),
+        script,
+    ]
+
+    full_path = next((p for p in candidate_paths if os.path.exists(p)), None)
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")
@@ -38,12 +51,13 @@ def run_script(script):
             print(result.stdout)
         return True
 
+
 # ---------------------- 전체 파이프라인 실행 ----------------------
 def run_pipeline():
     logging.info(f"🧩 파이프라인 시작: {datetime.now().strftime('%Y-%m-%d %H:%M')}")
     all_passed = True
 
-    for script in PIPELINE_SEQUENCE:
+    for script in PIPELINE_ORDER:
         success = run_script(script)
         if not success:
             all_passed = False
@@ -55,6 +69,7 @@ def run_pipeline():
         logging.info("✅ 모든 단계 성공적으로 완료")
     else:
         logging.warning("⚠️ 일부 단계에서 실패 발생")
+
 
 # ---------------------- 진입점 ----------------------
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update pipeline order names
- allow run_script to locate modules in `scripts/` or repo root
- format code with black and isort

## Testing
- `black --check run_pipeline.py`
- `isort run_pipeline.py --check-only`
- `mypy run_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_684e17d82238832eb8dbaf5f6f1849f9