### PR TITLE
Update hooks to use JSON responses

### DIFF
--- a/hook_generator.py
+++ b/hook_generator.py
@@ -29,7 +29,13 @@ def generate_hook_prompt(keyword, topic, source, score, growth, mentions):
     - 숏폼 영상의 후킹 문장 2개
     - 블로그 포스트의 3문단 초안
     - YouTube 영상 제목 예시 2개
-    를 마케팅적으로 끌리는 문장으로 생성해줘. 말투는 친근하면서도 전문가처럼.
+    를 친근하지만 전문가처럼 작성해줘.
+    결과는 다음 형식의 JSON으로만 답변해줘:
+    {{
+      "hook_lines": ["첫 번째 후킹", "두 번째 후킹"],
+      "blog_paragraphs": ["문단1", "문단2", "문단3"],
+      "video_titles": ["제목1", "제목2"]
+    }}
     """
     return base.strip()
 
@@ -104,16 +110,23 @@ def generate_hooks():
         }
 
         if response:
-            lines = response.split('\n')
-            result.update({
-                "hook_lines": lines[0:2],
-                "blog_paragraphs": lines[2:5],
-                "video_titles": lines[5:],
-                "generated_text": response
-            })
-            new_output.append(result)
-            logging.info(f"✅ 생성 완료: {keyword}")
-            success += 1
+            try:
+                parsed = json.loads(response)
+                result.update({
+                    "hook_lines": parsed.get("hook_lines", ["", ""])[:2],
+                    "blog_paragraphs": parsed.get("blog_paragraphs", ["", "", ""])[:3],
+                    "video_titles": parsed.get("video_titles", ["", ""])[:2],
+                    "generated_text": response
+                })
+                new_output.append(result)
+                logging.info(f"✅ 생성 완료: {keyword}")
+                success += 1
+            except Exception as e:
+                result["generated_text"] = response
+                result["error"] = f"JSON 파싱 실패: {e}"
+                failed_output.append(result)
+                logging.error(f"❌ 파싱 실패: {keyword}")
+                failed += 1
         else:
             result["generated_text"] = None
             result["error"] = "GPT 응답 실패"

--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -44,16 +44,20 @@ def page_exists(keyword):
 
 # ---------------------- GPT 결과 파싱 함수 ----------------------
 def parse_generated_text(text):
-    hook_lines = re.findall(r"후킹 ?문장[0-9]?[\s:：\-\)]*([^\n]+)", text)
-    blog_match = re.search(r"블로그(?:\s*초안)?[\s:：\-\)]*(.*?)\n+\s*(.*?\n+.*?\n+.*?)(?:\n|$)", text, re.DOTALL)
-    video_titles = re.findall(r"(?:영상 제목|YouTube 제목)[\s:：\-\)]*[^\n]*\n?-\s*(.+)", text)
-
-    blog_paragraphs = [p.strip() for p in blog_match[1].strip().split('\n')[:3]] if blog_match else ["", "", ""]
-    return {
-        "hook_lines": hook_lines[:2] if len(hook_lines) >= 2 else ["", ""],
-        "blog_paragraphs": blog_paragraphs,
-        "video_titles": video_titles[:2] if video_titles else ["", ""]
-    }
+    try:
+        data = json.loads(text)
+        return {
+            "hook_lines": data.get("hook_lines", ["", ""])[:2],
+            "blog_paragraphs": data.get("blog_paragraphs", ["", "", ""])[:3],
+            "video_titles": data.get("video_titles", ["", ""])[:2],
+        }
+    except Exception as e:
+        logging.warning(f"JSON 파싱 실패: {e}")
+        return {
+            "hook_lines": ["", ""],
+            "blog_paragraphs": ["", "", ""],
+            "video_titles": ["", ""],
+        }
 
 # ---------------------- Notion 페이지 생성 함수 ----------------------
 def create_notion_page(item):


### PR DESCRIPTION
## Summary
- change hook prompt to return JSON
- parse GPT responses as JSON for reliable fields
- update hook uploader parser for JSON

## Testing
- `python -m unittest discover`
- `mypy .`
- `pylint hook_generator.py notion_hook_uploader.py`
- `python hook_generator.py` *(fails: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_684e17127870832e82f0dc7cd54b0878