### PR TITLE
Add codex pipeline module and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run tests
+        run: |
+          PYTHONPATH=src pytest tests -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .env
 logs/
+coverage.xml
+.coverage
+__pycache__/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_unreachable = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pytest
+mypy
+pylint
+black
+isort

--- a/src/codex/pipeline.py
+++ b/src/codex/pipeline.py
@@ -1,0 +1,53 @@
+"""Codex Pipeline Core Module."""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class PipelineStep:
+    """파이프라인 단계를 나타내는 데이터 클래스."""
+
+    name: str
+    action: str
+    params: Dict[str, Any] = field(default_factory=dict)
+
+
+class Pipeline:
+    """기본 파이프라인 클래스."""
+
+    def __init__(self) -> None:
+        """파이프라인 초기화."""
+        self.steps: List[PipelineStep] = []
+
+    def add_step(
+        self, name: str, action: str, params: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """파이프라인에 단계를 추가합니다.
+
+        Args:
+            name: 단계 이름
+            action: 실행할 액션
+            params: 액션 파라미터
+        """
+        self.steps.append(PipelineStep(name=name, action=action, params=params or {}))
+
+    def run(self) -> List[Dict[str, Any]]:
+        """파이프라인을 실행합니다.
+
+        Returns:
+            실행 결과 목록
+        """
+        results = []
+        for step in self.steps:
+            try:
+                # 실제 구현에서는 여기에 액션 실행 로직 추가
+                result = {
+                    "step": step.name,
+                    "status": "success",
+                    "output": f"Executed {step.action}",
+                }
+            except Exception as e:  # pragma: no cover - placeholder for now
+                result = {"step": step.name, "status": "failure", "error": str(e)}
+            results.append(result)
+        return results

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package initialization."""

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,43 @@
+"""Pipeline 테스트."""
+
+from typing import Dict
+
+import pytest
+
+from codex.pipeline import Pipeline, PipelineStep
+
+
+@pytest.fixture
+def sample_step_params() -> Dict[str, str]:
+    """테스트용 스텝 파라미터."""
+    return {"message": "Hello"}
+
+
+def test_pipeline_creation() -> None:
+    """파이프라인 생성 테스트."""
+    pipeline = Pipeline()
+    assert isinstance(pipeline.steps, list)
+    assert len(pipeline.steps) == 0
+
+
+def test_add_step(sample_step_params: Dict[str, str]) -> None:
+    """스텝 추가 테스트."""
+    pipeline = Pipeline()
+    pipeline.add_step("test", "echo", sample_step_params)
+
+    assert len(pipeline.steps) == 1
+    assert isinstance(pipeline.steps[0], PipelineStep)
+    assert pipeline.steps[0].name == "test"
+    assert pipeline.steps[0].action == "echo"
+    assert pipeline.steps[0].params == sample_step_params
+
+
+def test_run_pipeline(sample_step_params: Dict[str, str]) -> None:
+    """파이프라인 실행 테스트."""
+    pipeline = Pipeline()
+    pipeline.add_step("test1", "echo", sample_step_params)
+    pipeline.add_step("test2", "echo", {"message": "World"})
+
+    results = pipeline.run()
+    assert len(results) == 2
+    assert all(result["status"] == "success" for result in results)


### PR DESCRIPTION
## Summary
- add Codex pipeline with typed steps
- create basic test suite for pipeline logic
- configure mypy and GitHub CI workflow
- document dev dependencies
- update gitignore for build artifacts

## Testing
- `pip install -r requirements.txt`
- `mypy src tests`
- `pylint src tests`
- `PYTHONPATH=src pytest tests -v --cov=src --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_684f3aa28524832eab687c62d978e156