### PR TITLE
Implement CEO kernel modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 logs/
+__pycache__/

--- a/ceo_kernel/__init__.py
+++ b/ceo_kernel/__init__.py
@@ -1,0 +1,19 @@
+"""Codex Autonomous CEO Kernel modules."""
+
+from . import (
+    market_scanner,
+    competitor_analyzer,
+    pricing_optimizer,
+    investor_deck_writer,
+    saas_cloner,
+    cashflow_planner,
+)
+
+__all__ = [
+    "market_scanner",
+    "competitor_analyzer",
+    "pricing_optimizer",
+    "investor_deck_writer",
+    "saas_cloner",
+    "cashflow_planner",
+]

--- a/ceo_kernel/cashflow_planner.py
+++ b/ceo_kernel/cashflow_planner.py
@@ -1,0 +1,20 @@
+"""Simple cashflow forecasting."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def forecast(mrr: float, growth: float, churn: float, expense: float) -> pd.DataFrame:
+    months = range(1, 13)
+    revenue = []
+    cash = 0.0
+    for _ in months:
+        mrr *= (1 + growth - churn)
+        cash += mrr - expense
+        revenue.append(cash)
+    df = pd.DataFrame({"Month": list(months), "Cashflow": revenue})
+    return df
+
+if __name__ == "__main__":
+    print(forecast(1000, 0.1, 0.05, 500))

--- a/ceo_kernel/competitor_analyzer.py
+++ b/ceo_kernel/competitor_analyzer.py
@@ -1,0 +1,23 @@
+"""Simple competitor analysis using OpenAI."""
+
+import os
+import openai
+
+
+def _build_client() -> openai.OpenAI:
+    return openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY", "sk-dummy"))
+
+
+client = _build_client()
+
+def analyze_competitor(name: str) -> str:
+    """Summarize competitor SaaS information."""
+    prompt = f"Summarize {name} SaaS business model, pricing, weak points."
+    completion = client.chat.completions.create(
+        model="gpt-4o", messages=[{"role": "user", "content": prompt}]
+    )
+    content = completion.choices[0].message.content or ""
+    return str(content)
+
+if __name__ == "__main__":
+    print(analyze_competitor("Example SaaS"))

--- a/ceo_kernel/investor_deck_writer.py
+++ b/ceo_kernel/investor_deck_writer.py
@@ -1,0 +1,23 @@
+"""Automatically draft investor pitch decks using OpenAI."""
+
+import os
+import openai
+
+
+def _build_client() -> openai.OpenAI:
+    return openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY", "sk-dummy"))
+
+
+client = _build_client()
+
+def draft_pitch(saas_name: str, metrics: str) -> str:
+    """Generate an investor pitch deck outline."""
+    prompt = f"Write investor pitch deck for {saas_name} with metrics: {metrics}"
+    completion = client.chat.completions.create(
+        model="gpt-4o", messages=[{"role": "user", "content": prompt}]
+    )
+    content = completion.choices[0].message.content or ""
+    return str(content)
+
+if __name__ == "__main__":
+    print(draft_pitch("My SaaS", "users:1000, MRR:$10k"))

--- a/ceo_kernel/market_scanner.py
+++ b/ceo_kernel/market_scanner.py
@@ -1,0 +1,24 @@
+"""Market scanning utilities using the OpenAI API."""
+
+import os
+import openai
+
+
+def _build_client() -> openai.OpenAI:
+    """Create an OpenAI client using an environment key or dummy value."""
+    return openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY", "sk-dummy"))
+
+
+client = _build_client()
+
+def scan_market(niche: str) -> str:
+    """Scan SaaS opportunities in a given niche."""
+    query = f"List SaaS opportunities in {niche} with gaps."
+    completion = client.chat.completions.create(
+        model="gpt-4o", messages=[{"role": "user", "content": query}]
+    )
+    content = completion.choices[0].message.content or ""
+    return str(content)
+
+if __name__ == "__main__":
+    print(scan_market("AI writing tools"))

--- a/ceo_kernel/pricing_optimizer.py
+++ b/ceo_kernel/pricing_optimizer.py
@@ -1,0 +1,9 @@
+"""Simple pricing optimization utilities."""
+
+def optimize_pricing(mrr_goal: float, churn_rate: float, cac: float, arpu: float) -> None:
+    lifetime_value = arpu / churn_rate
+    target_cac = lifetime_value * 0.3
+    print(f"Recommended ARPU: {arpu}, Target CAC: {target_cac}, LTV: {lifetime_value}")
+
+if __name__ == "__main__":
+    optimize_pricing(mrr_goal=1000, churn_rate=0.05, cac=100, arpu=50)

--- a/ceo_kernel/saas_cloner.py
+++ b/ceo_kernel/saas_cloner.py
@@ -1,0 +1,23 @@
+"""Prototype SaaS replication engine."""
+
+from typing import Any
+
+# Placeholder functions for demonstration
+
+def extract_spec_from_site(url: str) -> Any:
+    """Extract a simple spec from the target SaaS site."""
+    return {"url": url, "features": []}
+
+
+def launch_saas(spec: Any) -> None:
+    """Placeholder for launching a SaaS from a spec."""
+    print(f"Launching SaaS with spec: {spec}")
+
+
+def clone_saas(target_saas_url: str) -> None:
+    # Analyze -> Spec -> SaaS Generator call
+    spec = extract_spec_from_site(target_saas_url)
+    launch_saas(spec)
+
+if __name__ == "__main__":
+    clone_saas("https://example.com")

--- a/tests/test_ceo_kernel.py
+++ b/tests/test_ceo_kernel.py
@@ -1,0 +1,57 @@
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, str(__file__).split('/tests')[0])
+
+import pandas as pd
+
+from ceo_kernel import (
+    market_scanner,
+    competitor_analyzer,
+    investor_deck_writer,
+    pricing_optimizer,
+    saas_cloner,
+    cashflow_planner,
+)
+
+
+class DummyClient:
+    def __init__(self, text: str):
+        self.text = text
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
+
+    def _create(self, *args, **kwargs):
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=self.text))])
+
+
+def test_market_scanner(monkeypatch):
+    monkeypatch.setattr(market_scanner, "client", DummyClient("opportunities"))
+    assert market_scanner.scan_market("niche") == "opportunities"
+
+
+def test_competitor_analyzer(monkeypatch):
+    monkeypatch.setattr(competitor_analyzer, "client", DummyClient("summary"))
+    assert competitor_analyzer.analyze_competitor("name") == "summary"
+
+
+def test_investor_deck_writer(monkeypatch):
+    monkeypatch.setattr(investor_deck_writer, "client", DummyClient("pitch"))
+    assert investor_deck_writer.draft_pitch("saas", "metrics") == "pitch"
+
+
+def test_pricing_optimizer(capsys):
+    pricing_optimizer.optimize_pricing(100, 0.1, 10, 20)
+    captured = capsys.readouterr()
+    assert "Recommended ARPU" in captured.out
+
+
+def test_saas_cloner(capsys):
+    saas_cloner.clone_saas("http://example.com")
+    captured = capsys.readouterr()
+    assert "Launching SaaS" in captured.out
+
+
+def test_cashflow_planner():
+    df = cashflow_planner.forecast(1000, 0.1, 0.05, 500)
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty


### PR DESCRIPTION
## Summary
- add new `ceo_kernel` package for market scanning, competitor analysis, pricing optimization, investor deck writing, SaaS cloning and cashflow planning
- include tests for all CEO kernel modules
- ignore `__pycache__` in git

## Testing
- `pylint ceo_kernel tests/test_ceo_kernel.py`
- `mypy ceo_kernel`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3a0047a0832e81c095bbdbbd8a59