### PR TITLE
Implement environment-based monitoring integrations

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -7,9 +7,15 @@ on:
 
 jobs:
   run-pipeline:
+    strategy:
+      matrix:
+        env: [dev, qa, staging, prod]
     runs-on: ubuntu-latest
 
     env:
+      APP_ENV: ${{ matrix.env }}
+      TRACE_RATE: ${{ matrix.env == 'prod' && '0.05' || matrix.env == 'staging' && '0.20' || '1.0' }}
+      OPSGENIE_REGION: ${{ matrix.env == 'eu-prod' && 'EU' || 'US' }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       NOTION_API_TOKEN: ${{ secrets.NOTION_API_TOKEN }}
       NOTION_HOOK_DB_ID: ${{ secrets.NOTION_HOOK_DB_ID }}

--- a/autopipe/opsgenie.py
+++ b/autopipe/opsgenie.py
@@ -1,0 +1,20 @@
+import os
+import requests
+
+API_KEY = os.getenv("OPSGENIE_API_KEY")
+TEAM = os.getenv("OPSGENIE_TEAM", "DevOps")
+REGION = os.getenv("OPSGENIE_REGION", "US").upper()
+BASE = "https://api.eu.opsgenie.com" if REGION == "EU" else "https://api.opsgenie.com"
+ENV_TAG = os.getenv("APP_ENV", "prod")
+
+
+def notify(message: str, prio: str = "P3") -> None:
+    hdr = {"Authorization": f"GenieKey {API_KEY}"}
+    body = {
+        "message": message,
+        "priority": prio,
+        "teams": [{"name": TEAM}],
+        "tags": [f"env:{ENV_TAG}"],
+        "source": "autopipeline",
+    }
+    requests.post(f"{BASE}/v2/alerts", json=body, headers=hdr, timeout=5)

--- a/autopipe/sentry_init.py
+++ b/autopipe/sentry_init.py
@@ -1,0 +1,28 @@
+import os
+import sentry_sdk
+from sentry_sdk import SamplingContext
+
+ENV = os.getenv("APP_ENV", "prod")   # dev / qa / staging / prod
+
+
+def _default_rate(env: str) -> float:
+    return {"prod": 0.05, "staging": 0.20}.get(env, 1.0)
+
+
+def _traces_sampler(ctx: SamplingContext) -> float:
+    # root 트랜잭션만 평가
+    if ctx.parent_sampling_decision is not None:
+        return ctx.parent_sampling_decision
+    name = ctx.transaction_context.get("name", "")
+    if ENV == "prod" and name.startswith(("retry_", "dashboard_notifier")):
+        return 0.005   # 0.5 %
+    return _default_rate(ENV)
+
+
+sentry_sdk.init(
+    dsn=os.getenv("SENTRY_DSN"),
+    traces_sampler=_traces_sampler,
+    profiles_sample_rate=0.02,
+    environment=ENV,
+    release=os.getenv("DD_VERSION", "0.4.2"),
+)

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -2,6 +2,7 @@ import logging
 import subprocess
 import sys
 import os
+from autopipe import sentry_init  # Sentry initialization
 from datetime import datetime
 
 # ---------------------- 로깅 설정 ----------------------


### PR DESCRIPTION
## Summary
- add Sentry init with environment based sampler
- support EU region and tagging for Opsgenie alerts
- initialize Sentry in `run_pipeline.py`
- inject environment variables via matrix in workflow

## Testing
- `pylint autopipe/sentry_init.py autopipe/opsgenie.py run_pipeline.py`
- `mypy autopipe/sentry_init.py autopipe/opsgenie.py run_pipeline.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_684e187b8314832ebac3580c1998b0a5