### PR TITLE
Add unified env var validation

### DIFF
--- a/hook_generator.py
+++ b/hook_generator.py
@@ -5,9 +5,11 @@ import logging
 from datetime import datetime
 from dotenv import load_dotenv
 import openai
+from utils.env_validator import require_env_vars, MissingEnvironmentVariableError
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
+require_env_vars(["OPENAI_API_KEY"])
 KEYWORD_JSON_PATH = os.getenv("KEYWORD_OUTPUT_PATH", "data/keyword_output_with_cpc.json")
 HOOK_OUTPUT_PATH = os.getenv("HOOK_OUTPUT_PATH", "data/generated_hooks.json")
 FAILED_HOOK_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
@@ -50,9 +52,7 @@ def get_gpt_response(prompt, retries=3):
 
 # ---------------------- 메인 실행 함수 ----------------------
 def generate_hooks():
-    if not OPENAI_API_KEY:
-        logging.error("❗ OpenAI API 키가 누락되었습니다. .env 파일 확인 필요")
-        return
+
 
     try:
         with open(KEYWORD_JSON_PATH, 'r', encoding='utf-8') as f:

--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -6,9 +6,11 @@ import re
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from utils.env_validator import require_env_vars, MissingEnvironmentVariableError
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
+require_env_vars(["NOTION_API_TOKEN", "NOTION_HOOK_DB_ID"])
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
 HOOK_JSON_PATH = os.getenv("HOOK_OUTPUT_PATH", "data/generated_hooks.json")
@@ -76,9 +78,6 @@ def create_notion_page(item):
 
 # ---------------------- 업로드 실행 함수 ----------------------
 def upload_all_hooks():
-    if not NOTION_TOKEN or not NOTION_HOOK_DB_ID:
-        logging.error("❗ 환경 변수(NOTION_API_TOKEN, NOTION_HOOK_DB_ID)가 누락되었습니다.")
-        return
 
     try:
         with open(HOOK_JSON_PATH, 'r', encoding='utf-8') as f:

--- a/retry_dashboard_notifier.py
+++ b/retry_dashboard_notifier.py
@@ -4,9 +4,11 @@ import logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from utils.env_validator import require_env_vars, MissingEnvironmentVariableError
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
+require_env_vars(["NOTION_API_TOKEN", "NOTION_KPI_DB_ID"])
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_KPI_DB_ID = os.getenv("NOTION_KPI_DB_ID")
 SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
@@ -14,9 +16,6 @@ SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
 
 # ---------------------- Notion 클라이언트 ----------------------
-if not NOTION_TOKEN or not NOTION_KPI_DB_ID:
-    logging.error("❗ 환경 변수(NOTION_API_TOKEN, NOTION_KPI_DB_ID)가 누락되었습니다.")
-    exit(1)
 notion = Client(auth=NOTION_TOKEN)
 
 # ---------------------- KPI 데이터 수집 ----------------------

--- a/retry_failed_uploads.py
+++ b/retry_failed_uploads.py
@@ -5,9 +5,11 @@ import logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from utils.env_validator import require_env_vars, MissingEnvironmentVariableError
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
+require_env_vars(["NOTION_API_TOKEN", "NOTION_HOOK_DB_ID"])
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
 FAILED_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
@@ -16,9 +18,6 @@ RETRY_DELAY = float(os.getenv("RETRY_DELAY", "0.5"))
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
 
 # ---------------------- Notion 클라이언트 ----------------------
-if not NOTION_TOKEN or not NOTION_HOOK_DB_ID:
-    logging.error("❗ 환경 변수(NOTION_API_TOKEN, NOTION_HOOK_DB_ID)가 누락되었습니다.")
-    exit(1)
 notion = Client(auth=NOTION_TOKEN)
 
 # ---------------------- 유틸: rich_text 길이 제한 ----------------------

--- a/scripts/notion_uploader.py
+++ b/scripts/notion_uploader.py
@@ -5,9 +5,11 @@ import logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from utils.env_validator import require_env_vars, MissingEnvironmentVariableError
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
+require_env_vars(["NOTION_API_TOKEN", "NOTION_DB_ID"])
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_DB_ID = os.getenv("NOTION_DB_ID")
 KEYWORD_JSON_PATH = os.getenv("KEYWORD_OUTPUT_PATH", "data/keyword_output_with_cpc.json")
