### PR TITLE
Add update status workflow and README

### DIFF
--- a/.github/workflows/update-status.yml
+++ b/.github/workflows/update-status.yml
@@ -1,0 +1,43 @@
+name: Update Status
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'  # 5분마다 실행
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+      - 'README.md'
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Update README
+      run: |
+        current_time=$(date -u +"%Y-%m-%d %H:%M:%S")
+        # Update timestamp in badges
+        sed -i "s/Last%20Updated-.*-blue/Last%20Updated-$(date -u +\"%Y-%m-%d%%20%H%%3A%M%%3A%S\")-blue/" README.md
+        # Update timestamp in content
+        sed -i "s/Last Updated:.*/Last Updated: $current_time UTC/" README.md
+        sed -i "s/\*Last updated:.*/\*Last updated: $current_time UTC by @${{ github.actor }}*/" README.md
+        # Update current user if changed
+        current_user="${{ github.actor }}"
+        sed -i "s/Current%20User-@.*-green/Current%20User-@$current_user-green/" README.md
+        sed -i "s/Current User: @.*/Current User: @$current_user/" README.md
+
+    - name: Commit and push if changed
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add README.md
+        git diff --quiet && git diff --staged --quiet || (git commit -m "Update status timestamps and user information [skip ci]" && git push)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# Auto Pipeline
+
+## Current Status
+![Last Updated](https://img.shields.io/badge/Last%20Updated-2025--06--15%2022%3A23%3A01-blue)
+![Current User](https://img.shields.io/badge/Current%20User-@sunwoopark0512-green)
+
+## Workflow Status
+[![CI](https://github.com/sunwoopark0512/Auto_Pipeline/actions/workflows/ci.yml/badge.svg)](https://github.com/sunwoopark0512/Auto_Pipeline/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/sunwoopark0512/Auto_Pipeline/actions/workflows/codeql.yml/badge.svg)](https://github.com/sunwoopark0512/Auto_Pipeline/actions/workflows/codeql.yml)
+[![Security Scan](https://github.com/sunwoopark0512/Auto_Pipeline/actions/workflows/security.yml/badge.svg)](https://github.com/sunwoopark0512/Auto_Pipeline/actions/workflows/security.yml)
+
+## Pipeline Information
+- **Last Updated:** 2025-06-15 22:23:01 UTC
+- **Current User:** @sunwoopark0512
+- **Repository:** [Auto_Pipeline](https://github.com/sunwoopark0512/Auto_Pipeline)
+
+## Active Workflows
+| Workflow | Status | Description |
+|----------|--------|-------------|
+| CI | [![CI](https://github.com/sunwoopark0512/Auto_Pipeline/actions/workflows/ci.yml/badge.svg)](https://github.com/sunwoopark0512/Auto_Pipeline/actions/workflows/ci.yml) | Main continuous integration pipeline |
+| CodeQL | [![CodeQL](https://github.com/sunwoopark0512/Auto_Pipeline/actions/workflows/codeql.yml/badge.svg)](https://github.com/sunwoopark0512/Auto_Pipeline/actions/workflows/codeql.yml) | Security analysis |
+| Security Scan | [![Security Scan](https://github.com/sunwoopark0512/Auto_Pipeline/actions/workflows/security.yml/badge.svg)](https://github.com/sunwoopark0512/Auto_Pipeline/actions/workflows/security.yml) | Dependency and code security checks |
+
+## Quick Links
+- [CI Pipeline](https://github.com/sunwoopark0512/Auto_Pipeline/actions/workflows/ci.yml)
+- [Security Analysis](https://github.com/sunwoopark0512/Auto_Pipeline/actions/workflows/codeql.yml)
+- [Issue Tracker](https://github.com/sunwoopark0512/Auto_Pipeline/issues)
+- [Pull Requests](https://github.com/sunwoopark0512/Auto_Pipeline/pulls)
+
+## Getting Started
+```bash
+# Clone the repository
+git clone https://github.com/sunwoopark0512/Auto_Pipeline.git
+cd Auto_Pipeline
+
+# Install dependencies
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+
+# Run tests
+pytest
+```
+
+## Development Status
+- ![Status](https://img.shields.io/badge/Status-Active-success)
+- ![Python](https://img.shields.io/badge/Python-3.11-blue)
+- ![License](https://img.shields.io/badge/License-MIT-yellow)
+
+## Recent Updates
+- CI workflow optimization
+- Security scanning integration
+- Automated badge updates
+- Real-time status monitoring
+
+## Contributing
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/AmazingFeature`)
+3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
+4. Push to the branch (`git push origin feature/AmazingFeature`)
+5. Open a Pull Request
+
+## License
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+---
+*Last updated: 2025-06-15 22:23:01 UTC by @sunwoopark0512*


### PR DESCRIPTION
## Summary
- add README with project status and workflow details
- automate README updates via new update-status workflow

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684f481faae0832ea93e9328eaa9b191