### PR TITLE
Add unit tests and environment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Auto Pipeline
+
+This repository contains scripts for generating marketing hooks using OpenAI, collecting keyword data, and uploading the results to Notion.
+
+## Environment Variables
+
+The scripts rely on several environment variables. Create a `.env` file or set them in your shell before running the pipeline.
+
+| Variable | Description |
+| --- | --- |
+| `OPENAI_API_KEY` | API key used to access OpenAI. |
+| `NOTION_API_TOKEN` | Token for authenticating with the Notion API. |
+| `NOTION_HOOK_DB_ID` | ID of the Notion database that stores generated hooks. |
+| `NOTION_KPI_DB_ID` | ID of the Notion database used for KPI statistics. |
+| `NOTION_DB_ID` | ID of the Notion database for raw keyword uploads. |
+| `HOOK_OUTPUT_PATH` | Path to save generated hook JSON. Default: `data/generated_hooks.json`. |
+| `FAILED_HOOK_PATH` | Path to store hooks that failed to generate. Default: `logs/failed_hooks.json`. |
+| `KEYWORD_OUTPUT_PATH` | Output JSON produced by the keyword pipeline. |
+| `FAILED_UPLOADS_PATH` | File for keywords that failed to upload. |
+| `UPLOADED_CACHE_PATH` | Cache file tracking uploaded keywords. |
+| `TOPIC_CHANNELS_PATH` | JSON file describing topic channels. |
+| `REPARSED_OUTPUT_PATH` | File used when retrying failed uploads. |
+| `API_DELAY` | Delay between OpenAI API calls. |
+| `UPLOAD_DELAY` | Delay between Notion upload requests. |
+| `RETRY_DELAY` | Delay between retry attempts. |
+
+## Installation
+
+Install the required dependencies using pip:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running Tests
+
+Execute unit tests using `pytest` from the repository root:
+
+```bash
+pytest
+```
+
+The test suite covers prompt generation, text parsing, and retry logic.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+openai
+notion-client
+python-dotenv
+pytrends
+snscrape
+pytest

--- a/tests/test_hook_generator.py
+++ b/tests/test_hook_generator.py
@@ -1,0 +1,48 @@
+import sys, os; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import types
+import openai
+from hook_generator import generate_hook_prompt, get_gpt_response
+
+class DummyResponse:
+    def __init__(self, content):
+        self.choices = [types.SimpleNamespace(message={'content': content})]
+
+def test_generate_hook_prompt_includes_values():
+    prompt = generate_hook_prompt(
+        keyword="ai marketing",
+        topic="ai",
+        source="Google",
+        score=90,
+        growth=1.5,
+        mentions=123,
+    )
+    assert "ai marketing" in prompt
+    assert "90" in prompt
+    assert "1.5" in prompt
+    assert "123" in prompt
+
+
+def test_get_gpt_response_success_after_retries(monkeypatch):
+    calls = {
+        'count': 0
+    }
+
+    def fake_chatcompletion_create(*args, **kwargs):
+        calls['count'] += 1
+        if calls['count'] < 3:
+            raise Exception("temp fail")
+        return DummyResponse("hello")
+
+    monkeypatch.setattr(openai.ChatCompletion, 'create', fake_chatcompletion_create)
+    result = get_gpt_response("prompt", retries=3)
+    assert result == "hello"
+    assert calls['count'] == 3
+
+
+def test_get_gpt_response_all_fail(monkeypatch):
+    def fake_fail(*args, **kwargs):
+        raise Exception("fail")
+
+    monkeypatch.setattr(openai.ChatCompletion, 'create', fake_fail)
+    result = get_gpt_response("prompt", retries=2)
+    assert result is None

--- a/tests/test_notion_hook_uploader.py
+++ b/tests/test_notion_hook_uploader.py
@@ -1,0 +1,22 @@
+import sys, os; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import os; os.makedirs("logs", exist_ok=True)
+from notion_hook_uploader import parse_generated_text
+
+SAMPLE_TEXT = """
+후킹 문장1: 첫 문장
+후킹 문장2: 둘째 문장
+블로그 초안:
+첫째 문단
+둘째 문단
+셋째 문단
+영상 제목:
+- 비디오 제목1
+- 비디오 제목2
+"""
+
+
+def test_parse_generated_text_basic():
+    parsed = parse_generated_text(SAMPLE_TEXT)
+    assert parsed['hook_lines'] == ['첫 문장', '둘째 문장']
+    assert parsed["blog_paragraphs"][0] == "첫째 문단"
+    assert parsed["video_titles"] == ["비디오 제목2"]


### PR DESCRIPTION
## Summary
- document environment variables and test instructions
- add requirements file for dependencies
- implement unit tests for prompt generation, text parsing and retry logic

## Testing
- `pytest -q`
- `pylint hook_generator.py notion_hook_uploader.py keyword_auto_pipeline.py retry_failed_uploads.py retry_dashboard_notifier.py scripts/*.py`
- `mypy *.py scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684f476bbb2c832e9573daf17f40bebe