### PR TITLE
Fix pipeline script paths

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -21,9 +21,17 @@ PIPELINE_SEQUENCE = [
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    """Execute a script from the scripts directory or repository root."""
+    candidate_paths = [os.path.join("scripts", script), script]
+    full_path = None
+    for path in candidate_paths:
+        if os.path.exists(path):
+            full_path = path
+            break
+    if full_path is None:
+        logging.error(
+            f"❌ 파일이 존재하지 않습니다: {candidate_paths[0]} 또는 {candidate_paths[1]}"
+        )
         return False
 
     logging.info(f"🚀 실행 중: {script}")

--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,5 @@
+import logging
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+    logging.info("notify_retry_result placeholder executed")

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,5 @@
+import logging
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+    logging.info("parse_failed_gpt placeholder executed")


### PR DESCRIPTION
## Summary
- search scripts in project root when running pipeline
- point GitHub workflow to run `run_pipeline.py`
- add placeholder `parse_failed_gpt.py`
- add placeholder `notify_retry_result.py`

## Testing
- `python -m py_compile $(find . -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684f2a08a71c832e8e83a4519ef887cd