### PR TITLE
Implement utils and duplicate import tests

### DIFF
--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -6,6 +6,7 @@ import re
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from scripts.utils import truncate_text, create_notion_page
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -24,10 +25,6 @@ logging.basicConfig(
         logging.StreamHandler()
     ]
 )
-
-# ---------------------- 유틸: Notion rich_text 제한 처리 ----------------------
-def truncate_text(text, max_length=2000):
-    return text if len(text) <= max_length else text[:max_length]
 
 # ---------------------- 중복 키워드 확인 함수 ----------------------
 def page_exists(keyword):
@@ -56,23 +53,6 @@ def parse_generated_text(text):
     }
 
 # ---------------------- Notion 페이지 생성 함수 ----------------------
-def create_notion_page(item):
-    keyword = item["keyword"]
-    parsed = parse_generated_text(item.get("generated_text", ""))
-    topic = keyword.split()[0] if " " in keyword else keyword
-
-    notion.pages.create(
-        parent={"database_id": NOTION_HOOK_DB_ID},
-        properties={
-            "키워드": {"title": [{"text": {"content": keyword}}]},
-            "채널": {"select": {"name": topic}},
-            "등록일": {"date": {"start": datetime.utcnow().isoformat() + 'Z'}},
-            "후킹문1": {"rich_text": [{"text": {"content": truncate_text(parsed["hook_lines"][0])}}]},
-            "후킹문2": {"rich_text": [{"text": {"content": truncate_text(parsed["hook_lines"][1])}}]},
-            "블로그초안": {"rich_text": [{"text": {"content": truncate_text('\n'.join(parsed["blog_paragraphs"]))}}]},
-            "영상제목": {"rich_text": [{"text": {"content": truncate_text('\n'.join(parsed["video_titles"]))}}]}
-        }
-    )
 
 # ---------------------- 업로드 실행 함수 ----------------------
 def upload_all_hooks():
@@ -102,9 +82,10 @@ def upload_all_hooks():
             skipped += 1
             continue
 
+        parsed = parse_generated_text(item.get("generated_text", ""))
         for attempt in range(3):
             try:
-                create_notion_page(item)
+                create_notion_page(notion, NOTION_HOOK_DB_ID, keyword, parsed)
                 logging.info(f"✅ 업로드 완료: {keyword}")
                 success += 1
                 break

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+
+def truncate_text(text: str, max_length: int = 2000) -> str:
+    """Truncate Notion rich_text content to avoid API errors."""
+    return text if len(text) <= max_length else text[:max_length]
+
+
+def create_notion_page(notion, database_id: str, keyword: str, parsed: dict) -> None:
+    """Create a Notion page using parsed hook data."""
+    topic = keyword.split()[0] if " " in keyword else keyword
+    notion.pages.create(
+        parent={"database_id": database_id},
+        properties={
+            "키워드": {"title": [{"text": {"content": keyword}}]},
+            "채널": {"select": {"name": topic}},
+            "등록일": {"date": {"start": datetime.utcnow().isoformat() + 'Z'}},
+            "후킹문1": {"rich_text": [{"text": {"content": truncate_text(parsed.get("hook_lines", ["", ""])[0])}}]},
+            "후킹문2": {"rich_text": [{"text": {"content": truncate_text(parsed.get("hook_lines", ["", ""])[1])}}]},
+            "블로그초안": {"rich_text": [{"text": {"content": truncate_text('\n'.join(parsed.get("blog_paragraphs", ["", "", ""])))}}]},
+            "영상제목": {"rich_text": [{"text": {"content": truncate_text('\n'.join(parsed.get("video_titles", ["", ""])))}}]},
+        },
+    )

--- a/tests/test_duplicate_import.py
+++ b/tests/test_duplicate_import.py
@@ -1,0 +1,19 @@
+import os
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from run_pipeline import run_script
+
+
+def test_duplicate_import(tmp_path, monkeypatch):
+    module_name = "dummy_mod"
+    script = tmp_path / f"{module_name}.py"
+    script.write_text("print('ok')\n")
+    monkeypatch.chdir(tmp_path)
+    loaded = set()
+    assert run_script(module_name, loaded) is True
+    with pytest.raises(ImportError):
+        run_script(module_name, loaded)
+


### PR DESCRIPTION
## Summary
- fix pipeline module order
- refactor Notion upload helpers into new `scripts/utils.py`
- update `notion_hook_uploader` and `retry_failed_uploads` to use shared helpers
- enforce duplicate-module detection in `run_pipeline`
- add regression test for duplicate module import

## Testing
- `pytest -q`
- `pre-commit run --all-files` *(fails: `.pre-commit-config.yaml is not a file`)*

------
https://chatgpt.com/codex/tasks/task_e_684e17ef9f4c832ea7abf4a1e780572c