### PR TITLE
Add Python CI workflow and tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E501,E302,E305,E129,W391,F401,W504,W292
+max-line-length = 120

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Lint with flake8
+        run: flake8 .
+
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=.
+          coverage xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Security check
+        run: |
+          pip install safety
+          safety check
+
+      - name: Build docs
+        run: |
+          pip install sphinx
+          if [ -d docs ]; then cd docs && make html; fi
+
+      - name: Archive build artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 .env
 logs/
+__pycache__/
+*.pyc
+.coverage
+coverage.xml
+dist/
+*.egg-info/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+pytest>=7.0.0
+pytest-cov>=4.0.0
+flake8>=6.0.0
+safety>=2.3.5
+sphinx>=7.0.0
+python-dotenv>=1.0.0
+openai>=1.14.3

--- a/tests/test_hook_generator.py
+++ b/tests/test_hook_generator.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from hook_generator import generate_hook_prompt  # noqa: E402
+
+
+def test_generate_hook_prompt_basic():
+    keyword = '테스트 키워드'
+    prompt = generate_hook_prompt(keyword, '주제', '출처', 5, 1.2, 100)
+    assert keyword in prompt
+    assert '주제:' in prompt
+


### PR DESCRIPTION
## Summary
- set up Python CI workflow with flake8, pytest coverage and Codecov
- add basic unit test for hook prompt generator
- include development dependencies in requirements
- configure flake8 rules and ignore patterns
- expand `.gitignore`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f29832854832e9c0d513f795942ec