### PR TITLE
Add webhook receiver service

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+uvicorn
+fastapi

--- a/tests/test_webhook_receiver.py
+++ b/tests/test_webhook_receiver.py
@@ -1,0 +1,27 @@
+from fastapi.testclient import TestClient
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+from webhook_receiver import app  # noqa: E402
+
+client = TestClient(app)
+
+
+def test_health():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"status": "alive"}
+
+
+def test_invalid_secret():
+    payload = {"secret": "wrong", "command": "orchestrator"}
+    res = client.post("/webhook/", json=payload)
+    assert res.status_code == 401
+
+
+def test_invalid_command():
+    payload = {"secret": "supersecret", "command": "unknown"}
+    res = client.post("/webhook/", json=payload)
+    assert res.status_code == 400

--- a/webhook_receiver.py
+++ b/webhook_receiver.py
@@ -1,0 +1,84 @@
+"""Minimal webhook receiver for triggering pipeline components."""
+
+import logging
+import os
+import subprocess
+
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel  # pylint: disable=no-name-in-module
+
+app = FastAPI(title="v-Infinity Webhook Receiver")
+
+# 기본 간단 인증 (Webhooks 보호용)
+WEBHOOK_SECRET = os.getenv("WEBHOOK_SECRET", "supersecret")
+
+
+# 수신 요청 모델
+class HookRequest(BaseModel):
+    """Schema for webhook requests."""
+
+    secret: str
+    command: str  # 실행할 모듈명 ex: orchestrator, ab_variant_manager
+    table: str = "content"
+    limit: int = 5
+    days: int = 7
+    params: dict = {}
+
+
+@app.post("/webhook/")
+async def webhook(req: HookRequest):
+    """Execute a pipeline command if the secret matches."""
+    if req.secret != WEBHOOK_SECRET:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    # 명령어 매핑
+    command_map = {
+        "orchestrator": "python orchestrator.py",
+        "ab_variants": (
+            "python ab_variant_manager.py --table"
+            f" {req.table} --limit {req.limit} --title-variants 3 --thumb-variants 2"
+        ),
+        "rewriter": (
+            f"python auto_rewriter.py --table {req.table} --threshold 0.3"
+        ),
+        "uploader": (
+            f"python hook_uploader.py --table {req.table} --limit {req.limit}"
+        ),
+        "osmu": (
+            f"python osmu_analytics.py --table {req.table} "
+            f"--days {req.days} --limit {req.limit}"
+        ),
+        "graphic": (
+            f"python graphic_generator.py --table {req.table} --limit {req.limit}"
+        ),
+        "podcast": (
+            f"python podcast_creator.py --table {req.table} --limit {req.limit}"
+        ),
+        "insight": (
+            f"python auto_insight.py --table {req.table} "
+            f"--days {req.days} --notion-db $NOTION_DB_ID"
+        ),
+    }
+
+    if req.command not in command_map:
+        raise HTTPException(status_code=400, detail="Invalid command")
+
+    command = command_map[req.command]
+    logging.info("Webhook Triggered: %s", command)
+
+    try:
+        subprocess.Popen(command, shell=True)
+        return {"status": "accepted", "executed": command}
+    except Exception as e:  # noqa: W0718
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@app.get("/")
+async def health():
+    """Simple health check."""
+    return {"status": "alive"}
+
+
+if __name__ == "__main__":
+    uvicorn.run("webhook_receiver:app", host="0.0.0.0", port=9000)


### PR DESCRIPTION
## Summary
- implement `webhook_receiver.py` for dynamic pipeline control via FastAPI
- document dependencies in `requirements.txt`
- add pytest coverage for the webhook receiver endpoints

## Testing
- `mypy webhook_receiver.py tests/test_webhook_receiver.py`
- `pylint webhook_receiver.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3a3122c0832eb5ed50e0b74c4d7d