### PR TITLE
Add auto_rewriter tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Auto Pipeline
+
+This repository contains automation scripts for content generation and publishing pipelines.
+
+## auto_rewriter 사용법
+
+```bash
+export SUPABASE_URL="https://xyz.supabase.co"
+export SUPABASE_ANON_KEY="public-anon-key"
+export OPENAI_API_KEY="sk-..."
+python auto_rewriter.py --table content --threshold 0.25
+```
+
+```mermaid
+flowchart TD
+    A[Query low KPI rows] --> B[GPT-4o rewrite]
+    B --> C[Update Supabase row\n+ needs_rewrite=true]
+    C --> D[Downstream publisher\n(CI 또는 cron)]
+```
+
+### ✔️ 실행 빠른 체크리스트
+
+1. **의존 설치**  
+   `pip install -r requirements.txt`
+2. **환경 변수**  
+   `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `OPENAI_API_KEY`
+3. **테스트 실행**  
+   `pytest -q`
+4. **실전 실행**  
+   `python auto_rewriter.py --table content --threshold 0.25`

--- a/auto_rewriter.py
+++ b/auto_rewriter.py
@@ -1,0 +1,120 @@
+"""
+Supabase에서 성과가 저조한 콘텐츠를 자동으로 가져와
+GPT-4o로 리라이팅 후 다시 Supabase에 업데이트·플래그하는 모듈.
+
+Usage (CLI):
+    python auto_rewriter.py --table content --threshold 0.3
+"""
+
+from __future__ import annotations
+
+import os
+import argparse
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+
+
+# --------------------- 환경 변수 --------------------- #
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_KEY = os.getenv("SUPABASE_ANON_KEY")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+MODEL = "gpt-4o"
+LOW_SCORE_FIELD = "engagement_score"      # KPI 필드명 (0.0 ~ 1.0)
+REWRITE_FLAG_FIELD = "needs_rewrite"      # bool
+
+
+# --------------------- GPT 호출 ---------------------- #
+def _ask_gpt(original: str, topic: str) -> str:
+    """Return an improved version of `original` suited for the given topic."""
+    import openai  # local import to allow tests without openai installed
+
+    rsp = openai.ChatCompletion.create(
+        model=MODEL,
+        api_key=OPENAI_API_KEY,
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "You are an expert content marketer who quickly rewrites"
+                    " under-performing copy for higher engagement."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    f"Rewrite the following text for maximum engagement on"
+                    f" social media.\n\nTopic: {topic}\n\n### ORIGINAL ###\n{original}"
+                ),
+            },
+        ],
+        temperature=0.7,
+    )
+    return rsp.choices[0].message.content.strip()
+
+
+# ------------------ Supabase 핸들러 ------------------ #
+def _get_client():
+    """Return a lazily imported Supabase client using env vars."""
+    if not (SUPABASE_URL and SUPABASE_KEY):
+        raise EnvironmentError("Supabase env vars not set")
+    from supabase import create_client  # import here to avoid hard dependency in tests
+
+    return create_client(SUPABASE_URL, SUPABASE_KEY)
+
+
+def fetch_low_performers(table: str, threshold: float) -> List[Dict[str, Any]]:
+    """가져오기: KPI가 threshold 이하 & 아직 리라이팅 안 된 레코드."""
+    supa = _get_client()
+    res = (
+        supa.table(table)
+        .select("*")
+        .lte(LOW_SCORE_FIELD, threshold)
+        .is_(REWRITE_FLAG_FIELD, False)
+        .execute()
+    )
+    return res.data or []
+
+
+def update_rewritten_row(table: str, row_id: Any, new_content: str):
+    """Supabase row 업데이트 + rewrite 플래그."""
+    supa = _get_client()
+    supa.table(table).update(
+        {
+            "content": new_content,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+            REWRITE_FLAG_FIELD: True,
+        }
+    ).eq("id", row_id).execute()
+
+
+# ----------------------- 메인 ------------------------ #
+def rewrite_batch(table: str, threshold: float, topic_field: str = "topic"):
+    """Fetch → GPT rewrite → update 루프."""
+    targets = fetch_low_performers(table, threshold)
+    if not targets:
+        print("🎉 No low performers found.")
+        return
+    print(f"🔧 Rewriting {len(targets)} item(s)...")
+
+    for item in targets:
+        new_content = _ask_gpt(item["content"], item.get(topic_field, "general"))
+        update_rewritten_row(table, item["id"], new_content)
+        print(f"✅ Row {item['id']} rewritten.")
+
+
+def _cli():
+    parser = argparse.ArgumentParser(description="Auto rewrite poor-performing content")
+    parser.add_argument("--table", required=True, help="Supabase table name")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.3,
+        help="KPI threshold (<= triggers rewrite)",
+    )
+    args = parser.parse_args()
+    rewrite_batch(args.table, args.threshold)
+
+
+if __name__ == "__main__":
+    _cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+supabase-py>=2.0

--- a/tests/test_auto_rewriter.py
+++ b/tests/test_auto_rewriter.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock, patch
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import auto_rewriter as ar
+
+
+def test_fetch_low_performers():
+    mock_client = MagicMock()
+    mock_client.table.return_value.select.return_value.lte.return_value.is_.return_value.execute.return_value.data = [
+        {"id": 1, "content": "old", "engagement_score": 0.1, "needs_rewrite": False}
+    ]
+    with patch("auto_rewriter._get_client", return_value=mock_client):
+        rows = ar.fetch_low_performers("content", 0.3)
+    assert rows and rows[0]["id"] == 1
+
+
+def test_rewrite_batch(monkeypatch):
+    """GPT 호출·Supabase 업데이트가 모두 불리는지 확인."""
+    monkeypatch.setattr(
+        "auto_rewriter.fetch_low_performers",
+        lambda table, threshold: [{"id": 99, "content": "hello", "topic": "test"}],
+    )
+    monkeypatch.setattr("auto_rewriter._ask_gpt", lambda txt, topic: "new")
+    updated = {}
+
+    def _mock_update(table, row_id, new_content):
+        updated["row_id"] = row_id
+        updated["content"] = new_content
+
+    monkeypatch.setattr("auto_rewriter.update_rewritten_row", _mock_update)
+    ar.rewrite_batch("content", 0.3)
+    assert updated["content"] == "new" and updated["row_id"] == 99


### PR DESCRIPTION
## Summary
- implement `auto_rewriter.py` module for rewriting low performance content
- add unit tests for `auto_rewriter`
- document usage with Mermaid flow in `README.md`
- add Supabase client requirement

## Testing
- `pytest -q`
- `pylint auto_rewriter.py tests/test_auto_rewriter.py` *(fails: import-error openai, supabase)*
- `mypy auto_rewriter.py tests/test_auto_rewriter.py` *(fails: missing imports openai, supabase)*

------
https://chatgpt.com/codex/tasks/task_e_684f18f83464832eafd37bb15afdd877