### PR TITLE
Standardize failed data paths

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,18 @@
+# Example environment configuration
+OPENAI_API_KEY=
+NOTION_API_TOKEN=
+NOTION_HOOK_DB_ID=
+NOTION_KPI_DB_ID=
+NOTION_DB_ID=
+
+TOPIC_CHANNELS_PATH=config/topic_channels.json
+KEYWORD_OUTPUT_PATH=data/keyword_output_with_cpc.json
+HOOK_OUTPUT_PATH=data/generated_hooks.json
+FAILED_HOOK_PATH=logs/failed_keywords_reparsed.json
+FAILED_UPLOADS_PATH=logs/failed_uploads.json
+UPLOADED_CACHE_PATH=data/uploaded_keywords_cache.json
+
+UPLOAD_DELAY=0.5
+RETRY_DELAY=0.5
+API_DELAY=1.0
+

--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -15,7 +15,7 @@ jobs:
       NOTION_HOOK_DB_ID: ${{ secrets.NOTION_HOOK_DB_ID }}
       NOTION_KPI_DB_ID: ${{ secrets.NOTION_KPI_DB_ID }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      REPARSED_OUTPUT_PATH: logs/failed_keywords_reparsed.json
+      FAILED_HOOK_PATH: logs/failed_keywords_reparsed.json
 
     steps:
       - name: 📂 Checkout repository
@@ -39,11 +39,11 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: failed-keywords
-          path: logs/failed_keywords_reparsed.json
+          path: ${{ env.FAILED_HOOK_PATH }}
 
       - name: ✍️ Append workflow summary
         if: always()
         run: |
           echo "## 🌐 Notion Hook 파이프라인 실행 완료" >> $GITHUB_STEP_SUMMARY
           echo "- 실행 시각: $(date '+%Y-%m-%d %H:%M:%S')" >> $GITHUB_STEP_SUMMARY
-          echo "- 실패 항목 JSON: logs/failed_keywords_reparsed.json" >> $GITHUB_STEP_SUMMARY
+          echo "- 실패 항목 JSON: ${{ env.FAILED_HOOK_PATH }}" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Auto Pipeline
+
+This repository contains small utilities for generating marketing hooks and uploading them to Notion. All scripts rely on environment variables loaded via `.env`.
+
+## Environment Variables
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `OPENAI_API_KEY` | API key for OpenAI | |
+| `NOTION_API_TOKEN` | Token for Notion API | |
+| `NOTION_HOOK_DB_ID` | Notion database ID for generated hooks | |
+| `NOTION_KPI_DB_ID` | Notion database ID used for KPI logging | |
+| `NOTION_DB_ID` | Notion database ID for keyword uploads | |
+| `TOPIC_CHANNELS_PATH` | Path to topic configuration JSON | `config/topic_channels.json` |
+| `KEYWORD_OUTPUT_PATH` | Output path for keyword collection | `data/keyword_output_with_cpc.json` |
+| `HOOK_OUTPUT_PATH` | Output path for generated hooks | `data/generated_hooks.json` |
+| `FAILED_HOOK_PATH` | Location of failed hook items and reparsed data | `logs/failed_keywords_reparsed.json` |
+| `FAILED_UPLOADS_PATH` | Location of failed upload logs | `logs/failed_uploads.json` |
+| `UPLOADED_CACHE_PATH` | Cache file for uploaded keywords | `data/uploaded_keywords_cache.json` |
+| `UPLOAD_DELAY` | Delay between Notion uploads (seconds) | `0.5` |
+| `RETRY_DELAY` | Delay between retry attempts (seconds) | `0.5` |
+| `API_DELAY` | Delay between OpenAI API calls (seconds) | `1.0` |
+
+Create a `.env` file based on the `.env.template` provided and fill in the required credentials.
+
+## Usage
+
+Run individual scripts with Python. For example, to upload generated hooks:
+
+```bash
+python notion_hook_uploader.py
+```
+
+A GitHub Actions workflow is available at `.github/workflows/daily-pipeline.yml.txt` for automated execution.
+

--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -12,7 +12,7 @@ load_dotenv()
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
 HOOK_JSON_PATH = os.getenv("HOOK_OUTPUT_PATH", "data/generated_hooks.json")
-FAILED_OUTPUT_PATH = "data/upload_failed_hooks.json"
+FAILED_OUTPUT_PATH = os.getenv("FAILED_UPLOADS_PATH", "data/upload_failed_hooks.json")
 UPLOAD_DELAY = float(os.getenv("UPLOAD_DELAY", "0.5"))
 
 notion = Client(auth=NOTION_TOKEN)

--- a/retry_dashboard_notifier.py
+++ b/retry_dashboard_notifier.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 load_dotenv()
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_KPI_DB_ID = os.getenv("NOTION_KPI_DB_ID")
-SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+SUMMARY_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_keywords_reparsed.json")
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
 
@@ -65,3 +65,4 @@ if __name__ == "__main__":
     if kpi:
         logging.info(f"📈 KPI 요약: {kpi}")
         push_kpi_to_notion(kpi)
+

--- a/retry_failed_uploads.py
+++ b/retry_failed_uploads.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 load_dotenv()
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
-FAILED_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_keywords_reparsed.json")
 RETRY_DELAY = float(os.getenv("RETRY_DELAY", "0.5"))
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')


### PR DESCRIPTION
## Summary
- unify env vars for failed paths across scripts
- add README and .env template for environment variables
- update workflow to use new FAILED_HOOK_PATH variable

## Testing
- `pylint hook_generator.py notion_hook_uploader.py retry_failed_uploads.py retry_dashboard_notifier.py scripts/notion_uploader.py scripts/retry_failed_uploads.py`
- `mypy hook_generator.py notion_hook_uploader.py retry_failed_uploads.py retry_dashboard_notifier.py scripts/notion_uploader.py`
- `python -m py_compile hook_generator.py notion_hook_uploader.py retry_failed_uploads.py retry_dashboard_notifier.py scripts/notion_uploader.py scripts/retry_failed_uploads.py`

------
https://chatgpt.com/codex/tasks/task_e_684e171501bc832eaa3b9995a779c120