### PR TITLE
Fix pipeline script list

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,17 +13,20 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
     "retry_dashboard_notifier.py"
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    # 우선 scripts 디렉터리에서 찾고, 없으면 루트 경로를 사용한다.
+    candidate_paths = [os.path.join("scripts", script), script]
+    for path in candidate_paths:
+        if os.path.exists(path):
+            full_path = path
+            break
+    else:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {candidate_paths[0]}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- drop missing scripts from PIPELINE_SEQUENCE
- allow `run_pipeline.py` to locate scripts in either `scripts/` or repo root

## Testing
- `pytest -q`
- `pylint run_pipeline.py`
- `mypy run_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_684ea1fff6bc832eaf0a0f56a14d8494