### PR TITLE
Add dynamic pipeline orchestration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - run: pytest -q
+
+  run-pipeline:
+    runs-on: ubuntu-latest
+    # 수동 트리거 & 매일 새벽 03:00 UTC 실행
+    workflow_dispatch:
+    schedule:
+      - cron: "0 3 * * *"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - run: python run_pipeline.py --config pipeline_config
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Auto Pipeline
+
+## run_pipeline 사용법
+
+```bash
+python run_pipeline.py --config pipeline_config
+```
+
+```mermaid
+flowchart TD
+    A[Load cfg + validate] --> B[Iterate PIPELINE_ORDER]
+    B --> C{step success?}
+    C --yes--> D[Structured log OK]
+    C --no --> E[Add to failures<br/>Structured log error]
+    D & E --> F{last step?}
+    F --no--> B
+    F --yes--> G[Run NOTIFIER_STEP<br/>with failures list]
+    G --> H[Exit 0/1]
+```

--- a/pipeline_config.py
+++ b/pipeline_config.py
@@ -1,0 +1,16 @@
+"""
+파이프라인 단계 정의.
+각 이름은 import 가능한 모듈이어야 하며, 모듈 안에 `main()` 함수가 존재해야 합니다.
+"""
+
+PIPELINE_ORDER = [
+    "cursor_chunk_doc_gen",
+    "auto_rewriter",
+    "qa_tester",
+    "auto_insight",
+    "hook_uploader",
+]
+
+# 모든 단계 완료 후 항상 실행할 알림/후처리 스텝 (선택)
+# 모듈에 `main(failures: list[str])` 시그니처 필요
+NOTIFIER_STEP = "retry_dashboard_notifier"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-json-logger>=2.0
+slack_sdk>=3.21

--- a/retry_dashboard_notifier.py
+++ b/retry_dashboard_notifier.py
@@ -1,67 +1,18 @@
+"""
+예시: 실패 단계 목록을 슬랙 대시보드로 보내 재시도 트리거.
+"""
+
+from __future__ import annotations
+
 import os
-import json
-import logging
-from datetime import datetime
-from notion_client import Client
-from dotenv import load_dotenv
+from slack_sdk.webhook import WebhookClient
 
-# ---------------------- 설정 로딩 ----------------------
-load_dotenv()
-NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
-NOTION_KPI_DB_ID = os.getenv("NOTION_KPI_DB_ID")
-SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+_WEBHOOK = WebhookClient(os.getenv("SLACK_WEBHOOK_URL", ""))
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
 
-# ---------------------- Notion 클라이언트 ----------------------
-if not NOTION_TOKEN or not NOTION_KPI_DB_ID:
-    logging.error("❗ 환경 변수(NOTION_API_TOKEN, NOTION_KPI_DB_ID)가 누락되었습니다.")
-    exit(1)
-notion = Client(auth=NOTION_TOKEN)
-
-# ---------------------- KPI 데이터 수집 ----------------------
-def get_retry_stats():
-    if not os.path.exists(SUMMARY_PATH):
-        logging.error(f"❌ 재시도 데이터 파일이 없습니다: {SUMMARY_PATH}")
-        return None
-
-    with open(SUMMARY_PATH, 'r', encoding='utf-8') as f:
-        data = json.load(f)
-
-    total = len(data)
-    failed = len([d for d in data if d.get("retry_error")])
-    success = total - failed
-    rate = round((success / total) * 100, 1) if total > 0 else 0.0
-
-    now = datetime.now()
-    return {
-        "date": now,
-        "total": total,
-        "success": success,
-        "failed": failed,
-        "rate": rate
-    }
-
-# ---------------------- Notion KPI 행 추가 ----------------------
-def push_kpi_to_notion(kpi):
-    try:
-        notion.pages.create(
-            parent={"database_id": NOTION_KPI_DB_ID},
-            properties={
-                "날짜": {"date": {"start": kpi["date"].isoformat()}},
-                "전체 시도": {"number": kpi["total"]},
-                "성공": {"number": kpi["success"]},
-                "실패": {"number": kpi["failed"]},
-                "성공률(%)": {"number": kpi["rate"]}
-            }
-        )
-        logging.info("📊 Notion KPI 업데이트 완료")
-    except Exception as e:
-        logging.error(f"❌ Notion KPI 전송 실패: {e}")
-
-# ---------------------- 실행 진입점 ----------------------
-if __name__ == "__main__":
-    kpi = get_retry_stats()
-    if kpi:
-        logging.info(f"📈 KPI 요약: {kpi}")
-        push_kpi_to_notion(kpi)
+def main(failures: list[str]):
+    if not failures or not _WEBHOOK.url:
+        return
+    _WEBHOOK.send(
+        text=f":warning: Pipeline failures: {', '.join(failures)}",
+    )

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,61 +1,95 @@
+"""
+Dynamic pipeline runner with structured JSON logging, fail-fast check,
+and graceful teardown.
+
+CLI:
+    python run_pipeline.py --config pipeline_config
+"""
+
+from __future__ import annotations
+
+import importlib
 import logging
-import subprocess
 import sys
-import os
-from datetime import datetime
+from argparse import ArgumentParser
+from types import ModuleType
+from typing import List, Optional
 
-# ---------------------- 로깅 설정 ----------------------
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s %(levelname)s:%(message)s'
+from pythonjsonlogger import jsonlogger
+
+_LOG = logging.getLogger("pipeline")
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(
+    jsonlogger.JsonFormatter("%(asctime)s %(levelname)s %(name)s %(message)s")
 )
+_LOG.addHandler(handler)
+_LOG.setLevel(logging.INFO)
 
