### PR TITLE
Add Podcast CI workflow

### DIFF
--- a/.github/workflows/podcast-ci.yml
+++ b/.github/workflows/podcast-ci.yml
@@ -1,0 +1,89 @@
+name: Podcast CI
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Python ${{ matrix.python-version }} 설정
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+
+    - name: 의존성 설치
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest pytest-cov black isort pylint
+        if [ -f requirements.txt ]; then
+          pip install -r requirements.txt
+        fi
+
+    - name: 코드 포맷팅 검사
+      run: |
+        black --check .
+        isort --check-only --diff .
+
+    - name: Lint 검사
+      run: |
+        pylint --recursive=y src tests
+
+    - name: 테스트 실행
+      run: |
+        PYTHONPATH=src pytest tests/ -v --cov=src --cov-report=xml
+
+    - name: 테스트 결과 업로드
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: test-results-${{ github.sha }}
+        path: |
+          ./coverage.xml
+          .pytest_cache
+        retention-days: 14
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Python 설정
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+        cache: 'pip'
+
+    - name: 빌드
+      run: |
+        python -m pip install --upgrade pip build
+        python -m build
+
+    - name: 빌드 결과물 업로드
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist
+        path: dist/
+        retention-days: 14


### PR DESCRIPTION
## Summary
- add a dedicated CI workflow `podcast-ci.yml` to run lint, test and build steps

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_684f3c87ea3c832e8d7dfc903b8d7f73