### PR TITLE
Add retry helper scripts for pipeline

### DIFF
--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,53 @@
+import os
+import json
+import logging
+import urllib.request
+from datetime import datetime
+from dotenv import load_dotenv
+
+load_dotenv()
+
+REPARSED_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def get_remaining_failures() -> int:
+    if not os.path.exists(REPARSED_PATH):
+        return 0
+    with open(REPARSED_PATH, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return len(data)
+
+
+def send_slack_message(message: str) -> None:
+    if not SLACK_WEBHOOK_URL:
+        logging.warning("SLACK_WEBHOOK_URL 미설정, 알림 생략")
+        return
+    payload = json.dumps({"text": message}).encode("utf-8")
+    req = urllib.request.Request(
+        SLACK_WEBHOOK_URL,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            resp.read()
+        logging.info("Slack 알림 전송 완료")
+    except Exception as e:
+        logging.error(f"Slack 알림 실패: {e}")
+
+
+def notify_retry_result() -> None:
+    remaining = get_remaining_failures()
+    msg = (
+        f"재시도 완료 - 남은 실패 항목: {remaining}개"
+        f" ({datetime.now().strftime('%Y-%m-%d %H:%M')})"
+    )
+    logging.info(msg)
+    send_slack_message(msg)
+
+
+if __name__ == "__main__":
+    notify_retry_result()

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,64 @@
+import os
+import json
+import logging
+import re
+from dotenv import load_dotenv
+
+load_dotenv()
+
+FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def parse_generated_text(text: str):
+    hook_lines = re.findall(r"후킹 ?문장[0-9]?[\s:：\-\)]*([^\n]+)", text)
+    blog_match = re.search(
+        r"블로그(?:\s*초안)?[\s:：\-\)]*(.*?)\n+\s*(.*?\n+.*?\n+.*?)(?:\n|$)",
+        text,
+        re.DOTALL,
+    )
+    video_titles = re.findall(r"(?:영상 제목|YouTube 제목)[\s:：\-\)]*[^\n]*\n?-\s*(.+)", text)
+    blog_paragraphs = (
+        [p.strip() for p in blog_match[1].strip().split("\n")[:3]] if blog_match else ["", "", ""]
+    )
+    return {
+        "hook_lines": hook_lines[:2] if len(hook_lines) >= 2 else ["", ""],
+        "blog_paragraphs": blog_paragraphs,
+        "video_titles": video_titles[:2] if video_titles else ["", ""],
+    }
+
+
+def parse_failed_gpt() -> None:
+    if not os.path.exists(FAILED_PATH):
+        logging.error(f"❌ 실패 데이터가 존재하지 않습니다: {FAILED_PATH}")
+        return
+
+    with open(FAILED_PATH, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    reparsed = []
+    for item in data:
+        text = item.get("generated_text")
+        keyword = item.get("keyword")
+        if not text:
+            logging.warning(f"⚠️ 내용이 없어 건너뜀: {keyword}")
+            continue
+        parsed = parse_generated_text(text)
+        item["parsed"] = parsed
+        reparsed.append(item)
+        logging.info(f"✅ 파싱 완료: {keyword}")
+
+    if not reparsed:
+        logging.info("📭 파싱할 항목이 없습니다.")
+        return
+
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, "w", encoding="utf-8") as f:
+        json.dump(reparsed, f, ensure_ascii=False, indent=2)
+    logging.info(f"📄 파싱 결과 저장: {OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    parse_failed_gpt()


### PR DESCRIPTION
## Summary
- parse GPT failures from hook generation output
- notify Slack about remaining failures after retries

## Testing
- `python -m py_compile scripts/parse_failed_gpt.py scripts/notify_retry_result.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1662f79c832e9928290efe19c1b2