### PR TITLE
Add graphics generator module and CI workflows

### DIFF
--- a/.github/workflows/daily-graphics.yml
+++ b/.github/workflows/daily-graphics.yml
@@ -1,0 +1,70 @@
+name: Daily Graphics Generation
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+        cache: 'pip'
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libcairo2-dev pkg-config python3-dev
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Generate daily graphics
+      run: |
+        python - <<'PY'
+from pathlib import Path
+from graphic_generator import GraphicGenerator, GraphicConfig
+from datetime import datetime, timezone
+
+output_dir = Path('daily_graphics')
+config = GraphicConfig(
+    width=800,
+    height=400,
+    background_color=(0.95, 0.95, 0.95),
+    line_color=(0.2, 0.4, 0.8),
+    line_width=2.0,
+    font_size=16.0
+)
+
+generator = GraphicGenerator(output_dir)
+now = datetime.now(timezone.utc)
+data = [1.0, 1.5, 2.0, 1.8, 2.2, 2.8, 2.5]
+chart_path = generator.create_chart(data, config, f'Daily Stats - {now.strftime("%Y-%m-%d")}')
+
+badge_config = GraphicConfig(
+    width=200,
+    height=30,
+    background_color=(0.2, 0.6, 0.2),
+    line_color=(1.0, 1.0, 1.0),
+    font_size=14.0
+)
+badge_path = generator.create_badge('Updated Daily', badge_config, style='rounded')
+print('Chart saved to', chart_path)
+print('Badge saved to', badge_path)
+PY
+
+    - name: Upload generated graphics
+      uses: actions/upload-artifact@v4
+      with:
+        name: daily-graphics-${{ github.run_id }}
+        path: daily_graphics/
+        retention-days: 7

