### PR TITLE
Fix pipeline script list

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,9 +13,7 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
     "retry_dashboard_notifier.py"
 ]
 
@@ -23,8 +21,12 @@ PIPELINE_SEQUENCE = [
 def run_script(script):
     full_path = os.path.join("scripts", script)
     if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
-        return False
+        alt_path = script
+        if os.path.exists(alt_path):
+            full_path = alt_path
+        else:
+            logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+            return False
 
     logging.info(f"🚀 실행 중: {script}")
     result = subprocess.run([sys.executable, full_path], capture_output=True, text=True)


### PR DESCRIPTION
## Summary
- remove references to missing scripts from `PIPELINE_SEQUENCE`
- allow `run_script` to locate files either in `scripts/` or project root

## Testing
- `mypy run_pipeline.py`
- `pylint run_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684f1a4d7084832ebeb7f2da2617227f