### PR TITLE
Add OSMU analytics module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - run: pytest
+
+  weekly-osmu-analytics:
+    runs-on: ubuntu-latest
+    schedule:
+      - cron: "0 9 * * MON"   # 매주 월요일 09:00 UTC
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - run: python osmu_analytics.py --table content --days 7 --limit 50
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+## osmu_analytics 사용법
+
+```bash
+export SUPABASE_URL="https://xyz.supabase.co"
+export SUPABASE_ANON_KEY="public-anon-key"
+python osmu_analytics.py --table content --days 7 --limit 50
+```
+
+```mermaid
+flowchart TD
+    A[Fetch recent published rows] --> B[Compute normalized KPIs]
+    B --> C[Calculate mean priority_score]
+    C --> D[Upsert into osmu_priority table]
+```

--- a/osmu_analytics.py
+++ b/osmu_analytics.py
@@ -1,0 +1,101 @@
+"""
+Compute cross-channel performance matrix and suggest next-use priority.
+
+Usage (CLI):
+    python osmu_analytics.py --table content --days 7 --limit 10
+"""
+
+import os
+import argparse
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Any
+
+import pandas as pd
+from supabase import create_client
+
+# ───────── 환경변수 ───────── #
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_KEY = os.getenv("SUPABASE_ANON_KEY")
+
+# KPI 필드
+KPI_FIELDS = {
+    "youtube": "youtube_views",
+    "medium": "medium_reads",
+    "x": "x_engagement",
+    "tistory": "tistory_views",
+}
+
+PRIORITY_TABLE = "osmu_priority"  # 결과 저장 테이블
+
+
+def _get_client():
+    if not (SUPABASE_URL and SUPABASE_KEY):
+        raise EnvironmentError("Supabase creds missing")
+    return create_client(SUPABASE_URL, SUPABASE_KEY)
+
+
+def fetch_recent(table: str, days: int, limit: int) -> pd.DataFrame:
+    """최근 days일 내 publish_ready=False 레코드 가져와 DataFrame으로."""
+    since = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+    supa = _get_client()
+    data = (
+        supa.table(table)
+        .select("*")
+        .gte("published_at", since)
+        .order("published_at", desc=True)
+        .limit(limit)
+        .execute()
+        .data
+    )
+    return pd.DataFrame(data or [])
+
+
+def compute_priority(df: pd.DataFrame) -> pd.DataFrame:
+    """채널별 KPI 비율을 계산하고 우선순위 점수 컬럼 추가."""
+    if df.empty:
+        return df
+    # normalize each KPI to [0,1]
+    for ch, field in KPI_FIELDS.items():
+        if field in df:
+            vals = df[field].astype(float)
+            df[f"{ch}_norm"] = (vals - vals.min()) / (vals.max() - vals.min() + 1e-6)
+        else:
+            df[f"{ch}_norm"] = 0.0
+    # 우선순위 점수: 채널별 normalized KPI 가중합
+    df["priority_score"] = df[[f"{c}_norm" for c in KPI_FIELDS]].mean(axis=1)
+    return df
+
+
+def publish_priority(df: pd.DataFrame):
+    """우선순위 테이블에 결과를 업서트(upsert)."""
+    supa = _get_client()
+    for _, row in df.iterrows():
+        props: Dict[str, Any] = {
+            "content_id": row["id"],
+            "priority_score": float(row["priority_score"]),
+            "computed_at": datetime.now(timezone.utc).isoformat(),
+        }
+        supa.table(PRIORITY_TABLE).upsert(props, on_conflict="content_id").execute()
+
+
+def process(table: str, days: int, limit: int):
+    df = fetch_recent(table, days, limit)
+    df = compute_priority(df)
+    if df.empty:
+        print("🎉 No recent content to analyze.")
+        return
+    publish_priority(df)
+    print(f"✅ Processed {len(df)} items. Priority table updated.")
+
+
+def _cli():
+    p = argparse.ArgumentParser(description="OSMU Analytics")
+    p.add_argument("--table", required=True, help="Supabase source table")
+    p.add_argument("--days", type=int, default=7, help="Lookback days")
+    p.add_argument("--limit", type=int, default=50, help="Max items")
+    args = p.parse_args()
+    process(args.table, args.days, args.limit)
+
+
+if __name__ == "__main__":
+    _cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas>=2.2
+supabase-py>=2.0

--- a/tests/test_osmu_analytics.py
+++ b/tests/test_osmu_analytics.py
@@ -1,0 +1,37 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from unittest.mock import MagicMock
+import osmu_analytics as oa
+import pandas as pd
+
+FAKE_DATA = [
+    {"id":1, "youtube_views":100, "medium_reads":50, "x_engagement":20, "tistory_views":80, "published_at": "2025-06-10T00:00:00Z"},
+    {"id":2, "youtube_views":10,  "medium_reads":5,  "x_engagement":2,  "tistory_views":8,  "published_at": "2025-06-11T00:00:00Z"},
+]
+
+def test_compute_priority():
+    df = pd.DataFrame(FAKE_DATA)
+    out = oa.compute_priority(df.copy())
+    assert "priority_score" in out
+    assert out.loc[out["id"]==1, "priority_score"].iloc[0] > out.loc[out["id"]==2, "priority_score"].iloc[0]
+
+def test_process(monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "url")
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "key")
+    mock_client = MagicMock()
+    mock_table = MagicMock()
+    mock_client.table.return_value = mock_table
+    monkeypatch.setattr("osmu_analytics._get_client", lambda: mock_client)
+    df = pd.DataFrame(FAKE_DATA)
+    monkeypatch.setattr("osmu_analytics.fetch_recent", lambda t,d,l: df)
+    updated = []
+    def fake_execute():
+        return MagicMock()
+    def fake_upsert(props, on_conflict=None):
+        updated.append(props)
+        m = MagicMock()
+        m.execute = fake_execute
+        return m
+    mock_table.upsert.side_effect = fake_upsert
+    oa.process("content", 7, 10)
+    assert any(item["content_id"]==1 for item in updated)


### PR DESCRIPTION
## Summary
- implement `osmu_analytics.py` with CLI for computing cross-channel KPI priority
- add pytest coverage for analytics logic
- document usage and flow in README
- declare dependencies and CI workflow

## Testing
- `pytest -q`
- `mypy osmu_analytics.py tests/test_osmu_analytics.py`
- `pylint osmu_analytics.py tests/test_osmu_analytics.py`

------
https://chatgpt.com/codex/tasks/task_e_684f3919b0e8832ea9d2358c5b1e3ef7