@@ -66,9 +68,6 @@ def create_notion_page(item):
 
 # ---------------------- 업로드 메인 함수 ----------------------
 def upload_all_keywords():
-    if not NOTION_TOKEN or not NOTION_DB_ID:
-        logging.error("❗ 환경 변수(NOTION_API_TOKEN, NOTION_DB_ID)가 누락되었습니다.")
-        return
 
     try:
         with open(KEYWORD_JSON_PATH, 'r', encoding='utf-8') as f:

--- a/scripts/retry_failed_uploads.py
+++ b/scripts/retry_failed_uploads.py
@@ -5,9 +5,11 @@ import logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from utils.env_validator import require_env_vars, MissingEnvironmentVariableError
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
+require_env_vars(["NOTION_API_TOKEN", "NOTION_HOOK_DB_ID"])
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
 FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_keywords.json")
@@ -16,9 +18,6 @@ RETRY_DELAY = float(os.getenv("RETRY_DELAY", "0.5"))
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
 
 # ---------------------- Notion 클라이언트 ----------------------
-if not NOTION_TOKEN or not NOTION_HOOK_DB_ID:
-    logging.error("❗ 환경 변수(NOTION_API_TOKEN, NOTION_HOOK_DB_ID)가 누락되었습니다.")
-    exit(1)
 notion = Client(auth=NOTION_TOKEN)
 
 # ---------------------- 유틸: rich_text 길이 제한 ----------------------

--- a/tests/test_env_validator.py
+++ b/tests/test_env_validator.py
@@ -1,0 +1,31 @@
+import importlib
+import sys
+import pytest
+
+from utils import env_validator
+from utils.env_validator import MissingEnvironmentVariableError
+
+
+def test_require_env_vars_missing(monkeypatch):
+    monkeypatch.delenv('SOME_TOKEN', raising=False)
+    with pytest.raises(MissingEnvironmentVariableError):
+        env_validator.require_env_vars(['SOME_TOKEN'])
+
+
+def test_require_env_vars_present(monkeypatch):
+    monkeypatch.setenv('SOME_TOKEN', 'abc')
+    # Should not raise
+    env_validator.require_env_vars(['SOME_TOKEN'])
+
+
+def test_hook_generator_import_without_token(monkeypatch):
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    dummy_module = type(sys)('dotenv')
+    dummy_module.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, 'dotenv', dummy_module)
+    monkeypatch.setitem(sys.modules, 'openai', type(sys)('openai'))
+    with pytest.raises(MissingEnvironmentVariableError):
+        if 'hook_generator' in sys.modules:
+            del sys.modules['hook_generator']
+        import hook_generator
+        importlib.reload(hook_generator)

--- a/utils/env_validator.py
+++ b/utils/env_validator.py
@@ -1,0 +1,21 @@
+import os
+from typing import Iterable
+
+class MissingEnvironmentVariableError(EnvironmentError):
+    """Raised when required environment variables are missing."""
+
+
+def require_env_vars(vars: Iterable[str]) -> None:
+    """Ensure required environment variables are present.
+
+    Args:
+        vars: Iterable of environment variable names to validate.
+
+    Raises:
+        MissingEnvironmentVariableError: if any variable is missing.
+    """
+    missing = [var for var in vars if not os.getenv(var)]
+    if missing:
+        raise MissingEnvironmentVariableError(
+            "Missing required environment variables: " + ", ".join(missing)
+        )


### PR DESCRIPTION
## Summary
- add `utils.env_validator` module for env var checks
- validate tokens in hook and notion scripts via helper
- add tests covering missing variable scenarios

## Testing
- `PYTHONPATH=. pytest -q`
- `pylint utils/env_validator.py hook_generator.py notion_hook_uploader.py retry_dashboard_notifier.py retry_failed_uploads.py scripts/notion_uploader.py scripts/retry_failed_uploads.py`
- `mypy utils/env_validator.py`


------
https://chatgpt.com/codex/tasks/task_e_684e167c8a50832ea189149de68024c2