### PR TITLE
Fix pytrends usage per thread

### DIFF
--- a/keyword_auto_pipeline.py
+++ b/keyword_auto_pipeline.py
@@ -128,7 +128,8 @@ def filter_keywords(entries):
     return filtered
 
 # ---------------------- 키워드별 수집 작업 ----------------------
-def collect_data_for_keyword(keyword, pytrends):
+def collect_data_for_keyword(keyword):
+    pytrends = TrendReq(hl='ko', tz=540)
     results = []
     try:
         gtrend = fetch_google_trends(keyword, pytrends)
@@ -149,11 +150,10 @@ def collect_data_for_keyword(keyword, pytrends):
 # ---------------------- 메인 파이프라인 ----------------------
 def run_pipeline():
     keywords = generate_keyword_pairs(TOPIC_DETAILS)
-    pytrends = TrendReq(hl='ko', tz=540)
     all_results = []
 
     with ThreadPoolExecutor(max_workers=10) as executor:
-        futures = {executor.submit(collect_data_for_keyword, kw, pytrends): kw for kw in keywords}
+        futures = {executor.submit(collect_data_for_keyword, kw): kw for kw in keywords}
 
         for future in as_completed(futures):
             kw = futures[future]


### PR DESCRIPTION
## Summary
- ensure each thread creates its own `TrendReq`
- simplify thread pool calls

## Testing
- `pylint keyword_auto_pipeline.py`
- `mypy --ignore-missing-imports keyword_auto_pipeline.py`
- `python -m compileall keyword_auto_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684f1a4c2e78832e89dbf025e73d7c75