### PR TITLE
Update pipeline script paths

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,15 +13,14 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
+    "notion_hook_uploader.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
     "retry_dashboard_notifier.py"
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
+    full_path = os.path.join(os.path.dirname(__file__), script)
     if not os.path.exists(full_path):
         logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
         return False


### PR DESCRIPTION
## Summary
- fix `PIPELINE_SEQUENCE` to point at existing scripts
- resolve script path lookup in `run_script`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: E501 line too long)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f4768951c832e9a2b6a0f6903961e