### PR TITLE
Fix pipeline runner path and scripts

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1,8 +1,8 @@
 import logging
 import subprocess
 import sys
-import os
 from datetime import datetime
+from pathlib import Path
 
 # ---------------------- 로깅 설정 ----------------------
 logging.basicConfig(
@@ -12,22 +12,24 @@ logging.basicConfig(
 
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
+    "keyword_auto_pipeline.py",
     "hook_generator.py",
-    "parse_failed_gpt.py",
+    "notion_hook_uploader.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
     "retry_dashboard_notifier.py"
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
-def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+def run_script(script: str) -> bool:
+    full_path = PROJECT_ROOT / script
+    if not full_path.exists():
         logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")
-    result = subprocess.run([sys.executable, full_path], capture_output=True, text=True)
+    result = subprocess.run([sys.executable, str(full_path)], capture_output=True, text=True)
 
     if result.returncode != 0:
         logging.error(f"❌ 실패: {script}\n{result.stderr}")


### PR DESCRIPTION
## Summary
- move `run_pipeline.py` into the `scripts/` folder
- update `PIPELINE_SEQUENCE` to use available scripts
- resolve script paths relative to project root

## Testing
- `python -m py_compile scripts/run_pipeline.py`
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`
- `python scripts/run_pipeline.py` *(fails: ModuleNotFoundError: No module named 'pytrends')*

------
https://chatgpt.com/codex/tasks/task_e_684f480616ec832ea8b8ccde4771049f