### PR TITLE
Add Auto Insight module with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Weekly Insight CI
+
+on:
+  schedule:
+    - cron: "0 8 * * MON"
+
+jobs:
+  weekly-insight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - run: python auto_insight.py --table content --days 7 --notion-db ${{ secrets.NOTION_DB_ID }}
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+## auto_insight 사용법
+
+```bash
+export SUPABASE_URL=... SUPABASE_ANON_KEY=...
+export OPENAI_API_KEY=...
+export NOTION_TOKEN="secret_xxx"
+python auto_insight.py --table content --days 7 --notion-db YOUR_DB_ID
+```
+
+```mermaid
+flowchart TD
+    A[Pull last N-days rows<br/>from Supabase] --> B[Compute stats (pandas)]
+    B --> C[GPT-4o executive summary]
+    C --> D[Create Notion page<br/>with props + text]
+```

--- a/auto_insight.py
+++ b/auto_insight.py
@@ -1,0 +1,122 @@
+"""
+Aggregate performance metrics from Supabase → GPT-4o summary →
+publish to Notion database as a new Page.
+
+CLI:
+    python auto_insight.py --table content --days 7 --notion-db MY_DB_ID
+"""
+
+from __future__ import annotations
+
+import os
+import argparse
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List
+
+import openai
+import pandas as pd
+from notion_client import Client as Notion
+from supabase import create_client
+
+
+# ------------------ ENVIRONMENT ------------------ #
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_KEY = os.getenv("SUPABASE_ANON_KEY")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+NOTION_TOKEN = os.getenv("NOTION_TOKEN")
+
+MODEL = "gpt-4o"
+METRIC_FIELD = "engagement_score"
+
+
+# ------------------ DATA LAYER ------------------- #
+def _get_supa():
+    if not (SUPABASE_URL and SUPABASE_KEY):
+        raise EnvironmentError("Supabase env vars missing")
+    return create_client(SUPABASE_URL, SUPABASE_KEY)
+
+
+def fetch_range(table: str, days: int) -> pd.DataFrame:
+    """Fetch last `days` of content rows into DataFrame."""
+    since = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+    data = (
+        _get_supa()
+        .table(table)
+        .select("*")
+        .gte("created_at", since)
+        .execute()
+        .data
+    )
+    return pd.DataFrame(data or [])
+
+
+# ------------------ ANALYTICS -------------------- #
+def summarize_metrics(df: pd.DataFrame) -> Dict[str, Any]:
+    """Compute basic stats for METRIC_FIELD."""
+    if df.empty:
+        return {"count": 0}
+    metric = df[METRIC_FIELD].astype(float)
+    return {
+        "count": len(metric),
+        "avg": float(metric.mean()),
+        "median": float(metric.median()),
+        "p90": float(metric.quantile(0.9)),
+        "best_id": int(df.loc[metric.idxmax()]["id"]),
+        "worst_id": int(df.loc[metric.idxmin()]["id"]),
+    }
+
+
+def gpt_insight(stats: Dict[str, Any], horizon: int) -> str:
+    """Return text insight from GPT."""
+    prompt = (
+        "You are a senior growth analyst. Based on the stats and time horizon,"
+        " write a concise (~150 words) executive insight with one actionable tip."
+        f"\n\nHORIZON_DAYS={horizon}\nSTATS={stats}"
+    )
+    rsp = openai.ChatCompletion.create(
+        model=MODEL,
+        api_key=OPENAI_API_KEY,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.2,
+    )
+    return rsp.choices[0].message.content.strip()
+
+
+# ------------------ NOTION ----------------------- #
+def notion_publish(db_id: str, title: str, text: str, stats: Dict[str, Any]):
+    notion = Notion(auth=NOTION_TOKEN)
+    props = {
+        "Name": {"title": [{"text": {"content": title}}]},
+        "Count": {"number": stats.get("count", 0)},
+        "Avg": {"number": stats.get("avg")},
+        "Median": {"number": stats.get("median")},
+        "p90": {"number": stats.get("p90")},
+    }
+    notion.pages.create(
+        parent={"database_id": db_id},
+        properties=props,
+        children=[{"object": "block", "type": "paragraph", "paragraph": {"text": [{"type": "text", "text": {"content": text}}]}}],
+    )
+
+
+# ------------------ MAIN ------------------------- #
+def generate_insight(table: str, days: int, notion_db: str):
+    df = fetch_range(table, days)
+    stats = summarize_metrics(df)
+    insight = gpt_insight(stats, days)
+    title = f"Insight {datetime.now().strftime('%Y-%m-%d')}"
+    notion_publish(notion_db, title, insight, stats)
+    print(f"\u2705 Notion page created: {title}")
+
+
+def _cli():
+    parser = argparse.ArgumentParser(description="Generate weekly insight")
+    parser.add_argument("--table", required=True)
+    parser.add_argument("--days", type=int, default=7)
+    parser.add_argument("--notion-db", required=True)
+    args = parser.parse_args()
+    generate_insight(args.table, args.days, args.notion_db)
+
+
+if __name__ == "__main__":
+    _cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas>=2.2
+notion-client>=2.2

--- a/tests/test_auto_insight.py
+++ b/tests/test_auto_insight.py
@@ -1,0 +1,37 @@
+from unittest.mock import MagicMock, patch
+
+import auto_insight as ai
+
+
+def test_summarize_metrics():
+    import pandas as pd
+
+    df = pd.DataFrame(
+        [
+            {"id": 1, "engagement_score": 0.1},
+            {"id": 2, "engagement_score": 0.9},
+        ]
+    )
+    stats = ai.summarize_metrics(df)
+    assert stats["avg"] == 0.5 and stats["count"] == 2
+
+
+def test_generate_insight(monkeypatch):
+    # mock data fetch
+    monkeypatch.setattr(
+        "auto_insight.fetch_range",
+        lambda table, days: __import__("pandas").DataFrame(
+            [{"id": 1, "engagement_score": 0.4}]
+        ),
+    )
+    # mock GPT
+    monkeypatch.setattr("auto_insight.gpt_insight", lambda stats, horizon: "INSIGHT")
+    created = {}
+
+    def _mock_publish(db_id, title, text, stats):
+        created["title"] = title
+        created["text"] = text
+
+    monkeypatch.setattr("auto_insight.notion_publish", _mock_publish)
+    ai.generate_insight("content", 7, "fake_db")
+    assert created["text"] == "INSIGHT"


### PR DESCRIPTION
## Summary
- add `auto_insight.py` CLI module to fetch Supabase metrics, summarize with GPT-4o, and publish to Notion
- include tests for data summarization and page generation logic
- document usage and flow chart
- specify pandas and notion-client deps
- add weekly insight GitHub Actions workflow

## Testing
- `python -m pytest -q`
- `pylint auto_insight.py`

------
https://chatgpt.com/codex/tasks/task_e_684f1a2e495c832e8c781d85cbda0d6d