### PR TITLE
Add logs directory creation before logging setup

### DIFF
--- a/hook_generator.py
+++ b/hook_generator.py
@@ -17,6 +17,7 @@ API_DELAY = float(os.getenv("API_DELAY", "1.0"))
 openai.api_key = OPENAI_API_KEY
 
 # ---------------------- 로깅 설정 ----------------------
+os.makedirs("logs", exist_ok=True)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
 
 # ---------------------- GPT 프롬프트 생성 함수 ----------------------

--- a/keyword_auto_pipeline.py
+++ b/keyword_auto_pipeline.py
@@ -19,6 +19,7 @@ TWITTER_MIN_TOP_RETWEET = 50
 MIN_CPC = 1000  # 원 (더미 기준)
 
 # ---------------------- 로깅 설정 ----------------------
+os.makedirs("logs", exist_ok=True)
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s %(levelname)s:%(message)s'

--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -16,6 +16,7 @@ FAILED_OUTPUT_PATH = "data/upload_failed_hooks.json"
 UPLOAD_DELAY = float(os.getenv("UPLOAD_DELAY", "0.5"))
 
 notion = Client(auth=NOTION_TOKEN)
+os.makedirs("logs", exist_ok=True)
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s %(levelname)s:%(message)s',

--- a/retry_dashboard_notifier.py
+++ b/retry_dashboard_notifier.py
@@ -11,6 +11,7 @@ NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_KPI_DB_ID = os.getenv("NOTION_KPI_DB_ID")
 SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
 
+os.makedirs("logs", exist_ok=True)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
 
 # ---------------------- Notion 클라이언트 ----------------------

--- a/retry_failed_uploads.py
+++ b/retry_failed_uploads.py
@@ -13,6 +13,7 @@ NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
 FAILED_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
 RETRY_DELAY = float(os.getenv("RETRY_DELAY", "0.5"))
 
+os.makedirs("logs", exist_ok=True)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
 
 # ---------------------- Notion 클라이언트 ----------------------

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -5,6 +5,7 @@ import os
 from datetime import datetime
 
 # ---------------------- 로깅 설정 ----------------------
+os.makedirs("logs", exist_ok=True)
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s %(levelname)s:%(message)s'

--- a/scripts/notion_uploader.py
+++ b/scripts/notion_uploader.py
@@ -16,6 +16,7 @@ CACHE_PATH = os.getenv("UPLOADED_CACHE_PATH", "data/uploaded_keywords_cache.json
 FAILED_PATH = os.getenv("FAILED_UPLOADS_PATH", "logs/failed_uploads.json")
 
 # ---------------------- 로깅 설정 ----------------------
+os.makedirs("logs", exist_ok=True)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
 
 # ---------------------- Notion 클라이언트 ----------------------

--- a/scripts/retry_failed_uploads.py
+++ b/scripts/retry_failed_uploads.py
@@ -13,6 +13,7 @@ NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
 FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_keywords.json")
 RETRY_DELAY = float(os.getenv("RETRY_DELAY", "0.5"))
 
+os.makedirs("logs", exist_ok=True)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
 
 # ---------------------- Notion 클라이언트 ----------------------


### PR DESCRIPTION
## Summary
- ensure scripts create `logs/` before setting up logging

## Testing
- `pytest -q`
- `flake8` *(fails: E501 line too long and other style issues)*

------
https://chatgpt.com/codex/tasks/task_e_684f193b5dd0832eb83e8bae01659d43