### PR TITLE
Add podcast creator module with CI and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt pytest
+      - run: pytest
+  daily-podcast:
+    runs-on: ubuntu-latest
+    schedule:
+      - cron: "0 6 * * *"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: python podcast_creator.py --table content --limit 5
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          PODCAST_RSS_FILE: "podcast_feed.xml"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+## podcast_creator 사용법
+
+```bash
+export SUPABASE_URL="https://xyz.supabase.co"
+export SUPABASE_ANON_KEY="public-anon-key"
+export PODCAST_RSS_FILE="podcast_feed.xml"
+python podcast_creator.py --table content --limit 5
+```
+
+```mermaid
+flowchart TD
+    A[Fetch pending rows] --> B[Generate MP3 via gTTS]
+    B --> C[Upload to Supabase Storage]
+    C --> D[Append <item> to RSS file]
+    D --> E[Update DB flags + URLs]
+```

--- a/podcast_creator.py
+++ b/podcast_creator.py
@@ -1,0 +1,113 @@
+"""
+Fetch content rows flagged for podcast → generate MP3 via TTS →
+upload to Supabase Storage → append to local RSS feed → mark as done.
+
+Usage (CLI):
+    python podcast_creator.py --table content --limit 5
+"""
+
+import os
+import argparse
+from datetime import datetime, timezone
+from typing import List, Dict
+
+from gtts import gTTS
+from supabase import create_client
+
+
+# ───────────────── 환경변수 ───────────────── #
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_KEY = os.getenv("SUPABASE_ANON_KEY")
+RSS_FILE = os.getenv("PODCAST_RSS_FILE", "podcast_feed.xml")
+BUCKET = "podcasts"
+
+
+def _get_client():
+    if not (SUPABASE_URL and SUPABASE_KEY):
+        raise EnvironmentError("Supabase credentials missing")
+    return create_client(SUPABASE_URL, SUPABASE_KEY)
+
+
+def fetch_pending(table: str, limit: int) -> List[Dict]:
+    """generate_podcast=True & podcast_generated=False rows."""
+    supa = _get_client()
+    res = (
+        supa.table(table)
+        .select("*")
+        .eq("generate_podcast", True)
+        .is_("podcast_generated", False)
+        .limit(limit)
+        .execute()
+    )
+    return res.data or []
+
+
+def generate_audio(text: str, lang: str = "en") -> str:
+    """TTS로 MP3 생성, 로컬 파일명 반환."""
+    fname = f"podcast_{int(datetime.now().timestamp())}.mp3"
+    tts = gTTS(text=text, lang=lang)
+    tts.save(fname)
+    return fname
+
+
+def upload_audio(file_path: str) -> str:
+    """Supabase Storage에 업로드 후 public URL 반환."""
+    supa = _get_client()
+    with open(file_path, "rb") as f:
+        supa.storage.from_(BUCKET).upload(file_path, f)
+    url = supa.storage.from_(BUCKET).get_public_url(file_path)["publicURL"]
+    return url
+
+
+def append_rss(item_id: int, title: str, url: str):
+    """간단한 RSS <item> 블록을 로컬 RSS 파일에 추가."""
+    entry = f"""
+  <item>
+    <guid isPermaLink="false">{item_id}</guid>
+    <title>{title}</title>
+    <link>{url}</link>
+    <pubDate>{datetime.now(timezone.utc).strftime('%a, %d %b %Y %H:%M:%S %z')}</pubDate>
+  </item>
+"""
+    with open(RSS_FILE, "a", encoding="utf-8") as rss:
+        rss.write(entry)
+
+
+def mark_done(table: str, row_id: int, file_name: str, url: str):
+    """DB에 podcast_generated, podcast_url, podcast_id 업데이트."""
+    supa = _get_client()
+    supa.table(table).update(
+        {
+            "podcast_generated": True,
+            "podcast_url": url,
+            "podcast_id": file_name,
+            "podcast_generated_at": datetime.now(timezone.utc).isoformat(),
+        }
+    ).eq("id", row_id).execute()
+
+
+def process_batch(table: str, limit: int):
+    rows = fetch_pending(table, limit)
+    if not rows:
+        print("🎉 No pending podcasts.")
+        return
+
+    for row in rows:
+        print(f"🔊 Generating podcast for row {row['id']}…")
+        file_name = generate_audio(row["content"])
+        url = upload_audio(file_name)
+        append_rss(row["id"], row["title"], url)
+        mark_done(table, row["id"], file_name, url)
+        print(f"✅ Podcast created → {url}")
+
+
+def _cli():
+    p = argparse.ArgumentParser(description="Auto podcast generator")
+    p.add_argument("--table", required=True, help="Supabase table name")
+    p.add_argument("--limit", type=int, default=5)
+    args = p.parse_args()
+    process_batch(args.table, args.limit)
+
+
+if __name__ == "__main__":
+    _cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+gTTS>=2.3
+supabase>=2.0

--- a/tests/test_podcast_creator.py
+++ b/tests/test_podcast_creator.py
@@ -1,0 +1,39 @@
+import importlib
+from unittest.mock import MagicMock
+
+
+def test_fetch_pending(monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "url")
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "key")
+    monkeypatch.setenv("PODCAST_RSS_FILE", "tmp.xml")
+    import podcast_creator as pc
+    importlib.reload(pc)
+    mock_supa = MagicMock()
+    mock_supa.table.return_value.select.return_value.eq.return_value.is_.return_value.limit.return_value.execute.return_value.data = [
+        {"id": 1, "content": "Hello", "title": "Test", "generate_podcast": True, "podcast_generated": False}
+    ]
+    monkeypatch.setattr("podcast_creator._get_client", lambda: mock_supa)
+    rows = pc.fetch_pending("content", 1)
+    assert rows and rows[0]["id"] == 1
+
+
+def test_process_batch(monkeypatch, tmp_path):
+    monkeypatch.setenv("SUPABASE_URL", "url")
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "key")
+    rss_file = tmp_path/"rss.xml"
+    monkeypatch.setenv("PODCAST_RSS_FILE", str(rss_file))
+    import podcast_creator as pc
+    importlib.reload(pc)
+    # mock fetch
+    monkeypatch.setattr("podcast_creator.fetch_pending", lambda t, l: [{"id": 2, "content": "Hi", "title": "T"}])
+    # mock TTS & upload
+    audio_path = tmp_path/"f.mp3"
+    audio_path.write_bytes(b"test")
+    monkeypatch.setattr("podcast_creator.generate_audio", lambda text: str(audio_path))
+    mock_supa = MagicMock()
+    mock_supa.storage.from_.return_value.get_public_url.return_value = {"publicURL": "http://audio.mp3"}
+    mock_supa.storage.from_.return_value.upload.return_value = None
+    monkeypatch.setattr("podcast_creator._get_client", lambda: mock_supa)
+    # mock append_rss to file
+    pc.process_batch("content", 1)
+    assert rss_file.exists()


### PR DESCRIPTION
## Summary
- implement `podcast_creator.py` for automated TTS podcast generation
- create tests verifying pending-fetch and batch processing
- document podcast creator usage and flow diagram
- add requirements and CI workflow including daily podcast job

## Testing
- `python -m pytest -q`
- `pylint podcast_creator.py tests/test_podcast_creator.py`
- `mypy --ignore-missing-imports podcast_creator.py tests/test_podcast_creator.py`


------
https://chatgpt.com/codex/tasks/task_e_684f384f5fac832eada6677734329c76