### PR TITLE
Add Conglomerate kernel modules

### DIFF
--- a/conglomerate/deployer.py
+++ b/conglomerate/deployer.py
@@ -1,0 +1,17 @@
+from .opportunity_map import map_opportunities
+
+
+def localize_spec(template: dict, country: str) -> dict:
+    localized = template.copy()
+    localized["country"] = country
+    return localized
+
+
+def launch_saas(spec: dict):
+    # Placeholder for deployment logic
+    print(f"Deploying SaaS for {spec['country']}")
+
+
+def deploy_saas(country: str, saas_template: dict):
+    localized_spec = localize_spec(saas_template, country)
+    launch_saas(localized_spec)

--- a/conglomerate/legal_engine.py
+++ b/conglomerate/legal_engine.py
@@ -1,0 +1,9 @@
+import openai
+
+
+def design_legal(country: str) -> str:
+    prompt = f"""
+    Suggest ideal legal entity type, VAT %, SaaS data compliance law for {country}.
+    """
+    response = openai.ChatCompletion.create(model="gpt-4o", messages=[{"role": "user", "content": prompt}])
+    return response.choices[0].message.content

--- a/conglomerate/opportunity_map.py
+++ b/conglomerate/opportunity_map.py
@@ -1,0 +1,10 @@
+import openai
+
+
+def map_opportunities():
+    prompt = """
+    For 30 global countries, list SaaS sectors with highest growth CAGR for 2024-2028.
+    Output as: country, sector, CAGR%
+    """
+    response = openai.ChatCompletion.create(model="gpt-4o", messages=[{"role": "user", "content": prompt}])
+    return response.choices[0].message.content

--- a/conglomerate/portfolio_controller.py
+++ b/conglomerate/portfolio_controller.py
@@ -1,0 +1,8 @@
+import numpy as np
+
+
+def allocate_growth_budget(global_portfolio, total_capex):
+    weights = np.array([p["growth_potential"] for p in global_portfolio], dtype=float)
+    weights /= weights.sum()
+    allocation = weights * total_capex
+    return allocation

--- a/conglomerate/tax_optimizer.py
+++ b/conglomerate/tax_optimizer.py
@@ -1,0 +1,10 @@
+import openai
+
+
+def optimal_holding_structure(markets):
+    prompt = f"""
+    Given markets: {markets}, suggest optimal HQ location for SaaS tax minimization.
+    Consider withholding tax, profit repatriation, VAT rules.
+    """
+    response = openai.ChatCompletion.create(model="gpt-4o", messages=[{"role": "user", "content": prompt}])
+    return response.choices[0].message.content

--- a/tests/test_portfolio_controller.py
+++ b/tests/test_portfolio_controller.py
@@ -1,0 +1,11 @@
+import numpy as np
+from conglomerate.portfolio_controller import allocate_growth_budget
+
+
+def test_allocate_growth_budget_basic():
+    portfolio = [
+        {"growth_potential": 1},
+        {"growth_potential": 1},
+    ]
+    result = allocate_growth_budget(portfolio, 100)
+    assert np.allclose(result, [50, 50])


### PR DESCRIPTION
## Summary
- implement Step-13 Conglomerate Kernel modules for multi-country SaaS
- add minimal unit test for portfolio controller

## Testing
- `PYTHONPATH=. pytest -q`
- `mypy --ignore-missing-imports conglomerate`
- `pylint conglomerate` *(fails: Unable to import 'openai', missing docstrings)*

------
https://chatgpt.com/codex/tasks/task_e_684f3a8f738c832ea5969094ecbd3425