### PR TITLE
Adjust pytrends initialization

### DIFF
--- a/keyword_auto_pipeline.py
+++ b/keyword_auto_pipeline.py
@@ -128,8 +128,9 @@ def filter_keywords(entries):
     return filtered
 
 # ---------------------- 키워드별 수집 작업 ----------------------
-def collect_data_for_keyword(keyword, pytrends):
+def collect_data_for_keyword(keyword):
     results = []
+    pytrends = TrendReq(hl='ko', tz=540)
     try:
         gtrend = fetch_google_trends(keyword, pytrends)
         if gtrend:
@@ -149,11 +150,10 @@ def collect_data_for_keyword(keyword, pytrends):
 # ---------------------- 메인 파이프라인 ----------------------
 def run_pipeline():
     keywords = generate_keyword_pairs(TOPIC_DETAILS)
-    pytrends = TrendReq(hl='ko', tz=540)
     all_results = []
 
     with ThreadPoolExecutor(max_workers=10) as executor:
-        futures = {executor.submit(collect_data_for_keyword, kw, pytrends): kw for kw in keywords}
+        futures = {executor.submit(collect_data_for_keyword, kw): kw for kw in keywords}
 
         for future in as_completed(futures):
             kw = futures[future]


### PR DESCRIPTION
## Summary
- initialize `TrendReq` within `collect_data_for_keyword`
- update thread pool calls to use the new function signature

## Testing
- `pylint keyword_auto_pipeline.py`
- `mypy keyword_auto_pipeline.py` *(fails: Cannot find implementation or library stub for module named "pytrends.request")*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ea201c63c832ea8028d309c202a69