### PR TITLE
Add requirements and retry pipeline scripts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+openai
+notion-client
+python-dotenv
+pytrends
+snscrape
+requests

--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,51 @@
+import os
+import json
+import logging
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def load_summary():
+    if not os.path.exists(SUMMARY_PATH):
+        logging.warning(f"❗ 요약 파일이 없습니다: {SUMMARY_PATH}")
+        return []
+    with open(SUMMARY_PATH, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def send_slack(total: int, success: int, failed: int):
+    if not WEBHOOK_URL:
+        logging.error("SLACK_WEBHOOK_URL 환경 변수가 설정되지 않았습니다.")
+        return
+    text = f"재업로드 결과 - 총 {total}개 중 성공 {success}개, 실패 {failed}개"
+    try:
+        resp = requests.post(WEBHOOK_URL, json={"text": text})
+        if resp.status_code != 200:
+            logging.error(f"Slack 응답 오류: {resp.status_code} {resp.text}")
+        else:
+            logging.info("Slack 알림 전송 완료")
+    except Exception as e:
+        logging.error(f"Slack 전송 실패: {e}")
+
+
+def notify_retry_result():
+    data = load_summary()
+    if not data:
+        logging.info("요약할 데이터가 없습니다.")
+        return
+
+    total = len(data)
+    failed = len([d for d in data if d.get("retry_error")])
+    success = total - failed
+
+    send_slack(total, success, failed)
+
+
+if __name__ == "__main__":
+    notify_retry_result()

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,38 @@
+import os
+import json
+import logging
+from dotenv import load_dotenv
+from notion_hook_uploader import parse_generated_text
+
+load_dotenv()
+FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_keywords.json")
+OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def parse_failed_gpt():
+    if not os.path.exists(FAILED_PATH):
+        logging.warning(f"❗ 실패 항목 파일이 없습니다: {FAILED_PATH}")
+        return []
+
+    with open(FAILED_PATH, 'r', encoding='utf-8') as f:
+        items = json.load(f)
+
+    reparsed = []
+    for item in items:
+        text = item.get("generated_text", "")
+        item["parsed"] = parse_generated_text(text)
+        reparsed.append(item)
+
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        json.dump(reparsed, f, ensure_ascii=False, indent=2)
+
+    logging.info(f"📄 재파싱 결과 저장 완료: {OUTPUT_PATH}")
+    return reparsed
+
+
+
+if __name__ == "__main__":
+    parse_failed_gpt()


### PR DESCRIPTION
## Summary
- add root-level `requirements.txt`
- implement missing `parse_failed_gpt.py` and `notify_retry_result.py`

## Testing
- `python -m compileall -q .`
- `pylint hook_generator.py run_pipeline.py keyword_auto_pipeline.py retry_failed_uploads.py notion_hook_uploader.py retry_dashboard_notifier.py scripts/notion_uploader.py scripts/retry_failed_uploads.py scripts/parse_failed_gpt.py scripts/notify_retry_result.py`
- `mypy .` *(fails: Duplicate module named "retry_failed_uploads")*
- `sqlfluff lint --dialect postgres '*.sql'` *(fails: specified path does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_684f2a748050832ea251473f00310def