### PR TITLE
Update README and add status workflow

### DIFF
--- a/.github/workflows/update-status.yml
+++ b/.github/workflows/update-status.yml
@@ -1,0 +1,42 @@
+name: Update Status
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'  # Every 5 minutes
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+      - 'README.md'
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Update README timestamps
+      run: |
+        current_time=$(date -u +"%Y-%m-%d %H:%M:%S")
+        sed -i "s/Last%20Updated-.*-blue/Last%20Updated-$(date -u +"%Y-%m-%d%%20%H%%3A%M%%3A%S")-blue/" README.md
+        sed -i "s/Last Updated:.*UTC/Last Updated: $current_time UTC/" README.md
+        sed -i "s/\*Last updated:.*UTC/\*Last updated: $current_time UTC/" README.md
+
+    - name: Update user information
+      run: |
+        echo "Updating user information to: ${{ github.actor }}"
+        sed -i "s/User-.*-green/User-${{ github.actor }}-green/" README.md
+        sed -i "s/Current User: @.*/Current User: @${{ github.actor }}/" README.md
+        sed -i "s/UTC by @.*/UTC by @${{ github.actor }}*/" README.md
+
+    - name: Commit and push if changed
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add README.md
+        git diff --quiet && git diff --staged --quiet || (git commit -m "Update status [skip ci]" && git push)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Auto Pipeline
+
+## Current Status
+![Last Updated](https://img.shields.io/badge/Last%20Updated-2025--06--15%2022%3A24%3A26-blue)
+![User](https://img.shields.io/badge/User-sunwoopark0512-green)
+[![CI](https://github.com/sunwoopark0512/Auto_Pipeline/actions/workflows/ci.yml/badge.svg)](https://github.com/sunwoopark0512/Auto_Pipeline/actions/workflows/ci.yml)
+
+## Project Information
+- **Last Updated:** 2025-06-15 22:24:26 UTC
+- **Current User:** @sunwoopark0512
+- **Build Status:** [![CI](https://github.com/sunwoopark0512/Auto_Pipeline/actions/workflows/ci.yml/badge.svg)](https://github.com/sunwoopark0512/Auto_Pipeline/actions/workflows/ci.yml)
+
+## Quick Links
+- [CI Pipeline](https://github.com/sunwoopark0512/Auto_Pipeline/actions/workflows/ci.yml)
+- [Issues](https://github.com/sunwoopark0512/Auto_Pipeline/issues)
+- [Pull Requests](https://github.com/sunwoopark0512/Auto_Pipeline/pulls)
+
+## Getting Started
+```
+# Clone the repository
+git clone https://github.com/sunwoopark0512/Auto_Pipeline.git
+cd Auto_Pipeline
+
+# Install dependencies
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+
+# Run tests
+pytest
+```
+
+## Development Status
+- ![Python](https://img.shields.io/badge/Python-3.11-blue)
+- ![Status](https://img.shields.io/badge/Status-Active-success)
+- ![License](https://img.shields.io/badge/License-MIT-yellow)
+
+## Contributing
+1. Fork the repository
+2. Create your feature branch
+3. Commit your changes
+4. Push to the branch
+5. Open a Pull Request
+
+---
+*Last updated: 2025-06-15 22:24:26 UTC by @sunwoopark0512*


### PR DESCRIPTION
## Summary
- add README with project and CI badges
- automate updating status via GitHub Actions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f4866ea70832e94180343b5d32278