### PR TITLE
Add docstring generator and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: doc-gen CI
+
+on:
+  push:
+    branches: [ "main" ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Python 설정
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+        cache: 'pip'
+    
+    - name: 의존성 설치
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest pytest-cov black isort pydocstyle
+        if [ -f requirements.txt ]; then
+          pip install -r requirements.txt
+        fi
+
+    - name: 코드 스타일 검사
+      run: |
+        black --check .
+        isort --check-only --diff .
+        pydocstyle src tests
+
+    - name: 테스트 실행
+      run: |
+        PYTHONPATH=src pytest tests/ -v --cov=src --cov-report=xml
+
+    - name: 문서 생성
+      run: |
+        pip install sphinx sphinx-rtd-theme
+        sphinx-build -b html docs/source docs/build
+
+    - name: 테스트 결과 업로드
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: test-results
+        path: |
+          ./coverage.xml
+          .pytest_cache
+          docs/build
+        retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 .env
 logs/
+__pycache__/
+*.pyc
+.pytest_cache/
+coverage.xml
+.coverage
+docs/build/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,3 @@
+# Minimal Sphinx configuration for tests
+project = "docgen"
+extensions = []

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,1 @@
+Docgen documentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+# 테스트 의존성
+pytest>=7.0.0
+pytest-cov>=4.0.0
+black>=23.0.0
+isort>=5.12.0
+pydocstyle>=6.3.0
+
+# 문서 생성
+sphinx>=7.0.0
+sphinx-rtd-theme>=1.3.0
+
+# 프로젝트 의존성
+# 여기에 필요한 패키지들을 추가하세요

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,31 @@
+[metadata]
+name = docgen
+version = 0.1.0
+description = Docstring Generator Utility
+long_description = file: README.md
+author = sunwoopark0512
+
+[options]
+package_dir =
+    = src
+packages = find:
+python_requires = >=3.11
+install_requires =
+
+[options.packages.find]
+where = src
+
+[tool:pytest]
+testpaths = tests
+python_files = test_*.py
+addopts = -v --cov=src --cov-report=xml
+
+[coverage:run]
+source = src
+omit = tests/*
+
+[pydocstyle]
+inherit = false
+convention = google
+add-ignore = D203, D213
+match = .*\.py

--- a/src/docgen/__init__.py
+++ b/src/docgen/__init__.py
@@ -1,0 +1,6 @@
+"""Docstring generator package."""
+
+from .generator import DocstringGenerator, DocstringTemplate
+
+__version__ = "0.1.0"
+__all__ = ["DocstringGenerator", "DocstringTemplate"]

--- a/src/docgen/generator.py
+++ b/src/docgen/generator.py
@@ -1,0 +1,128 @@
+"""Docstring generator utility module."""
+
+import ast
+import inspect
+from dataclasses import dataclass
+from typing import Any, List, Optional, Tuple
+
+
+@dataclass
+class DocstringTemplate:
+    """Docstring template for various Python objects."""
+
+    summary: str
+    description: Optional[str] = None
+    args: List[Tuple[str, str, str]] = None  # (name, type, description)
+    returns: Optional[Tuple[str, str]] = None  # (type, description)
+    raises: List[Tuple[str, str]] = None  # (exception, description)
+
+    def generate(self) -> str:
+        """Generate formatted docstring.
+
+        Returns:
+            str: Formatted docstring following Google style
+        """
+        lines = [self.summary]
+
+        if self.description:
+            lines.extend(["", self.description])
+
+        if self.args:
+            lines.append("")
+            lines.append("Args:")
+            for name, type_, desc in self.args:
+                lines.append(f"    {name} ({type_}): {desc}")
+
+        if self.returns:
+            lines.append("")
+            lines.append("Returns:")
+            lines.append(f"    {self.returns[0]}: {self.returns[1]}")
+
+        if self.raises:
+            lines.append("")
+            lines.append("Raises:")
+            for exc, desc in self.raises:
+                lines.append(f"    {exc}: {desc}")
+
+        return "\n".join(lines)
+
+
+class DocstringGenerator:
+    """Utility class for generating docstrings."""
+
+    def __init__(self) -> None:
+        """Initialize the docstring generator."""
+        self.ast_parser = ast.parse
+
+    def analyze_function(self, func: Any) -> DocstringTemplate:
+        """Analyze a function and create a docstring template.
+
+        Args:
+            func: Function to analyze
+
+        Returns:
+            DocstringTemplate: Template containing function information
+
+        Raises:
+            ValueError: If the input is not a valid function
+        """
+        if not inspect.isfunction(func):
+            raise ValueError("Input must be a function")
+
+        sig = inspect.signature(func)
+        args = []
+
+        for name, param in sig.parameters.items():
+            param_type = (
+                param.annotation.__name__
+                if param.annotation != inspect.Parameter.empty
+                else "Any"
+            )
+            args.append((name, param_type, f"Description for {name}"))
+
+        return_type = (
+            sig.return_annotation.__name__
+            if sig.return_annotation != inspect.Parameter.empty
+            else "None"
+        )
+
+        return DocstringTemplate(
+            summary=f"Generated docstring for {func.__name__}",
+            args=args,
+            returns=(return_type, "Description of return value"),
+        )
+
+    def analyze_class(self, cls: Any) -> DocstringTemplate:
+        """Analyze a class and create a docstring template.
+
+        Args:
+            cls: Class to analyze
+
+        Returns:
+            DocstringTemplate: Template containing class information
+
+        Raises:
+            ValueError: If the input is not a valid class
+        """
+        if not inspect.isclass(cls):
+            raise ValueError("Input must be a class")
+
+        return DocstringTemplate(
+            summary=f"Generated docstring for {cls.__name__}",
+            description=f"Class representing {cls.__name__}",
+        )
+
+    def apply_docstring(self, obj: Any, template: DocstringTemplate) -> None:
+        """Apply generated docstring to an object.
+
+        Args:
+            obj: Object to apply docstring to
+            template: Docstring template to apply
+
+        Raises:
+            ValueError: If the object is not valid for docstring application
+        """
+        if not (inspect.isfunction(obj) or inspect.isclass(obj)):
+            raise ValueError("Object must be a function or class")
+
+        obj.__doc__ = template.generate()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,68 @@
+"""Tests for docstring generator."""
+
+from typing import List, Optional
+
+import pytest
+
+from docgen.generator import DocstringGenerator, DocstringTemplate
+
+
+def test_docstring_template():
+    """Test docstring template generation."""
+    template = DocstringTemplate(
+        summary="Test function",
+        description="This is a test function",
+        args=[("param1", "str", "First parameter")],
+        returns=("bool", "Success status"),
+        raises=[("ValueError", "If parameter is invalid")],
+    )
+
+    docstring = template.generate()
+    assert "Test function" in docstring
+    assert "This is a test function" in docstring
+    assert "param1 (str): First parameter" in docstring
+    assert "bool: Success status" in docstring
+    assert "ValueError: If parameter is invalid" in docstring
+
+
+def sample_function(param1: str, param2: Optional[int] = None) -> List[str]:
+    """Sample function for testing."""
+    return [param1]
+
+
+def test_analyze_function():
+    """Test function analysis."""
+    generator = DocstringGenerator()
+    template = generator.analyze_function(sample_function)
+
+    assert isinstance(template, DocstringTemplate)
+    assert "sample_function" in template.summary
+    assert len(template.args) == 2
+    assert template.args[0][0] == "param1"
+    assert template.args[0][1] == "str"
+    assert template.returns[0] == "List"
+
+
+def test_apply_docstring():
+    """Test docstring application."""
+    generator = DocstringGenerator()
+    template = DocstringTemplate(
+        summary="Updated docstring", description="New description"
+    )
+
+    def test_func():
+        pass
+
+    generator.apply_docstring(test_func, template)
+    assert test_func.__doc__ == template.generate()
+
+
+def test_invalid_input():
+    """Test error handling for invalid inputs."""
+    generator = DocstringGenerator()
+
+    with pytest.raises(ValueError):
+        generator.analyze_function("not a function")
+
+    with pytest.raises(ValueError):
+        generator.analyze_class("not a class")


### PR DESCRIPTION
## Summary
- add docstring generator utility under `src/docgen`
- add tests for docstring generator
- configure pydocstyle and coverage in `setup.cfg`
- add CI workflow running formatters, tests and docs build
- add development requirements
- ignore build and cache artifacts

## Testing
- `black --check .`
- `isort --check-only --diff .`
- `pydocstyle src tests`
- `PYTHONPATH=src pytest tests/ -v --cov=src --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_684f3b3e992c832e80e1edae4321146f