### PR TITLE
Implement asyncio for OpenAI calls

### DIFF
--- a/hook_generator.py
+++ b/hook_generator.py
@@ -1,6 +1,6 @@
 import os
 import json
-import time
+import asyncio
 import logging
 from datetime import datetime
 from dotenv import load_dotenv
@@ -34,22 +34,23 @@ def generate_hook_prompt(keyword, topic, source, score, growth, mentions):
     return base.strip()
 
 # ---------------------- GPT 호출 함수 (재시도 포함) ----------------------
-def get_gpt_response(prompt, retries=3):
+async def get_gpt_response(prompt: str, retries: int = 3) -> str | None:
+    """Call OpenAI ChatCompletion asynchronously with retries."""
     for attempt in range(retries):
         try:
-            response = openai.ChatCompletion.create(
+            response = await openai.ChatCompletion.acreate(
                 model="gpt-4",
                 messages=[{"role": "user", "content": prompt}],
-                temperature=0.7
+                temperature=0.7,
             )
-            return response.choices[0].message['content']
-        except Exception as e:
-            logging.warning(f"GPT 호출 실패 {attempt + 1}/{retries}: {e}")
-            time.sleep(2)
+            return response.choices[0].message["content"]
+        except Exception as e:  # pragma: no cover - network errors simulated
+            logging.warning("GPT 호출 실패 %s/%s: %s", attempt + 1, retries, e)
+            await asyncio.sleep(2)
     return None
 
 # ---------------------- 메인 실행 함수 ----------------------
-def generate_hooks():
+async def generate_hooks() -> None:
     if not OPENAI_API_KEY:
         logging.error("❗ OpenAI API 키가 누락되었습니다. .env 파일 확인 필요")
         return
@@ -72,56 +73,69 @@ def generate_hooks():
         except Exception as e:
             logging.warning(f"기존 결과 로딩 실패: {e}")
 
-    new_output = []
-    failed_output = []
-    skipped, success, failed = 0, 0, 0
-
-    for item in keywords:
-        keyword = item.get('keyword')
+    async def process_item(item: dict) -> tuple[str, dict | None]:
+        keyword = item.get("keyword")
         if not keyword:
             logging.warning("⛔ 빈 키워드 항목, 건너뜁니다.")
-            continue
+            return "skipped", None
 
         if keyword in existing:
-            logging.info(f"⏭️ 중복 스킵: {keyword}")
-            skipped += 1
-            continue
+            logging.info("⏭️ 중복 스킵: %s", keyword)
+            return "skipped", None
 
         prompt = generate_hook_prompt(
             keyword=keyword,
             topic=keyword.split()[0],
-            source=item.get('source'),
-            score=item.get('score', 0),
-            growth=item.get('growth', 0),
-            mentions=item.get('mentions', 0)
+            source=item.get("source"),
+            score=item.get("score", 0),
+            growth=item.get("growth", 0),
+            mentions=item.get("mentions", 0),
         )
-        response = get_gpt_response(prompt)
+
+        response = await get_gpt_response(prompt)
 
         result = {
             "keyword": keyword,
             "hook_prompt": prompt,
-            "timestamp": datetime.utcnow().isoformat() + 'Z'
+            "timestamp": datetime.utcnow().isoformat() + "Z",
         }
 
         if response:
-            lines = response.split('\n')
-            result.update({
-                "hook_lines": lines[0:2],
-                "blog_paragraphs": lines[2:5],
-                "video_titles": lines[5:],
-                "generated_text": response
-            })
-            new_output.append(result)
-            logging.info(f"✅ 생성 완료: {keyword}")
-            success += 1
-        else:
-            result["generated_text"] = None
-            result["error"] = "GPT 응답 실패"
-            failed_output.append(result)
-            logging.error(f"❌ 생성 실패: {keyword}")
-            failed += 1
+            lines = response.split("\n")
+            result.update(
+                {
+                    "hook_lines": lines[0:2],
+                    "blog_paragraphs": lines[2:5],
+                    "video_titles": lines[5:],
+                    "generated_text": response,
+                }
+            )
+            logging.info("✅ 생성 완료: %s", keyword)
+            return "success", result
 
-        time.sleep(API_DELAY)
+        result["generated_text"] = None
+        result["error"] = "GPT 응답 실패"
+        logging.error("❌ 생성 실패: %s", keyword)
+        return "failed", result
+
+    new_output: list[dict] = []
+    failed_output: list[dict] = []
+    skipped = success = failed = 0
+
+    tasks = []
+    for item in keywords:
+        tasks.append(asyncio.create_task(process_item(item)))
+        await asyncio.sleep(API_DELAY)
+
+    for status, result in await asyncio.gather(*tasks):
+        if status == "success" and result:
+            new_output.append(result)
+            success += 1
+        elif status == "failed" and result:
+            failed_output.append(result)
+            failed += 1
+        else:
+            skipped += 1
 
     full_output = list(existing.values()) + new_output
     os.makedirs(os.path.dirname(HOOK_OUTPUT_PATH), exist_ok=True)
@@ -139,4 +153,4 @@ def generate_hooks():
     logging.info(f"🎉 후킹 문장 저장 완료: {HOOK_OUTPUT_PATH}")
 
 if __name__ == "__main__":
-    generate_hooks()
+    asyncio.run(generate_hooks())

--- a/tests/test_hook_generator_async.py
+++ b/tests/test_hook_generator_async.py
@@ -1,0 +1,41 @@
+import json
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+@pytest.mark.asyncio
+async def test_generate_hooks(tmp_path, monkeypatch):
+    keywords_path = tmp_path / "keywords.json"
+    output_path = tmp_path / "hooks.json"
+    fail_path = tmp_path / "failed.json"
+
+    data = {"filtered_keywords": [{"keyword": "test", "source": "s", "score": 1, "growth": 1, "mentions": 1}]}
+    keywords_path.write_text(json.dumps(data), encoding="utf-8")
+
+    monkeypatch.setenv("KEYWORD_OUTPUT_PATH", str(keywords_path))
+    monkeypatch.setenv("HOOK_OUTPUT_PATH", str(output_path))
+    monkeypatch.setenv("FAILED_HOOK_PATH", str(fail_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk")
+    monkeypatch.setenv("API_DELAY", "0")
+
+    import importlib
+    hg = importlib.reload(__import__("hook_generator"))
+
+    class _Resp:
+        def __init__(self, content: str):
+            self.choices = [type("Obj", (), {"message": {"content": content}})()]
+
+    async_mock = AsyncMock(return_value=_Resp("a\nb\nc\nd\ne\nf"))
+
+    with patch.object(hg.openai.ChatCompletion, "acreate", async_mock):
+        await hg.generate_hooks()
+
+    saved = json.loads(output_path.read_text(encoding="utf-8"))
+    assert saved[0]["keyword"] == "test"
+    assert "generated_text" in saved[0]
+


### PR DESCRIPTION
## Summary
- add asyncio-based OpenAI call logic
- process keywords concurrently with async tasks
- include pytest test verifying async behavior

## Testing
- `pylint hook_generator.py tests/test_hook_generator_async.py`
- `mypy hook_generator.py tests/test_hook_generator_async.py` *(fails: Module has no attribute "ChatCompletion")*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dfe2679e8832e88535dafb52e5d73