### PR TITLE
Implement Private Equity Kernel modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 logs/
+__pycache__/

--- a/pe_kernel/__init__.py
+++ b/pe_kernel/__init__.py
@@ -1,0 +1,17 @@
+"""Codex AI Private Equity Kernel modules."""
+
+from .target_scanner import scan_targets
+from .valuator import valuate
+from .risk_scanner import scan_risks
+from .acquisition_planner import plan_acquisition
+from .post_merge_cloner import clone_and_merge
+from .portfolio_optimizer import optimize_allocation
+
+__all__ = [
+    "scan_targets",
+    "valuate",
+    "scan_risks",
+    "plan_acquisition",
+    "clone_and_merge",
+    "optimize_allocation",
+]

--- a/pe_kernel/acquisition_planner.py
+++ b/pe_kernel/acquisition_planner.py
@@ -1,0 +1,11 @@
+"""Simple acquisition planning utilities."""
+
+def plan_acquisition(value: float, growth_plan: float) -> dict:
+    """Return a basic acquisition plan dictionary."""
+    invest_budget = value * 0.6
+    hiring_plan = int(growth_plan * 10)
+    return {
+        "offer_price": value,
+        "post_merge_budget": invest_budget,
+        "team_expansion": hiring_plan,
+    }

--- a/pe_kernel/portfolio_optimizer.py
+++ b/pe_kernel/portfolio_optimizer.py
@@ -1,0 +1,10 @@
+"""Portfolio allocation utilities."""
+
+import numpy as np
+
+def optimize_allocation(portfolio: list[dict], max_budget: float) -> np.ndarray:
+    """Allocate budget inversely proportional to risk."""
+    weights = np.array([1 / p["risk"] for p in portfolio], dtype=float)
+    weights /= weights.sum()
+    allocation = weights * max_budget
+    return allocation

--- a/pe_kernel/post_merge_cloner.py
+++ b/pe_kernel/post_merge_cloner.py
@@ -1,0 +1,11 @@
+"""Utilities for cloning and merging SaaS specs."""
+
+def clone_and_merge(original_spec: dict, target_customers: int) -> dict:
+    """Return a new spec with unified billing and updated customers."""
+    new_spec = original_spec.copy()
+    # ensure features list is copied to avoid mutating original
+    features = list(original_spec.get("features", []))
+    features.append("Unified Billing Layer")
+    new_spec["features"] = features
+    new_spec["customers"] = target_customers
+    return new_spec

--- a/pe_kernel/risk_scanner.py
+++ b/pe_kernel/risk_scanner.py
@@ -1,0 +1,13 @@
+import openai
+
+def scan_risks(domain: str, tech_stack: str, customer_base: str):
+    """Analyze potential risks for a SaaS company."""
+    prompt = f"""
+    Analyze legal, technical, data privacy risks for SaaS company with:
+    domain={domain}, stack={tech_stack}, customers={customer_base}
+    """
+    client = openai.OpenAI()
+    response = client.chat.completions.create(
+        model="gpt-4o", messages=[{"role": "user", "content": prompt}]
+    )
+    return response.choices[0].message.content

--- a/pe_kernel/target_scanner.py
+++ b/pe_kernel/target_scanner.py
@@ -1,0 +1,13 @@
+import openai
+
+def scan_targets(niche: str, min_mrr: int = 10000, growth: float = 0.1):
+    """Use OpenAI to find SaaS targets in a given niche."""
+    prompt = f"""
+    Find active SaaS companies in {niche} with MRR > ${min_mrr}, 
+    growth > {growth*100}% suitable for acquisition.
+    """
+    client = openai.OpenAI()
+    response = client.chat.completions.create(
+        model="gpt-4o", messages=[{"role": "user", "content": prompt}]
+    )
+    return response.choices[0].message.content

--- a/pe_kernel/valuator.py
+++ b/pe_kernel/valuator.py
@@ -1,0 +1,7 @@
+"""Basic SaaS valuation utilities."""
+
+def valuate(mrr: float, growth: float, churn: float, margin: float) -> float:
+    """Return estimated value using a simple LTV multiple."""
+    ltv = (mrr * (1 + growth - churn)) * 12
+    value = ltv * margin * 5
+    return value

--- a/tests/test_acquisition_planner.py
+++ b/tests/test_acquisition_planner.py
@@ -1,0 +1,8 @@
+from pe_kernel.acquisition_planner import plan_acquisition
+
+
+def test_plan_acquisition():
+    plan = plan_acquisition(100000, 0.3)
+    assert plan["offer_price"] == 100000
+    assert plan["post_merge_budget"] == 60000
+    assert plan["team_expansion"] == 3

--- a/tests/test_portfolio_optimizer.py
+++ b/tests/test_portfolio_optimizer.py
@@ -1,0 +1,11 @@
+import numpy as np
+from pe_kernel.portfolio_optimizer import optimize_allocation
+
+
+def test_optimize_allocation():
+    portfolio = [{"risk": 1}, {"risk": 2}]
+    allocation = optimize_allocation(portfolio, 100)
+    weights = np.array([1 / 1, 1 / 2], dtype=float)
+    weights /= weights.sum()
+    expected = weights * 100
+    assert np.allclose(allocation, expected)

--- a/tests/test_post_merge_cloner.py
+++ b/tests/test_post_merge_cloner.py
@@ -1,0 +1,10 @@
+from pe_kernel.post_merge_cloner import clone_and_merge
+
+
+def test_clone_and_merge():
+    spec = {"features": ["A"], "customers": 100}
+    new_spec = clone_and_merge(spec, 200)
+    assert new_spec["features"] == ["A", "Unified Billing Layer"]
+    assert new_spec["customers"] == 200
+    # original should remain unchanged
+    assert spec["features"] == ["A"]

--- a/tests/test_target_and_risk_scanner.py
+++ b/tests/test_target_and_risk_scanner.py
@@ -1,0 +1,26 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from pe_kernel import target_scanner, risk_scanner
+
+
+def _setup_mock(monkeypatch):
+    mock_client = MagicMock()
+    mock_choice = MagicMock()
+    mock_choice.message.content = "ok"
+    mock_client.chat.completions.create.return_value.choices = [mock_choice]
+    monkeypatch.setattr(target_scanner.openai, "OpenAI", MagicMock(return_value=mock_client))
+    monkeypatch.setattr(risk_scanner.openai, "OpenAI", MagicMock(return_value=mock_client))
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_scan_targets(monkeypatch):
+    _setup_mock(monkeypatch)
+    assert target_scanner.scan_targets("crm") == "ok"
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_scan_risks(monkeypatch):
+    _setup_mock(monkeypatch)
+    assert risk_scanner.scan_risks("crm.com", "python", "smb") == "ok"

--- a/tests/test_valuator.py
+++ b/tests/test_valuator.py
@@ -1,0 +1,7 @@
+from pe_kernel.valuator import valuate
+
+
+def test_valuate():
+    value = valuate(mrr=50000, growth=0.2, churn=0.05, margin=0.7)
+    expected = ((50000 * (1 + 0.2 - 0.05)) * 12) * 0.7 * 5
+    assert value == expected


### PR DESCRIPTION
## Summary
- add `pe_kernel` package with SaaS private equity utilities
- include unit tests for new modules
- ignore `__pycache__`

## Testing
- `pytest -q`
- `pylint pe_kernel tests`

------
https://chatgpt.com/codex/tasks/task_e_684f3a41fb20832e8415e170856d22e6