### PR TITLE
Fix pipeline sequence and script discovery

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,17 +13,28 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    "retry_dashboard_notifier.py",
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    # Check for the script inside the `scripts` directory first. If it does not
+    # exist there, fall back to searching in the repository root. This allows
+    # pipeline steps to reference scripts regardless of their location while
+    # keeping backward compatibility with previous implementations.
+    candidate_paths = [
+        os.path.join("scripts", script),
+        script,
+    ]
+    full_path = None
+    for path in candidate_paths:
+        if os.path.exists(path):
+            full_path = path
+            break
+
+    if full_path is None:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- remove missing scripts from `PIPELINE_SEQUENCE`
- allow pipeline to run scripts located either in `scripts/` or in repo root

## Testing
- `pylint run_pipeline.py`
- `mypy run_pipeline.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ea6ea9928832eb424fdab966d2fef