### PR TITLE
Implement missing retry scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Auto_Pipeline
+
+This repository contains scripts used to generate marketing hooks with GPT and upload results to Notion.
+
+## Pipeline Steps
+
+The pipeline is executed via `run_pipeline.py` and runs scripts from the `scripts/` directory in the following order:
+
+1. `hook_generator.py` – generate hooks with GPT.
+2. `parse_failed_gpt.py` – parse failed GPT outputs for retry.
+3. `retry_failed_uploads.py` – upload parsed failures again.
+4. `notify_retry_result.py` – print a summary of retry results.
+5. `retry_dashboard_notifier.py` – push KPI data to Notion.
+
+Run the pipeline:
+
+```bash
+python run_pipeline.py
+```
+
+Unit tests are located in the `tests/` folder and can be run with:
+
+```bash
+python -m unittest discover -s tests -v
+```

--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,25 @@
+import os
+import json
+import logging
+
+REPARSED_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+def notify() -> int:
+    if not os.path.exists(REPARSED_PATH):
+        logging.warning(f"❗ 재시도 결과 파일이 없습니다: {REPARSED_PATH}")
+        return 0
+
+    with open(REPARSED_PATH, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    total = len(data)
+    failed = len([d for d in data if d.get("retry_error")])
+    success = total - failed
+
+    logging.info(f"📢 재시도 결과 - 총 {total}, 성공 {success}, 실패 {failed}")
+    return total
+
+if __name__ == "__main__":
+    notify()

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,50 @@
+import os
+import json
+import logging
+import re
+
+FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+def parse_generated_text(text: str) -> dict:
+    hook_lines = re.findall(r"후킹 ?문장[0-9]?[\s:：\-\)]*([^\n]+)", text)
+    blog_match = re.search(
+        r"블로그(?:\s*초안)?[\s:：\-\)]*(.*?)\n+\s*(.*?\n+.*?\n+.*?)(?:\n|$)",
+        text,
+        re.DOTALL,
+    )
+    video_titles = re.findall(r"(?:영상 제목|YouTube 제목)[\s:：\-\)]*[^\n]*\n?-\s*(.+)", text)
+
+    blog_paragraphs = [p.strip() for p in blog_match[1].strip().split('\n')[:3]] if blog_match else ["", "", ""]
+    return {
+        "hook_lines": hook_lines[:2] if len(hook_lines) >= 2 else ["", ""],
+        "blog_paragraphs": blog_paragraphs,
+        "video_titles": video_titles[:2] if video_titles else ["", ""],
+    }
+
+def parse_failed() -> list:
+    if not os.path.exists(FAILED_PATH):
+        logging.warning(f"❗ 실패 로그 파일이 없습니다: {FAILED_PATH}")
+        return []
+
+    with open(FAILED_PATH, "r", encoding="utf-8") as f:
+        items = json.load(f)
+
+    results = []
+    for item in items:
+        text = item.get("generated_text") or ""
+        parsed = parse_generated_text(text)
+        item["parsed"] = parsed
+        results.append(item)
+
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, "w", encoding="utf-8") as f:
+        json.dump(results, f, ensure_ascii=False, indent=2)
+
+    logging.info(f"✅ 파싱된 결과 저장: {OUTPUT_PATH}")
+    return results
+
+if __name__ == "__main__":
+    parse_failed()

--- a/tests/test_notify_retry_result.py
+++ b/tests/test_notify_retry_result.py
@@ -1,0 +1,25 @@
+import os
+import json
+import tempfile
+import importlib
+import unittest
+
+
+class TestNotifyRetryResult(unittest.TestCase):
+    def test_notify_reads_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "reparsed.json")
+            data = [{"keyword": "a"}, {"keyword": "b", "retry_error": "err"}]
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(data, f)
+
+            os.environ["REPARSED_OUTPUT_PATH"] = path
+
+            mod = importlib.import_module("scripts.notify_retry_result")
+            importlib.reload(mod)
+            count = mod.notify()
+            self.assertEqual(count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parse_failed_gpt.py
+++ b/tests/test_parse_failed_gpt.py
@@ -1,0 +1,35 @@
+import os
+import json
+import tempfile
+import importlib
+import unittest
+
+
+class TestParseFailedGPT(unittest.TestCase):
+    def test_parse_failed_creates_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            failed_path = os.path.join(tmp, "failed.json")
+            output_path = os.path.join(tmp, "out.json")
+
+            sample = [{
+                "keyword": "test",
+                "generated_text": "후킹 문장1: hi\n블로그 초안: a\nb\nc\n영상 제목: t1\n- t2"
+            }]
+            with open(failed_path, "w", encoding="utf-8") as f:
+                json.dump(sample, f)
+
+            os.environ["FAILED_HOOK_PATH"] = failed_path
+            os.environ["REPARSED_OUTPUT_PATH"] = output_path
+
+            mod = importlib.import_module("scripts.parse_failed_gpt")
+            importlib.reload(mod)
+            result = mod.parse_failed()
+            self.assertEqual(len(result), 1)
+            self.assertTrue(os.path.exists(output_path))
+            with open(output_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            self.assertIn("parsed", data[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `parse_failed_gpt.py` and `notify_retry_result.py`
- add basic unit tests for new scripts
- document pipeline sequence in README

## Testing
- `python -m unittest discover -s tests -v`
- `pylint scripts/parse_failed_gpt.py scripts/notify_retry_result.py`

------
https://chatgpt.com/codex/tasks/task_e_684f48072cf8832e87a99fc4b3ef4bdb