### PR TITLE
Add Supabase to Notion sync

### DIFF
--- a/.github/workflows/notion-sync.yml.txt
+++ b/.github/workflows/notion-sync.yml.txt
@@ -1,0 +1,21 @@
+name: Notion Sync
+
+on:
+  schedule:
+    - cron: "0 10 * * *"
+
+jobs:
+  notion-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - run: python notion_sync.py --table content --limit 50
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          NOTION_DB_ID: ${{ secrets.NOTION_DB_ID }}

--- a/notion_sync.py
+++ b/notion_sync.py
@@ -1,0 +1,92 @@
+# -------------------- filename: notion_sync.py ------------------------
+
+import os
+import argparse
+from datetime import datetime, timezone
+from typing import List, Dict, Any
+
+import pandas as pd
+from notion_client import Client as Notion
+from supabase import create_client
+
+# ────────────── ENV ────────────── #
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_KEY = os.getenv("SUPABASE_ANON_KEY")
+NOTION_TOKEN = os.getenv("NOTION_TOKEN")
+NOTION_DB = os.getenv("NOTION_DB_ID")
+
+# 매핑 필드 설정
+SUPABASE_FIELDS = [
+    "id", "title", "published_channel", "public_url",
+    "youtube_views", "medium_reads", "x_engagement", "tistory_views",
+    "priority_score", "published_at"
+]
+
+
+def _get_supa():
+    return create_client(SUPABASE_URL, SUPABASE_KEY)
+
+
+def _get_notion():
+    return Notion(auth=NOTION_TOKEN)
+
+
+def fetch_latest(table: str, limit: int = 50) -> pd.DataFrame:
+    """Supabase에서 최신 퍼블리시 데이터 로드"""
+    data = (
+        _get_supa().table(table)
+        .select(",".join(SUPABASE_FIELDS))
+        .order("published_at", desc=True)
+        .limit(limit)
+        .execute()
+        .data
+    )
+    return pd.DataFrame(data or [])
+
+
+def notion_format(row: Dict[str, Any]) -> Dict:
+    """Notion 페이지 속성 변환"""
+    props = {
+        "Content ID": {"number": row["id"]},
+        "Title": {"title": [{"text": {"content": row["title"]}}]},
+        "Channel": {"select": {"name": row.get("published_channel", "N/A")}},
+        "Public URL": {"url": row.get("public_url")},
+        "Priority Score": {"number": row.get("priority_score", 0)},
+        "YouTube Views": {"number": row.get("youtube_views", 0)},
+        "Medium Reads": {"number": row.get("medium_reads", 0)},
+        "X Engagement": {"number": row.get("x_engagement", 0)},
+        "Tistory Views": {"number": row.get("tistory_views", 0)},
+        "Published At": {"date": {"start": row["published_at"]}},
+    }
+    return props
+
+
+def sync_to_notion(df: pd.DataFrame):
+    notion = _get_notion()
+    for _, row in df.iterrows():
+        props = notion_format(row)
+        notion.pages.create(
+            parent={"database_id": NOTION_DB},
+            properties=props
+        )
+
+
+def sync(table: str, limit: int = 50):
+    df = fetch_latest(table, limit)
+    if df.empty:
+        print("🎉 No records found to sync.")
+        return
+    sync_to_notion(df)
+    print(f"✅ Synced {len(df)} records to Notion DB.")
+
+
+def _cli():
+    p = argparse.ArgumentParser(description="Sync Supabase → Notion")
+    p.add_argument("--table", required=True)
+    p.add_argument("--limit", type=int, default=50)
+    args = p.parse_args()
+    sync(args.table, args.limit)
+
+
+if __name__ == "__main__":
+    _cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+notion-client>=2.2
+pandas>=2.2
+supabase>=2.0


### PR DESCRIPTION
## Summary
- add `notion_sync.py` to push metrics from Supabase to Notion
- document packages in `requirements.txt`
- add scheduled workflow example `notion-sync.yml.txt`
- fix requirement for supabase package

## Testing
- `pylint notion_sync.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684f39f8a498832e88abbc568d1e0d22