### PR TITLE
Add graphic_generator with daily job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: pytest
+
+  daily-graphic:
+    runs-on: ubuntu-latest
+    schedule:
+      - cron: "0 2 * * *"   # \ub9e4\uc77c 02:00 UTC
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - run: python graphic_generator.py --table content --limit 5
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+## graphic_generator \uc0ac\uc6a9\ubc95
+
+```bash
+export OPENAI_API_KEY="sk-..."
+export SUPABASE_URL="https://xyz.supabase.co"
+export SUPABASE_ANON_KEY="public-anon-key"
+python graphic_generator.py --table content --limit 5
+```
+
+Flow
+```mermaid
+flowchart TD
+    A[Fetch pending rows] --> B[Prompt DALL\xb7E for infographic]
+    B --> C[Download image bytes]
+    C --> D[Upload to Supabase Storage]
+    D --> E[Update DB with graphic_url + flag]
+```

--- a/graphic_generator.py
+++ b/graphic_generator.py
@@ -1,0 +1,120 @@
+"""
+Fetch content rows flagged for graphic creation \u2192 generate infographic via DALL\xb7E \u2192
+download & upload to Supabase Storage \u2192 update DB with graphic_url.
+
+Usage (CLI):
+    python graphic_generator.py --table content --limit 5
+"""
+
+import os
+import argparse
+import requests
+from io import BytesIO
+from datetime import datetime, timezone
+from typing import List, Dict
+
+import openai
+from PIL import Image
+from supabase import create_client
+
+# \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 \ud658\uacbd\ubcc0\uc218 \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 \nOPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+SUPABASE_URL    = os.getenv("SUPABASE_URL")
+SUPABASE_KEY    = os.getenv("SUPABASE_ANON_KEY")
+GRAPHIC_BUCKET  = "graphics"
+
+# \ud544\ub4dc\uba85
+FIELD_ID             = "id"
+FIELD_CONTENT        = "content"
+FIELD_TITLE          = "title"
+FIELD_GEN_GRAPHIC    = "generate_graphic"
+FIELD_GRAPHIC_DONE   = "graphic_generated"
+FIELD_GRAPHIC_URL    = "graphic_url"
+
+
+def _get_client():
+    if not (SUPABASE_URL and SUPABASE_KEY):
+        raise EnvironmentError("Supabase credentials missing")
+    return create_client(SUPABASE_URL, SUPABASE_KEY)
+
+
+def fetch_pending(table: str, limit: int) -> List[Dict]:
+    """generate_graphic=True & graphic_generated=False rows."""
+    supa = _get_client()
+    res = (
+        supa.table(table)
+        .select("*")
+        .eq(FIELD_GEN_GRAPHIC, True)
+        .is_(FIELD_GRAPHIC_DONE, False)
+        .limit(limit)
+        .execute()
+    )
+    return res.data or []
+
+
+def generate_image(prompt: str, size: str = "512x512") -> str:
+    """Call DALL\xb7E to generate an image, return URL."""
+    openai.api_key = OPENAI_API_KEY
+    resp = openai.Image.create(
+        prompt=prompt,
+        n=1,
+        size=size
+    )
+    return resp["data"][0]["url"]
+
+
+def download_image(url: str) -> BytesIO:
+    """Download image bytes."""
+    r = requests.get(url, timeout=30)
+    r.raise_for_status()
+    return BytesIO(r.content)
+
+
+def upload_to_storage(file_bytes: BytesIO, filename: str) -> str:
+    """Upload image to Supabase Storage, return public URL."""
+    supa = _get_client()
+    # reset cursor
+    file_bytes.seek(0)
+    supa.storage.from_(GRAPHIC_BUCKET).upload(filename, file_bytes)
+    return supa.storage.from_(GRAPHIC_BUCKET).get_public_url(filename)["publicURL"]
+
+
+def update_row(table: str, row_id: int, url: str):
+    """Mark row with graphic_url and graphic_generated flag."""
+    supa = _get_client()
+    supa.table(table).update({
+        FIELD_GRAPHIC_URL: url,
+        FIELD_GRAPHIC_DONE: True,
+        "graphic_generated_at": datetime.now(timezone.utc).isoformat(),
+    }).eq(FIELD_ID, row_id).execute()
+
+
+def process_batch(table: str, limit: int):
+    rows = fetch_pending(table, limit)
+    if not rows:
+        print("\ud83c\udf89 No graphics to generate.")
+        return
+
+    for row in rows:
+        vid = row[FIELD_ID]
+        title = row.get(FIELD_TITLE, "") or ""
+        snippet = row[FIELD_CONTENT][:100]  # \uc694\uc57d\uc6a9 \ud14d\uc2a4\ud2b8
+        prompt = f"Create an infographic summarizing the following:\nTitle: {title}\nContent: {snippet}..."
+        print(f"\ud83c\udfa8 Generating graphic for row {vid}\u2026")
+        img_url = generate_image(prompt)
+        img_bytes = download_image(img_url)
+        fname = f"graphic_{vid}_{int(datetime.now().timestamp())}.png"
+        public_url = upload_to_storage(img_bytes, fname)
+        update_row(table, vid, public_url)
+        print(f"\u2705 Row {vid} graphic uploaded \u2192 {public_url}")
+
+
+def _cli():
+    p = argparse.ArgumentParser(description="Auto graphic (infographic) generator")
+    p.add_argument("--table", required=True, help="Supabase table name")
+    p.add_argument("--limit", type=int, default=5, help="Max rows to process")
+    args = p.parse_args()
+    process_batch(args.table, args.limit)
+
+
+if __name__ == "__main__":
+    _cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+openai>=0.27
+supabase-py>=2.0
+Pillow>=9.0
+requests>=2.25
+markdown

