### PR TITLE
Fix pipeline script paths

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -21,9 +21,17 @@ PIPELINE_SEQUENCE = [
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    # 먼저 루트 디렉터리에서 스크립트를 찾고, 없으면 scripts/ 에서 찾는다.
+    candidates = [script, os.path.join("scripts", script)]
+    full_path = None
+
+    for path in candidates:
+        if os.path.exists(path):
+            full_path = path
+            break
+
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- resolve run_pipeline script discovery across root and scripts folder
- invoke run_pipeline.py from repository root in scheduled workflow

## Testing
- `python -m py_compile run_pipeline.py`
- `pylint run_pipeline.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f38bf2834832e84c8631be454a4bc