--- a/.github/workflows/graphics-ci.yml
+++ b/.github/workflows/graphics-ci.yml
@@ -1,0 +1,70 @@
+name: Graphics CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/graphic_generator/**'
+      - 'tests/test_graphic_generator.py'
+      - '.github/workflows/graphics-ci.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'src/graphic_generator/**'
+      - 'tests/test_graphic_generator.py'
+      - '.github/workflows/graphics-ci.yml'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libcairo2-dev pkg-config python3-dev
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest pytest-cov black isort pylint
+        pip install -r requirements.txt
+
+    - name: Code formatting check
+      run: |
+        black --check src/graphic_generator tests/test_graphic_generator.py
+        isort --check-only --diff src/graphic_generator tests/test_graphic_generator.py
+
+    - name: Lint check
+      run: |
+        pylint src/graphic_generator tests/test_graphic_generator.py
+
+    - name: Run tests
+      run: |
+        PYTHONPATH=src pytest tests/test_graphic_generator.py -v --cov=src/graphic_generator --cov-report=xml
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: test-results-${{ github.sha }}
+        path: |
+          ./coverage.xml
+          .pytest_cache
+          ./output
+        retention-days: 14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+matplotlib
+Pillow

--- a/src/graphic_generator/__init__.py
+++ b/src/graphic_generator/__init__.py
@@ -1,0 +1,5 @@
+"""Public API for the graphic generator package."""
+
+from .generator import GraphicConfig, GraphicGenerator
+
+__all__ = ["GraphicGenerator", "GraphicConfig"]

--- a/src/graphic_generator/generator.py
+++ b/src/graphic_generator/generator.py
@@ -1,0 +1,98 @@
+"""Utility classes for generating simple charts and badges."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Tuple
+
+import matplotlib.pyplot as plt
+from PIL import Image, ImageDraw, ImageFont
+
+
+@dataclass
+class GraphicConfig:
+    """Configuration for a graphic element."""
+
+    width: int
+    height: int
+    background_color: Tuple[float, float, float]
+    line_color: Tuple[float, float, float] | None = None
+    line_width: float | None = None
+    font_size: float = 12.0
+
+
+def _ensure_dir(directory: Path) -> None:
+    """Create directory if it does not exist."""
+
+    directory.mkdir(parents=True, exist_ok=True)
+
+
+class GraphicGenerator:
+    """Generate simple graphics to disk."""
+
+    def __init__(self, output_dir: Path) -> None:
+        """Initialize the generator with an output directory."""
+
+        self.output_dir = output_dir
+        _ensure_dir(self.output_dir)
+
+    def create_chart(
+        self, data: Iterable[float], config: GraphicConfig, title: str
+    ) -> Path:
+        """Create a simple line chart and return the saved path."""
+        fig, ax = plt.subplots(
+            figsize=(config.width / 100, config.height / 100), dpi=100
+        )
+        ax.plot(
+            list(data),
+            color=config.line_color or "blue",
+            linewidth=config.line_width or 2,
+        )
+        ax.set_title(title)
+        fig.patch.set_facecolor(config.background_color)
+        ax.set_facecolor(config.background_color)
+        output_path = self.output_dir / f"{title.replace(' ', '_')}.png"
+        plt.tight_layout()
+        fig.savefig(output_path)
+        plt.close(fig)
+        return output_path
+
+    def create_badge(
+        self, text: str, config: GraphicConfig, style: str = "rounded"
+    ) -> Path:
+        """Create a badge image and return the saved path."""
+        img = Image.new(
+            "RGB",
+            (config.width, config.height),
+            tuple(int(c * 255) for c in config.background_color),
+        )
+        draw = ImageDraw.Draw(img)
+        try:
+            font = ImageFont.truetype("DejaVuSans.ttf", int(config.font_size))
+        except (OSError, IOError):
+            font = ImageFont.load_default()
+        bbox = draw.textbbox((0, 0), text, font=font)
+        text_w = bbox[2] - bbox[0]
+        text_h = bbox[3] - bbox[1]
+        text_x = (config.width - text_w) / 2
+        text_y = (config.height - text_h) / 2
+        draw.text(
+            (text_x, text_y),
+            text,
+            fill=tuple(int(c * 255) for c in (config.line_color or (1, 1, 1))),
+            font=font,
+        )
+        if style == "rounded":
+            mask = Image.new("L", (config.width, config.height), 0)
+            ImageDraw.Draw(mask).rounded_rectangle(
+                [(0, 0), (config.width, config.height)], 5, fill=255
+            )
+            rounded = Image.new(
+                "RGB",
+                (config.width, config.height),
+                tuple(int(c * 255) for c in config.background_color),
+            )
+            rounded.paste(img, (0, 0), mask)
+            img = rounded
+        output_path = self.output_dir / f"{text.replace(' ', '_')}_badge.png"
+        img.save(output_path)
+        return output_path

--- a/tests/test_graphic_generator.py
+++ b/tests/test_graphic_generator.py
@@ -1,0 +1,24 @@
+"""Tests for the :mod:`graphic_generator` package."""
+
+from pathlib import Path
+
+from graphic_generator import GraphicConfig, GraphicGenerator
+
+
+def test_create_chart(tmp_path: Path) -> None:
+    """Ensure a chart image is created."""
+
+    generator = GraphicGenerator(tmp_path)
+    config = GraphicConfig(width=400, height=200, background_color=(1, 1, 1))
+    data = [0, 1, 2, 3]
+    chart_path = generator.create_chart(data, config, "Test Chart")
+    assert chart_path.exists()
+
+
+def test_create_badge(tmp_path: Path) -> None:
+    """Ensure a badge image is created."""
+
+    generator = GraphicGenerator(tmp_path)
+    config = GraphicConfig(width=100, height=20, background_color=(1, 0, 0))
+    badge_path = generator.create_badge("OK", config)
+    assert badge_path.exists()


### PR DESCRIPTION
## Summary
- create a small graphics generator package with chart and badge helpers
- add tests for the graphic generator
- define `requirements.txt` for the module
- add `graphics-ci.yml` for path-based CI
- add `daily-graphics.yml` scheduled workflow

## Testing
- `python -m pylint src/graphic_generator tests/test_graphic_generator.py`
- `PYTHONPATH=src pytest tests/test_graphic_generator.py -v`


------
https://chatgpt.com/codex/tasks/task_e_684f45dac2f8832ebeaa29f4f9dfa93c