### PR TITLE
Add missing pipeline scripts and adjust runner

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -21,9 +21,11 @@ PIPELINE_SEQUENCE = [
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    """Run a single script located either in ./scripts or the repo root."""
+    candidates = [os.path.join("scripts", script), script]
+    full_path = next((p for p in candidates if os.path.exists(p)), None)
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")

--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,45 @@
+import os
+import json
+import logging
+from dotenv import load_dotenv
+
+load_dotenv()
+
+RESULT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def build_summary() -> str:
+    if not os.path.exists(RESULT_PATH):
+        return "No retry result file found."
+    with open(RESULT_PATH, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    total = len(data)
+    failed = len([d for d in data if d.get("retry_error")])
+    success = total - failed
+    return f"Retry summary - total: {total}, success: {success}, failed: {failed}"
+
+
+def send_slack_message(message: str) -> None:
+    if not SLACK_WEBHOOK_URL:
+        logging.info(message)
+        return
+    try:
+        import requests  # type: ignore
+
+        response = requests.post(SLACK_WEBHOOK_URL, json={"text": message})
+        if response.status_code != 200:
+            logging.error(f"Slack notification failed: {response.text}")
+    except Exception as e:
+        logging.error(f"Slack notification error: {e}")
+
+
+def main() -> None:
+    summary = build_summary()
+    send_slack_message(summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,49 @@
+import os
+import json
+import logging
+from dotenv import load_dotenv
+
+load_dotenv()
+
+FAILED_HOOK_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def simple_parse(text: str) -> dict:
+    """Parse GPT output in a very naive way."""
+    lines = [l.strip() for l in text.splitlines() if l.strip()]
+    hook_lines = lines[0:2]
+    blog_paragraphs = lines[2:5]
+    video_titles = lines[5:7]
+    return {
+        "hook_lines": hook_lines + ["", ""][:2-len(hook_lines)],
+        "blog_paragraphs": blog_paragraphs + ["", "", ""][:3-len(blog_paragraphs)],
+        "video_titles": video_titles + ["", ""][:2-len(video_titles)],
+    }
+
+
+def main() -> None:
+    if not os.path.exists(FAILED_HOOK_PATH):
+        logging.info(f"No failed hook file found at {FAILED_HOOK_PATH}")
+        return
+
+    with open(FAILED_HOOK_PATH, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    parsed_items = []
+    for item in data:
+        generated = item.get("generated_text", "")
+        parsed = simple_parse(generated)
+        item["parsed"] = parsed
+        parsed_items.append(item)
+
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, "w", encoding="utf-8") as f:
+        json.dump(parsed_items, f, ensure_ascii=False, indent=2)
+    logging.info(f"Parsed results written to {OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -1,0 +1,15 @@
+import os
+import unittest
+from run_pipeline import PIPELINE_SEQUENCE, run_script
+
+class PipelineTestCase(unittest.TestCase):
+    def test_scripts_exist(self):
+        for script in PIPELINE_SEQUENCE:
+            candidates = [os.path.join('scripts', script), script]
+            self.assertTrue(any(os.path.exists(p) for p in candidates), f"Missing script {script}")
+
+    def test_run_script_nonexistent(self):
+        self.assertFalse(run_script('nonexistent_script.py'))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `parse_failed_gpt.py` and `notify_retry_result.py`
- update `run_pipeline` to locate scripts in either `scripts/` or repo root
- add unit tests to verify pipeline scripts

## Testing
- `python -m unittest tests.test_run_pipeline -v`
- `mypy --ignore-missing-imports scripts/*.py run_pipeline.py tests/test_run_pipeline.py`
- `pylint run_pipeline.py scripts/*.py tests/test_run_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684ea39a8c84832e88c3f04740715a87