### PR TITLE
Rename pipeline workflow and add requirements

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+openai
+notion-client
+python-dotenv
+pytrends
+snscrape


### PR DESCRIPTION
## Summary
- rename workflow to `daily-pipeline.yml`
- adjust workflow to call `python run_pipeline.py`
- add initial `requirements.txt` for third‑party packages

## Testing
- `pylint run_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684ea6e93504832ea5b4541fe9fc8d2f