### PR TITLE
Add infrastructure configs for monitoring and cost optimization

### DIFF
--- a/.github/workflows/opsgenie_alert.yml
+++ b/.github/workflows/opsgenie_alert.yml
@@ -1,0 +1,19 @@
+name: OpsGenie Alert
+
+on:
+  workflow_run:
+    workflows: ["CI Tests"]
+    types: [failure]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send OpsGenie Alert
+        run: |
+          curl -X POST https://api.opsgenie.com/v2/alerts \
+            -H "Authorization: GenieKey $OG_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{"message":"CI 실패","priority":"P3"}'
+        env:
+          OG_KEY: ${{ secrets.OPSGENIE_KEY }}

--- a/cloud/iam-role.yml
+++ b/cloud/iam-role.yml
@@ -1,0 +1,17 @@
+apiVersion: iam/v1
+kind: IAMRole
+metadata:
+  name: lambda-execution-role
+spec:
+  policy:
+    statements:
+      - actions:
+          - "s3:GetObject"
+        resources:
+          - "arn:aws:s3:::my-bucket/*"
+        effect: Allow
+      - actions:
+          - "dynamodb:PutItem"
+        resources:
+          - "arn:aws:dynamodb:us-west-2:123456789012:table/my-table"
+        effect: Allow

--- a/cloud/security-group.yml
+++ b/cloud/security-group.yml
@@ -1,0 +1,14 @@
+apiVersion: securitygroup/v1
+kind: SecurityGroup
+metadata:
+  name: vpc-security-group
+spec:
+  description: "Allow only specific IP ranges"
+  ingress:
+    - cidr: "192.168.0.0/16"
+      protocol: "tcp"
+      portRange: "80,443"
+  egress:
+    - cidr: "0.0.0.0/0"
+      protocol: "tcp"
+      portRange: "80,443"

--- a/connectors/snowflake-sink.json
+++ b/connectors/snowflake-sink.json
@@ -1,0 +1,10 @@
+{
+  "name": "snowflake-sink",
+  "connector.class": "com.snowflake.kafka.connector.SnowflakeSinkConnector",
+  "topics": "vinfinity.events",
+  "tasks.max": "4",
+  "snowflake.url.name": "https://xy12345.snowflakecomputing.com:443",
+  "snowflake.user.name": "user",
+  "snowflake.private.key": "${file:/secrets/sf_key.pem}",
+  "value.converter": "org.apache.kafka.connect.json.JsonConverter"
+}

--- a/k8s/grafana.yml
+++ b/k8s/grafana.yml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+      - name: grafana
+        image: grafana/grafana:7.5.4
+        ports:
+        - containerPort: 3000
+        env:
+          - name: GF_SECURITY_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: grafana-secrets
+                key: admin-password

--- a/k8s/kubecost.yml
+++ b/k8s/kubecost.yml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubecost
+  namespace: cost-management
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubecost
+  template:
+    metadata:
+      labels:
+        app: kubecost
+    spec:
+      containers:
+      - name: kubecost
+        image: kubecost/cost-analyzer:v1.85.0
+        ports:
+        - containerPort: 9090

--- a/k8s/prometheus.yml
+++ b/k8s/prometheus.yml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+      - name: prometheus
+        image: prom/prometheus:v2.34.0
+        ports:
+        - containerPort: 9090
+        volumeMounts:
+          - mountPath: /etc/prometheus/prometheus.yml
+            name: prometheus-config
+            subPath: prometheus.yml
+      volumes:
+        - name: prometheus-config
+          configMap:
+            name: prometheus-config

--- a/k8s/spot-instance-deployment.yml
+++ b/k8s/spot-instance-deployment.yml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spot-instance-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spot-instance
+  template:
+    metadata:
+      labels:
+        app: spot-instance
+    spec:
+      nodeSelector:
+        "kubernetes.io/instance-type": "t3a.medium"
+      containers:
+        - name: nginx
+          image: nginx
+          ports:
+            - containerPort: 80


### PR DESCRIPTION
## Summary
- add Kubernetes manifests for Prometheus, Grafana, Kubecost and spot instance deployment
- define VPC security group and IAM role examples
- include Kafka → Snowflake connector configuration
- send OpsGenie alerts via GitHub Actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f2a41cca8832e92662bc5610e58bf