### PR TITLE
Add CI config and basic pipeline tooling

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,14 @@
+name: CI Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - run: pip install -r requirements.txt
+      - run: pytest -q
+      - run: ruff .

--- a/.github/workflows/codex-cleanup.yml
+++ b/.github/workflows/codex-cleanup.yml
@@ -1,0 +1,35 @@
+name: Codex Branch Cleanup
+
+on:
+  schedule:
+    - cron: "30 0 * * *"   # 매일 09:30 KST
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete stale codex branches
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          DAYS=7
+          api() { curl -s -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "$@"; }
+          OWNER="${{ github.repository_owner }}"
+          REPO="${{ github.event.repository.name }}"
+          mapfile -t branches < <(
+            api "https://api.github.com/repos/$OWNER/$REPO/branches?per_page=100" |
+            jq -r '.[].name' | grep '-codex/'
+          )
+          for br in "${branches[@]}"; do
+            pr_state=$(api "https://api.github.com/repos/$OWNER/$REPO/pulls?state=all&head=$OWNER:$br" |
+                       jq -r '.[0].state // empty')
+            last_date=$(api "https://api.github.com/repos/$OWNER/$REPO/commits/$br" |
+                       jq -r '.commit.author.date')
+            if [[ "$pr_state" == "closed" || "$(date -d "$last_date" +%s)" -lt $(date -d "7 days ago" +%s) ]]; then
+              echo "Deleting $br"
+              api -X DELETE "https://api.github.com/repos/$OWNER/$REPO/git/refs/heads/$br"
+            fi
+          done

--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -1,0 +1,17 @@
+name: Daily Pipeline
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *"   # UTC 매일 02:00 (KST 11:00)
+
+jobs:
+  pipeline:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - run: pip install -r requirements.txt
+      - name: Run daily pipeline
+        run: python run_pipeline.py --topic "daily-keyword" --token $WORDPRESS_API_TOKEN

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+      - id: ruff

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,3 @@
+line-length = 100
+target-version = "py311"
+select = ["E", "F", "I"]

--- a/content_writer.py
+++ b/content_writer.py
@@ -1,0 +1,4 @@
+"""Placeholder module."""
+
+def write_content():
+    return ""

--- a/editor_seo_optimizer.py
+++ b/editor_seo_optimizer.py
@@ -1,0 +1,4 @@
+"""Placeholder module."""
+
+def optimize_seo(text: str) -> str:
+    return text

--- a/keyword_generator.py
+++ b/keyword_generator.py
@@ -1,0 +1,4 @@
+"""Placeholder module."""
+
+def generate_keywords():
+    return []

--- a/qa_filter.py
+++ b/qa_filter.py
@@ -1,0 +1,4 @@
+"""Placeholder module."""
+
+def filter_quality(items):
+    return items

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+openai>=1.25.0
+notion-client>=2.2.0
+python-dotenv>=1.0.1
+requests>=2.32.3
+schedule>=1.2.1
+pandas>=2.2.2
+pytest>=8.2.0
+pytest-mock>=3.14.0
+ruff>=0.4.4

--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,22 @@
+"""
+stdin 으로 받은 재시도 결과(summary JSON)를 Slack Webhook으로 전송.
+"""
+import json
+import os
+import sys
+
+import requests
+
+HOOK = os.getenv("SLACK_WEBHOOK", "")
+
+def notify(summary: dict):
+    if not HOOK:
+        print("⚠️  SLACK_WEBHOOK 미설정 – 알림 생략")
+        return
+    text = json.dumps(summary, indent=2, ensure_ascii=False)
+    requests.post(HOOK, json={"text": f"✅ GPT 재시도 결과\n```{text}```"})
+
+
+if __name__ == "__main__":
+    payload = json.loads(sys.stdin.read())
+    notify(payload)

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,16 @@
+"""
+GPT 실패 로그(JSON 리스트)에서 status=='failed' 항목만 추출.
+사용: python scripts/parse_failed_gpt.py failed_log.json
+"""
+import json
+import pathlib
+import sys
+
+
+def parse_fail_log(path: str) -> list[dict]:
+    data = json.loads(pathlib.Path(path).read_text())
+    return [item for item in data if item.get("status") == "failed"]
+
+
+if __name__ == "__main__":
+    print(json.dumps(parse_fail_log(sys.argv[1]), indent=2, ensure_ascii=False))

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -1,0 +1,17 @@
+import importlib
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_imports():
+    """핵심 모듈 임포트가 깨지지 않는지만 확인."""
+    for module in (
+        "keyword_generator",
+        "content_writer",
+        "editor_seo_optimizer",
+        "qa_filter",
+        "run_pipeline",
+    ):
+        assert importlib.import_module(module)


### PR DESCRIPTION
## Summary
- add requirements and ruff/pre-commit config
- provide Github Actions for CI, cleanup and daily pipeline
- add helper scripts for failed GPT logs and Slack notification
- include smoke tests and placeholder modules

## Testing
- `ruff check keyword_generator.py content_writer.py editor_seo_optimizer.py qa_filter.py scripts/parse_failed_gpt.py scripts/notify_retry_result.py tests/test_pipeline_smoke.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f188b081c832ebfb1214faa8def87