### PR TITLE
Fix TrendReq instantiation per thread

### DIFF
--- a/keyword_auto_pipeline.py
+++ b/keyword_auto_pipeline.py
@@ -128,8 +128,9 @@ def filter_keywords(entries):
     return filtered
 
 # ---------------------- 키워드별 수집 작업 ----------------------
-def collect_data_for_keyword(keyword, pytrends):
+def collect_data_for_keyword(keyword):
     results = []
+    pytrends = TrendReq(hl='ko', tz=540)
     try:
         gtrend = fetch_google_trends(keyword, pytrends)
         if gtrend:
@@ -149,11 +150,10 @@ def collect_data_for_keyword(keyword, pytrends):
 # ---------------------- 메인 파이프라인 ----------------------
 def run_pipeline():
     keywords = generate_keyword_pairs(TOPIC_DETAILS)
-    pytrends = TrendReq(hl='ko', tz=540)
     all_results = []
 
     with ThreadPoolExecutor(max_workers=10) as executor:
-        futures = {executor.submit(collect_data_for_keyword, kw, pytrends): kw for kw in keywords}
+        futures = {executor.submit(collect_data_for_keyword, kw): kw for kw in keywords}
 
         for future in as_completed(futures):
             kw = futures[future]


### PR DESCRIPTION
## Summary
- ensure each thread creates its own `TrendReq` instance
- adjust thread executor invocation accordingly

## Testing
- `pytest -q`
- `pylint keyword_auto_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684ea76e0990832eae0d8a951fd59554