### PR TITLE
Add docstring generator utility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: doc-gen CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - run: pytest -q

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENTRYPOINT ["python", "cursor_chunk_doc_gen.py"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# cursor_chunk_doc_gen
+
+Codex / Cursor 한 파일용 **자동 Docstring 생성기**.
+
+```bash
+export OPENAI_API_KEY="sk-..."
+python cursor_chunk_doc_gen.py my_script.py
+Flow
+mermaid
+flowchart TD
+    A[Load source] --> B[Parse with ast]
+    B --> C{Docstring exists?}
+    C -- No --> D[Prompt GPT-4o for docstring]
+    D --> E[Insert docstring into AST]
+    C -- Yes --> E
+    E --> F[Unparse → source]
+    F --> G[Write *_docgen.py]
+```
+
+---
+
+### 📌 사용 방법 요약
+
+```bash
+# 1) 의존 설치
+pip install -r requirements.txt
+
+# 2) 실행
+export OPENAI_API_KEY="YOUR_API_KEY"
+python cursor_chunk_doc_gen.py your_module.py
+```

--- a/cursor_chunk_doc_gen.py
+++ b/cursor_chunk_doc_gen.py
@@ -1,0 +1,108 @@
+"""
+Generate Google-style docstrings for any Python source file.
+
+Usage (CLI):
+    python cursor_chunk_doc_gen.py path/to/your_script.py
+"""
+
+import ast
+import os
+import argparse
+from pathlib import Path
+
+import openai
+
+MODEL = "gpt-4o"          # 원하는 모델로 교체 가능
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+
+
+class _DocStringInjector(ast.NodeTransformer):
+    """AST NodeTransformer that inserts docstrings where missing."""
+
+    def __init__(self, ask_fn):
+        """
+        Args:
+            ask_fn: Callable[[str], str] – prompt → docstring 반환 함수
+        """
+        self.ask_fn = ask_fn
+        super().__init__()
+
+    # pylint: disable=invalid-name
+    def visit_FunctionDef(self, node):  # noqa: N802
+        self.generic_visit(node)
+        return self._maybe_inject(node)
+
+    def visit_AsyncFunctionDef(self, node):  # noqa: N802
+        self.generic_visit(node)
+        return self._maybe_inject(node)
+
+    def visit_ClassDef(self, node):  # noqa: N802
+        self.generic_visit(node)
+        return self._maybe_inject(node)
+
+    # --------------------------------------------------------------------- #
+    # internal helpers
+    # --------------------------------------------------------------------- #
+    def _maybe_inject(self, node):
+        if ast.get_docstring(node) is None:
+            prompt = self._build_prompt(node)
+            docstring = self.ask_fn(prompt)
+            node.body.insert(0, ast.Expr(value=ast.Constant(docstring)))
+        return node
+
+    @staticmethod
+    def _build_prompt(node):
+        header = f"### Code ###\n{ast.unparse(node)}\n### End ###"
+        return (
+            "Generate a concise Google-style docstring (English) for the"
+            " Python object below. Include Args / Returns / Raises sections"
+            " only when meaningful.\n"
+            f"{header}"
+        )
+
+
+def _ask_chatgpt(prompt: str) -> str:
+    """Low-level OpenAI 호출 래퍼 (temperature=0)."""
+    if not OPENAI_API_KEY:
+        raise EnvironmentError("OPENAI_API_KEY not set")
+    rsp = openai.ChatCompletion.create(
+        model=MODEL,
+        api_key=OPENAI_API_KEY,
+        messages=[
+            {"role": "system", "content": "You are a senior Python docstring expert."},
+            {"role": "user", "content": prompt},
+        ],
+        temperature=0,
+    )
+    return rsp.choices[0].message.content.strip()
+
+
+def generate_docstrings(source: str) -> str:
+    """Return new source with docstrings injected where missing."""
+    tree = ast.parse(source)
+    injector = _DocStringInjector(_ask_chatgpt)
+    tree = injector.visit(tree)
+    ast.fix_missing_locations(tree)
+    return ast.unparse(tree)
+
+
+def process_file(path: Path) -> Path:
+    """Create <name>_docgen.py with generated docstrings."""
+    src = path.read_text(encoding="utf-8")
+    new_src = generate_docstrings(src)
+    out_path = path.with_name(path.stem + "_docgen.py")
+    out_path.write_text(new_src, encoding="utf-8")
+    return out_path
+
+
+def _cli():
+    parser = argparse.ArgumentParser(description="Auto-generate docstrings")
+    parser.add_argument("file", type=Path, help="Target Python file")
+    args = parser.parse_args()
+    out = process_file(args.file)
+    print(f"✅ Docstring file created → {out}")
+
+
+if __name__ == "__main__":
+    _cli()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+openai>=1.14
+pytest>=8.0
+markdown

--- a/tests/test_doc_gen.py
+++ b/tests/test_doc_gen.py
@@ -1,0 +1,21 @@
+import textwrap
+from cursor_chunk_doc_gen import generate_docstrings
+
+
+_SAMPLE = textwrap.dedent(
+    '''
+    def add(x, y):
+        return x + y
+    '''
+)
+
+
+def test_docstring_injection(monkeypatch):
+    """Docstring가 삽입되는지 확인."""
+    monkeypatch.setattr(
+        "cursor_chunk_doc_gen._ask_chatgpt",
+        lambda prompt: '"""Add two numbers.\n\nArgs:\n    x: int\n    y: int\n\nReturns:\n    int\n"""',
+    )
+    result = generate_docstrings(_SAMPLE)
+    assert 'Add two numbers.' in result
+


### PR DESCRIPTION
## Summary
- add docstring generation module `cursor_chunk_doc_gen.py`
- include pytest test for docstring injection
- provide Dockerfile and GitHub Actions CI workflow
- document usage in README
- specify package requirements

## Testing
- `PYTHONPATH=. pytest -q`
- `python3 -m pylint cursor_chunk_doc_gen.py tests/test_doc_gen.py`
- `python3 -m mypy cursor_chunk_doc_gen.py tests/test_doc_gen.py`

------
https://chatgpt.com/codex/tasks/task_e_684f18a2b550832eb5819db1e10e93ee