### PR TITLE
Implement missing retry scripts

### DIFF
--- a/notify_retry_result.py
+++ b/notify_retry_result.py
@@ -1,0 +1,60 @@
+"""Notify Slack of retry results."""
+
+import json
+import logging
+import os
+from typing import List, Dict, Any
+
+from dotenv import load_dotenv
+import requests
+
+load_dotenv()
+WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO,
+                    format="%(asctime)s %(levelname)s:%(message)s")
+
+
+def load_summary() -> List[Dict[str, Any]]:
+    """Load retry summary data from ``SUMMARY_PATH``."""
+    if not os.path.exists(SUMMARY_PATH):
+        logging.warning("❗ 결과 파일이 없습니다: %s", SUMMARY_PATH)
+        return []
+    with open(SUMMARY_PATH, "r", encoding="utf-8") as file:
+        return json.load(file)
+
+
+def send_slack_message(text: str) -> None:
+    """Send ``text`` to Slack via incoming webhook."""
+    if not WEBHOOK_URL:
+        logging.error("❗ SLACK_WEBHOOK_URL 환경 변수가 설정되지 않았습니다.")
+        return
+    try:
+        response = requests.post(WEBHOOK_URL, json={"text": text}, timeout=10)
+        if response.status_code == 200:
+            logging.info("✅ 슬랙 알림 전송 완료")
+        else:
+            logging.error("❌ 슬랙 전송 실패: %s %s", response.status_code, response.text)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logging.error("❌ 슬랙 요청 중 오류: %s", exc)
+
+
+def notify_result() -> None:
+    """Read retry results and send a Slack notification."""
+    summary = load_summary()
+    total = len(summary)
+    failed = len([s for s in summary if s.get("retry_error")])
+    success = total - failed
+
+    message = (
+        "📢 Notion 업로드 재시도 결과\n"
+        f"총 항목: {total}\n"
+        f"성공: {success}\n"
+        f"실패: {failed}"
+    )
+    send_slack_message(message)
+
+
+if __name__ == "__main__":
+    notify_result()

--- a/parse_failed_gpt.py
+++ b/parse_failed_gpt.py
@@ -1,0 +1,49 @@
+"""Parse failed GPT results and save them in a structured form."""
+
+import json
+import logging
+import os
+from typing import List, Dict, Any
+
+from dotenv import load_dotenv
+from notion_hook_uploader import parse_generated_text
+
+load_dotenv()
+FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO,
+                    format="%(asctime)s %(levelname)s:%(message)s")
+
+
+def parse_failed_items() -> List[Dict[str, Any]]:
+    """Parse GPT outputs from ``FAILED_PATH`` and write results to
+    ``OUTPUT_PATH``.
+    """
+    if not os.path.exists(FAILED_PATH):
+        logging.info("❗ 실패 파일이 존재하지 않습니다: %s", FAILED_PATH)
+        return []
+
+    with open(FAILED_PATH, "r", encoding="utf-8") as file:
+        data = json.load(file)
+
+    parsed_items = []
+    for item in data:
+        text = item.get("generated_text", "")
+        parsed = parse_generated_text(text)
+        parsed_items.append({
+            "keyword": item.get("keyword"),
+            "generated_text": text,
+            "parsed": parsed,
+        })
+
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, "w", encoding="utf-8") as file:
+        json.dump(parsed_items, file, ensure_ascii=False, indent=2)
+
+    logging.info("✅ 파싱 완료: %s (항목 %d개)", OUTPUT_PATH, len(parsed_items))
+    return parsed_items
+
+
+if __name__ == "__main__":
+    parse_failed_items()


### PR DESCRIPTION
## Summary
- add `parse_failed_gpt.py` to parse GPT failures for retry
- add `notify_retry_result.py` to send Slack notifications
- pass `pylint` and `mypy` on new files

## Testing
- `pylint parse_failed_gpt.py notify_retry_result.py`
- `mypy --ignore-missing-imports parse_failed_gpt.py notify_retry_result.py`


------
https://chatgpt.com/codex/tasks/task_e_684ea7295c68832e90d92b623af99cb5