-# ---------------------- 실행할 스크립트 순서 정의 ----------------------
-PIPELINE_SEQUENCE = [
-    "hook_generator.py",
-    "parse_failed_gpt.py",
-    "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
-]
 
-# ---------------------- 스크립트 실행 함수 ----------------------
-def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
-        return False
+def _load_config(path: str) -> ModuleType:
+    if path.endswith(".py"):
+        path = path[:-3]
+    return importlib.import_module(path.replace("/", ".").rstrip(".py"))
 
-    logging.info(f"🚀 실행 중: {script}")
-    result = subprocess.run([sys.executable, full_path], capture_output=True, text=True)
 
-    if result.returncode != 0:
-        logging.error(f"❌ 실패: {script}\n{result.stderr}")
-        return False
-    else:
-        logging.info(f"✅ 완료: {script}")
-        if result.stdout.strip():
-            print(result.stdout)
-        return True
+def _validate_steps(cfg: ModuleType):
+    if not hasattr(cfg, "PIPELINE_ORDER") or not isinstance(cfg.PIPELINE_ORDER, list):
+        raise AttributeError("Config must define list `PIPELINE_ORDER`.")
+    for step in cfg.PIPELINE_ORDER:
+        try:
+            importlib.import_module(step)
+        except ModuleNotFoundError as exc:
+            raise ValueError(f"Unknown step: {step}") from exc
 
-# ---------------------- 전체 파이프라인 실행 ----------------------
-def run_pipeline():
-    logging.info(f"🧩 파이프라인 시작: {datetime.now().strftime('%Y-%m-%d %H:%M')}")
-    all_passed = True
 
-    for script in PIPELINE_SEQUENCE:
-        success = run_script(script)
-        if not success:
-            all_passed = False
-            # 실패해도 계속 실행할 것인지 중단할 것인지 선택 가능
-            # break
+def _run_step(step: str) -> Optional[str]:
+    try:
+        mod = importlib.import_module(step)
+        _LOG.info("step_start", extra={"step": step})
+        if hasattr(mod, "main"):
+            mod.main()
+        else:
+            _LOG.warning("step_no_main", extra={"step": step})
+        _LOG.info("step_success", extra={"step": step})
+        return None
+    except Exception as exc:  # pylint: disable=broad-except
+        _LOG.error("step_fail", extra={"step": step, "error": str(exc)})
+        return step
 
-    logging.info("🎯 파이프라인 전체 완료")
-    if all_passed:
-        logging.info("✅ 모든 단계 성공적으로 완료")
-    else:
-        logging.warning("⚠️ 일부 단계에서 실패 발생")
 
-# ---------------------- 진입점 ----------------------
-if __name__ == "__main__":
-    run_pipeline()
+def _run_notifier(cfg: ModuleType, failures: List[str]):
+    step = getattr(cfg, "NOTIFIER_STEP", None)
+    if not step:
+        return
+    try:
+        mod = importlib.import_module(step)
+        if hasattr(mod, "main"):
+            mod.main(failures)
+            _LOG.info("notifier_success", extra={"step": step, "failures": failures})
+    except Exception as exc:  # pylint: disable=broad-except
+        _LOG.error("notifier_fail", extra={"step": step, "error": str(exc)})
+
+
+def run_pipeline(cfg_path: str) -> int:
+    cfg = _load_config(cfg_path)
+    _validate_steps(cfg)
+
+    failures: List[str] = []
+    for step in cfg.PIPELINE_ORDER:
+        err = _run_step(step)
+        if err:
+            failures.append(err)
+
+    _run_notifier(cfg, failures)
+    return 0 if not failures else 1
+
+
+def _cli():
+    ap = ArgumentParser(description="Run content-automation pipeline")
+    ap.add_argument("--config", default="pipeline_config", help="Config module path")
+    args = ap.parse_args()
+    sys.exit(run_pipeline(args.config))
+
+
+if __name__ == "__main__":  # guard → 임포트 시 부작용 방지
+    _cli()

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -1,0 +1,31 @@
+import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from types import SimpleNamespace
+
+import run_pipeline as rp
+
+
+def test_unknown_step_validation(monkeypatch):
+    cfg = SimpleNamespace(PIPELINE_ORDER=["no_such_module"])
+    monkeypatch.setattr("run_pipeline._load_config", lambda p: cfg)
+    try:
+        rp.run_pipeline("dummy")
+    except ValueError as exc:
+        assert "Unknown step" in str(exc)
+
+
+def test_pipeline_collects_failures(monkeypatch):
+    ok_mod = SimpleNamespace(main=lambda: None)
+    bad_mod = SimpleNamespace(main=lambda: 1 / 0)
+
+    def _import(name):
+        if name == "good":
+            return ok_mod
+        if name == "bad":
+            return bad_mod
+        raise ModuleNotFoundError
+
+    cfg = SimpleNamespace(PIPELINE_ORDER=["good", "bad"], NOTIFIER_STEP=None)
+    monkeypatch.setattr("importlib.import_module", _import)
+    monkeypatch.setattr("run_pipeline._load_config", lambda p: cfg)
+    code = rp.run_pipeline("cfg")
+    assert code == 1


### PR DESCRIPTION
## Summary
- implement new `run_pipeline` dynamic orchestrator
- define `pipeline_config` for modular stages
- send Slack alerts via `retry_dashboard_notifier`
- add unit tests for pipeline behavior
- document pipeline usage with Mermaid diagram
- schedule pipeline run in CI
- add runtime dependencies

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `pylint run_pipeline.py pipeline_config.py retry_dashboard_notifier.py`
- `mypy run_pipeline.py pipeline_config.py retry_dashboard_notifier.py`


------
https://chatgpt.com/codex/tasks/task_e_684f29baa29c832e93a22799712ace41