--- a/tests/test_graphic_generator.py
+++ b/tests/test_graphic_generator.py
@@ -1,0 +1,35 @@
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+import graphic_generator as gg
+
+FAKE_ROW = {"id": 7, "content": "Deep dive into AI.", "title": "AI 101", "generate_graphic": True, "graphic_generated": False}
+
+
+def test_fetch_pending(monkeypatch):
+    mock_supa = MagicMock()
+    mock_supa.table.return_value.select.return_value.eq.return_value.is_.return_value.limit.return_value.execute.return_value.data = [FAKE_ROW]
+    monkeypatch.setenv("SUPABASE_URL","url"); monkeypatch.setenv("SUPABASE_ANON_KEY","key")
+    monkeypatch.setattr("graphic_generator._get_client", lambda: mock_supa)
+    rows = gg.fetch_pending("content", 1)
+    assert rows[0]["id"] == 7
+
+
+def test_process_batch(monkeypatch, tmp_path):
+    monkeypatch.setattr("graphic_generator.fetch_pending", lambda t,l: [FAKE_ROW])
+    monkeypatch.setenv("OPENAI_API_KEY","key")
+    fake_url = "https://img.example.com/1.png"
+    monkeypatch.setattr("graphic_generator.generate_image", lambda p: fake_url)
+    dummy_bytes = tmp_path/"f.png"
+    dummy_bytes.write_bytes(b"123")
+    monkeypatch.setattr("graphic_generator.download_image", lambda u: open(dummy_bytes, "rb"))
+    mock_supa = MagicMock()
+    mock_supa.storage.from_.return_value.get_public_url.return_value = {"publicURL": "https://cdn/1.png"}
+    mock_supa.storage.from_.return_value.upload.return_value = None
+    monkeypatch.setattr("graphic_generator._get_client", lambda: mock_supa)
+    updated = {}
+    monkeypatch.setattr("graphic_generator.update_row", lambda t,i,url: updated.update({"id": i, "url": url}))
+    gg.process_batch("content",1)
+    assert updated["id"] == 7 and updated["url"].startswith("https://cdn/")


### PR DESCRIPTION
## Summary
- implement `graphic_generator.py` for generating infographics
- add tests for the new module
- include required dependencies
- document usage with mermaid flowchart
- schedule daily graphic generation via CI workflow

## Testing
- `pytest -q`
- `pylint graphic_generator.py tests/test_graphic_generator.py`
- `mypy graphic_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_684f38effb00832eb41cbfdd1b43e6ce