### PR TITLE
Tune Sentry sampling and add Opsgenie mapping

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -16,6 +16,7 @@ jobs:
       NOTION_KPI_DB_ID: ${{ secrets.NOTION_KPI_DB_ID }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       REPARSED_OUTPUT_PATH: logs/failed_keywords_reparsed.json
+      TRACE_RATE: ${{ matrix.env == 'staging' && '0.20' || '0.05' }}
 
     steps:
       - name: 📂 Checkout repository

--- a/autopipe/opsgenie.py
+++ b/autopipe/opsgenie.py
@@ -1,0 +1,34 @@
+import os
+import requests
+
+API_KEY = os.getenv("OPSGENIE_API_KEY")
+TEAM = os.getenv("OPSGENIE_TEAM", "core")
+
+# priority 결정 로직
+
+def _map_priority(step: str, error: str) -> str:
+    if "gpt.api" in step and ("429" in error or error.startswith("5")):
+        return "P2"
+    if "notion.api" in step:
+        return "P3"
+    return "P4"
+
+def alert(message: str, step: str = "", error: str = "") -> None:
+    if not API_KEY:
+        return
+    prio = _map_priority(step, error)
+    body = {
+        "message": message,
+        "priority": prio,
+        "teams": [{"name": TEAM}],
+        "source": "autopipeline",
+    }
+    try:
+        requests.post(
+            "https://api.opsgenie.com/v2/alerts",
+            json=body,
+            headers={"Authorization": f"GenieKey {API_KEY}"},
+            timeout=5,
+        )
+    except Exception:
+        pass

--- a/autopipe/sentry_init.py
+++ b/autopipe/sentry_init.py
@@ -1,0 +1,10 @@
+import os
+import sentry_sdk
+
+RATE = float(os.getenv("TRACE_RATE", "0.05"))
+
+sentry_sdk.init(
+    dsn=os.getenv("SENTRY_DSN"),
+    traces_sample_rate=RATE,
+    profiles_sample_rate=min(RATE * 0.4, 0.1),
+)

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -4,6 +4,9 @@ import sys
 import os
 from datetime import datetime
 
+from autopipe.opsgenie import alert
+import autopipe.sentry_init
+
 # ---------------------- 로깅 설정 ----------------------
 logging.basicConfig(
     level=logging.INFO,
@@ -31,6 +34,7 @@ def run_script(script):
 
     if result.returncode != 0:
         logging.error(f"❌ 실패: {script}\n{result.stderr}")
+        alert(f"Step {script} failed", step=script, error=result.stderr.strip())
         return False
     else:
         logging.info(f"✅ 완료: {script}")


### PR DESCRIPTION
## Summary
- tune Sentry trace sampling via TRACE_RATE env
- map Opsgenie alert priority by step and error
- send alert when pipeline step fails
- expose TRACE_RATE variable in workflow

## Testing
- `pytest -q`
- `pylint run_pipeline.py autopipe/opsgenie.py autopipe/sentry_init.py`

------
https://chatgpt.com/codex/tasks/task_e_684e1802b394832e8c40c2eddfef534d