### PR TITLE
Fix script lookup and update workflow

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 logs/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Auto Pipeline
+
+This repository contains a collection of utility scripts used to generate and upload
+content to Notion. The main entry point is `run_pipeline.py` which sequentially
+executes a list of scripts.
+
+## Running the Pipeline
+
+```bash
+python run_pipeline.py
+```
+
+The runner searches for each script in both the repository root and the
+`scripts/` directory, so you can keep helper utilities in either location.
+
+## GitHub Workflow
+
+The daily scheduled workflow in `.github/workflows/daily-pipeline.yml.txt`
+invokes `python run_pipeline.py` to execute the full pipeline on GitHub
+Actions.

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -21,12 +21,19 @@ PIPELINE_SEQUENCE = [
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    # Look for the script first inside the scripts directory
+    candidate_paths = [os.path.join("scripts", script), script]
+    full_path = None
+    for path in candidate_paths:
+        if os.path.exists(path):
+            full_path = path
+            break
+
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
-    logging.info(f"🚀 실행 중: {script}")
+    logging.info(f"🚀 실행 중: {full_path}")
     result = subprocess.run([sys.executable, full_path], capture_output=True, text=True)
 
     if result.returncode != 0:


### PR DESCRIPTION
## Summary
- support scripts in repo root or `scripts/` folder
- update workflow to use `run_pipeline.py` in repo root
- document pipeline usage in new README
- ignore `__pycache__` artifacts

## Testing
- `python -m py_compile run_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_684f1a49c360832ead4480346b71501e