### PR TITLE
Add requirements and missing scripts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+openai
+notion-client
+python-dotenv
+pytrends
+snscrape
+requests

--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,42 @@
+import os
+import json
+import logging
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+def load_summary():
+    if not os.path.exists(SUMMARY_PATH):
+        logging.error(f"❌ 요약 파일이 없습니다: {SUMMARY_PATH}")
+        return None
+    with open(SUMMARY_PATH, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+def send_slack_message(message: str):
+    if not WEBHOOK_URL:
+        logging.warning("SLACK_WEBHOOK_URL 환경 변수가 설정되지 않았습니다.")
+        return
+    try:
+        resp = requests.post(WEBHOOK_URL, json={"text": message})
+        resp.raise_for_status()
+        logging.info("✅ Slack 알림 전송 완료")
+    except Exception as e:
+        logging.error(f"❌ Slack 알림 실패: {e}")
+
+def notify_result():
+    data = load_summary()
+    if data is None:
+        return
+    total = len(data)
+    failed = len([d for d in data if d.get("retry_error")])
+    success = total - failed
+    message = f"재업로드 결과\n전체: {total}개\n성공: {success}개\n실패: {failed}개"
+    send_slack_message(message)
+
+if __name__ == "__main__":
+    notify_result()

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,38 @@
+import os
+import json
+import logging
+from dotenv import load_dotenv
+from notion_hook_uploader import parse_generated_text
+
+load_dotenv()
+FAILED_HOOK_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+def reparse_failed_hooks():
+    if not os.path.exists(FAILED_HOOK_PATH):
+        logging.error(f"❌ 실패 파일이 없습니다: {FAILED_HOOK_PATH}")
+        return
+
+    with open(FAILED_HOOK_PATH, 'r', encoding='utf-8') as f:
+        items = json.load(f)
+
+    parsed_items = []
+    for item in items:
+        text = item.get("generated_text")
+        if text:
+            parsed = parse_generated_text(text)
+            item["parsed"] = parsed
+        else:
+            item["retry_error"] = "no_generated_text"
+        parsed_items.append(item)
+
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        json.dump(parsed_items, f, ensure_ascii=False, indent=2)
+
+    logging.info(f"✅ 재파싱 결과 저장: {OUTPUT_PATH}")
+
+if __name__ == "__main__":
+    reparse_failed_hooks()


### PR DESCRIPTION
## Summary
- add root `requirements.txt`
- implement `parse_failed_gpt.py` for reparsing failed hooks
- implement `notify_retry_result.py` for Slack notifications

## Testing
- `python -m py_compile scripts/parse_failed_gpt.py scripts/notify_retry_result.py`
- `pytest -q`
- `pylint scripts/parse_failed_gpt.py scripts/notify_retry_result.py` (fails: missing module imports)


------
https://chatgpt.com/codex/tasks/task_e_684f2a095890832eb15afecfc3a9fa33