### PR TITLE
Add podcast CI with tests

### DIFF
--- a/codex/.github/workflows/podcast-ci.yml
+++ b/codex/.github/workflows/podcast-ci.yml
@@ -1,0 +1,74 @@
+name: Podcast CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/podcast/**'
+      - 'tests/test_podcast/**'
+      - '.github/workflows/podcast-ci.yml'
+      - 'pyproject.toml'
+      - 'requirements*.txt'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'src/podcast/**'
+      - 'tests/test_podcast/**'
+      - '.github/workflows/podcast-ci.yml'
+      - 'pyproject.toml'
+      - 'requirements*.txt'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ffmpeg
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
+
+    - name: Create test directories
+      run: |
+        mkdir -p tests/test_results
+        mkdir -p tests/coverage_reports
+
+    - name: Run tests with coverage
+      run: |
+        PYTHONPATH=src pytest tests/test_podcast \
+          --cov=src/podcast \
+          --cov-report=term \
+          --cov-report=xml:tests/coverage_reports/coverage.xml \
+          --junitxml=tests/test_results/junit.xml \
+          -v
+
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results-py${{ matrix.python-version }}
+        path: |
+          tests/test_results/
+          tests/coverage_reports/
+        retention-days: 14

--- a/codex/pyproject.toml
+++ b/codex/pyproject.toml
@@ -1,0 +1,64 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "codex-podcast"
+version = "0.1.0"
+description = "Podcast Creation and Management Tools"
+requires-python = ">=3.11"
+authors = [
+    {name = "sunwoopark0512", email = "sunwoopark0512@example.com"},
+]
+dependencies = [
+    "pydub>=0.25.1",
+    "mutagen>=1.47.0",
+    "requests>=2.31.0",
+    "python-dateutil>=2.8.2",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+    "black>=23.0.0",
+    "isort>=5.12.0",
+    "pylint>=2.17.0",
+    "mypy>=1.0.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+addopts = """
+    -v
+    --cov=src
+    --cov-report=term
+    --cov-report=xml:tests/coverage_reports/coverage.xml
+    --junitxml=tests/test_results/junit.xml
+"""
+
+[tool.coverage.run]
+source = ["src"]
+branch = true
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+    "pass"
+]
+
+[tool.black]
+line-length = 100
+target-version = ['py311']
+include = '\\.pyi?$'
+
+[tool.isort]
+profile = "black"
+line_length = 100
+multi_line_output = 3
+include_trailing_comma = true

--- a/codex/requirements-dev.txt
+++ b/codex/requirements-dev.txt
@@ -1,0 +1,14 @@
+# 테스트
+pytest>=7.0.0
+pytest-cov>=4.0.0
+pytest-mock>=3.10.0
+
+# 코드 품질
+black>=23.0.0
+isort>=5.12.0
+pylint>=2.17.0
+mypy>=1.0.0
+
+# 문서화
+sphinx>=7.0.0
+sphinx-rtd-theme>=1.3.0

--- a/codex/requirements.txt
+++ b/codex/requirements.txt
@@ -1,0 +1,9 @@
+# 오디오 처리
+pydub>=0.25.1
+mutagen>=1.47.0
+
+# HTTP 클라이언트
+requests>=2.31.0
+
+# 유틸리티
+python-dateutil>=2.8.2

--- a/codex/src/podcast/__init__.py
+++ b/codex/src/podcast/__init__.py
@@ -1,0 +1,12 @@
+"""Podcast utilities package."""
+
+from .audio import AudioProcessor
+from .feed import Feed, Episode
+from .metadata import EpisodeMetadata
+
+__all__ = [
+    "AudioProcessor",
+    "Feed",
+    "Episode",
+    "EpisodeMetadata",
+]

--- a/codex/src/podcast/audio.py
+++ b/codex/src/podcast/audio.py
@@ -1,0 +1,74 @@
+"""Podcast 오디오 처리 모듈."""
+
+from pathlib import Path
+from typing import Optional
+
+from mutagen import File as MutagenFile
+from pydub import AudioSegment
+
+
+class AudioProcessor:
+    """팟캐스트 오디오 처리기."""
+
+    def __init__(self, output_dir: Path) -> None:
+        """오디오 처리기를 초기화합니다.
+
+        Args:
+            output_dir: 출력 디렉토리 경로
+        """
+        self.output_dir = output_dir
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def convert_to_mp3(
+        self,
+        input_path: Path,
+        bitrate: str = "192k",
+        sample_rate: int = 44100,
+    ) -> Path:
+        """오디오를 MP3 형식으로 변환합니다.
+
+        Args:
+            input_path: 입력 파일 경로
+            bitrate: 출력 비트레이트
+            sample_rate: 출력 샘플레이트
+
+        Returns:
+            Path: 변환된 MP3 파일 경로
+
+        Raises:
+            ValueError: 입력 파일이 존재하지 않는 경우
+        """
+        if not input_path.exists():
+            raise ValueError(f"Input file not found: {input_path}")
+
+        audio = AudioSegment.from_file(str(input_path))
+        audio = audio.set_frame_rate(sample_rate)
+
+        output_path = self.output_dir / f"{input_path.stem}_converted.mp3"
+        audio.export(str(output_path), format="mp3", bitrate=bitrate)
+
+        return output_path
+
+    def get_duration(self, file_path: Path) -> Optional[float]:
+        """오디오 파일의 재생 시간을 초 단위로 반환합니다."""
+        try:
+            audio = MutagenFile(str(file_path))
+            if audio and hasattr(audio.info, "length"):
+                return float(audio.info.length)
+        except Exception:
+            pass
+        return None
+
+    def normalize_audio(self, input_path: Path, target_db: float = -20.0) -> Path:
+        """오디오 레벨을 정규화합니다."""
+        if not input_path.exists():
+            raise ValueError(f"Input file not found: {input_path}")
+
+        audio = AudioSegment.from_file(str(input_path))
+        change_in_db = target_db - audio.dBFS
+        normalized_audio = audio.apply_gain(change_in_db)
+
+        output_path = self.output_dir / f"{input_path.stem}_normalized.mp3"
+        normalized_audio.export(str(output_path), format="mp3")
+
+        return output_path

--- a/codex/src/podcast/feed.py
+++ b/codex/src/podcast/feed.py
@@ -1,0 +1,33 @@
+"""Podcast feed utilities."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Optional
+
+
+@dataclass
+class Episode:
+    """Represents a podcast episode."""
+
+    title: str
+    audio_path: str
+    publish_date: datetime
+
+
+@dataclass
+class Feed:
+    """Simple podcast feed container."""
+
+    title: str
+    description: str
+    episodes: List[Episode] = field(default_factory=list)
+
+    def add_episode(self, episode: Episode) -> None:
+        """Add an episode to the feed."""
+        self.episodes.append(episode)
+
+    def get_latest_episode(self) -> Optional[Episode]:
+        """Return the most recently published episode."""
+        if not self.episodes:
+            return None
+        return max(self.episodes, key=lambda e: e.publish_date)

--- a/codex/src/podcast/metadata.py
+++ b/codex/src/podcast/metadata.py
@@ -1,0 +1,13 @@
+"""Podcast metadata models."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class EpisodeMetadata:
+    """Metadata for a podcast episode."""
+
+    title: str
+    description: str
+    published_at: datetime

--- a/codex/tests/test_podcast/test_audio.py
+++ b/codex/tests/test_podcast/test_audio.py
@@ -1,0 +1,59 @@
+"""팟캐스트 오디오 처리 테스트."""
+
+from pathlib import Path
+
+import pytest
+from pydub import AudioSegment
+
+from podcast.audio import AudioProcessor
+
+
+@pytest.fixture
+def temp_dir(tmp_path):
+    """임시 디렉토리를 생성합니다."""
+    return tmp_path
+
+
+@pytest.fixture
+def sample_audio(temp_dir):
+    """샘플 오디오 파일을 생성합니다."""
+    sample_path = temp_dir / "sample.mp3"
+    audio = AudioSegment.silent(duration=1000)  # 1초 무음
+    audio.export(str(sample_path), format="mp3")
+    return sample_path
+
+
+@pytest.fixture
+def processor(temp_dir):
+    """오디오 처리기 인스턴스를 생성합니다."""
+    return AudioProcessor(temp_dir / "output")
+
+
+def test_convert_to_mp3(processor, sample_audio):
+    """MP3 변환을 테스트합니다."""
+    output_path = processor.convert_to_mp3(sample_audio)
+    assert output_path.exists()
+    assert output_path.suffix == ".mp3"
+
+
+def test_get_duration(processor, sample_audio):
+    """재생 시간 측정을 테스트합니다."""
+    duration = processor.get_duration(sample_audio)
+    assert duration is not None
+    assert duration > 0
+
+
+def test_normalize_audio(processor, sample_audio):
+    """오디오 정규화를 테스트합니다."""
+    output_path = processor.normalize_audio(sample_audio)
+    assert output_path.exists()
+    assert output_path.suffix == ".mp3"
+
+
+def test_invalid_input(processor):
+    """잘못된 입력 처리를 테스트합니다."""
+    with pytest.raises(ValueError):
+        processor.convert_to_mp3(Path("nonexistent.mp3"))
+
+    with pytest.raises(ValueError):
+        processor.normalize_audio(Path("nonexistent.mp3"))

--- a/codex/tests/test_podcast/test_feed.py
+++ b/codex/tests/test_podcast/test_feed.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+from podcast.feed import Episode, Feed
+
+
+def test_add_and_get_latest_episode():
+    feed = Feed(title="My Podcast", description="Test")
+    ep1 = Episode("E1", "e1.mp3", datetime(2023, 1, 1))
+    ep2 = Episode("E2", "e2.mp3", datetime(2023, 1, 2))
+    feed.add_episode(ep1)
+    feed.add_episode(ep2)
+
+    assert feed.get_latest_episode() == ep2

--- a/codex/tests/test_podcast/test_metadata.py
+++ b/codex/tests/test_podcast/test_metadata.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+
+from podcast.metadata import EpisodeMetadata
+
+
+def test_episode_metadata_fields():
+    meta = EpisodeMetadata("Ep1", "Desc", datetime(2023, 1, 1))
+    assert meta.title == "Ep1"
+    assert meta.description == "Desc"
+    assert isinstance(meta.published_at, datetime)


### PR DESCRIPTION
## Summary
- add `podcast-ci` workflow for the new podcast project
- configure project dependencies and pytest options
- implement audio, feed, and metadata modules
- add unit tests for podcast utilities

## Testing
- `pip install -r codex/requirements.txt -r codex/requirements-dev.txt`
- `PYTHONPATH=src pytest -q`
- `pylint src/podcast`
- `mypy src/podcast --ignore-missing-imports`


------
https://chatgpt.com/codex/tasks/task_e_684f46dc93ec832e80a3bc6cde376283