### PR TITLE
Fix pipeline script path resolution

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -20,10 +20,25 @@ PIPELINE_SEQUENCE = [
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
-def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+def run_script(script: str) -> bool:
+    """Execute a pipeline script located either at the repository root or in
+    the ``scripts`` directory.
+
+    Parameters
+    ----------
+    script: str
+        The script name or relative path.
+
+    Returns
+    -------
+    bool
+        ``True`` if the script executed successfully, otherwise ``False``.
+    """
+
+    candidate_paths = [os.path.join("scripts", script), script]
+    full_path = next((p for p in candidate_paths if os.path.exists(p)), None)
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- allow `run_pipeline` to locate scripts either in repo root or `scripts/`
- update workflow to call `run_pipeline.py` from repository root

## Testing
- `mypy run_pipeline.py`
- `pylint run_pipeline.py` *(fails: rating 7.43/10, some warnings)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ea3966e5c832ea1050e942c917907