### PR TITLE
Allow scripts in root or scripts folder

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Auto Pipeline
+
+Run the keyword and hook generation pipeline using:
+
+```bash
+python run_pipeline.py
+```
+
+Each stage script may live in the repository root or in `scripts/`. The
+`run_pipeline.py` helper will automatically locate them.

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -20,13 +20,17 @@ PIPELINE_SEQUENCE = [
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
-def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+def run_script(script: str) -> bool:
+    """Run a script located either in the repository root or the scripts folder."""
+
+    candidates = [script, os.path.join("scripts", script)]
+    full_path = next((p for p in candidates if os.path.exists(p)), None)
+
+    if full_path is None:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
-    logging.info(f"🚀 실행 중: {script}")
+    logging.info(f"🚀 실행 중: {full_path}")
     result = subprocess.run([sys.executable, full_path], capture_output=True, text=True)
 
     if result.returncode != 0:


### PR DESCRIPTION
## Summary
- make `run_script` search both root and `scripts/` folder
- fix workflow to call `run_pipeline.py` from repo root
- document how to run the pipeline

## Testing
- `flake8 .` *(fails: E501 line too long, E302 expected 2 blank lines, ...)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ea5d6ddac832e948ab5549dd35aa1