### PR TITLE
Fix pipeline script path handling

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Auto Pipeline
+
+This repository contains automation scripts used for generating and uploading Notion hooks. The main entry point is `run_pipeline.py` which sequentially executes several helper scripts.
+
+## Running Locally
+
+```bash
+python run_pipeline.py
+```
+
+`run_pipeline.py` automatically looks for each pipeline script both in the repository root and in the `scripts/` directory so you can place your scripts in either location.
+
+## GitHub Actions
+
+The daily pipeline workflow executes `run_pipeline.py` directly. See `.github/workflows/daily-pipeline.yml.txt` for details.

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import os
 from datetime import datetime
+from pathlib import Path
 
 # ---------------------- 로깅 설정 ----------------------
 logging.basicConfig(
@@ -20,10 +21,21 @@ PIPELINE_SEQUENCE = [
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
-def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+ROOT_DIR = Path(__file__).parent.resolve()
+SEARCH_DIRS = [ROOT_DIR, ROOT_DIR / "scripts"]
+
+
+def run_script(script: str) -> bool:
+    """Execute a pipeline script regardless of its location."""
+    full_path = None
+    for directory in SEARCH_DIRS:
+        candidate = directory / script
+        if candidate.exists():
+            full_path = candidate
+            break
+
+    if full_path is None:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- allow `run_script` to locate files in root or `scripts/` automatically
- call `run_pipeline.py` directly in the workflow
- document script locations and usage in new README

## Testing
- `pytest`
- `pylint run_pipeline.py` *(fails: missing docstrings, warnings)*
- `mypy run_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684f193c3880832e92022ef96f366f9e