### PR TITLE
Fix pipeline sequence and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Auto Pipeline
+
+This repository contains a collection of scripts for generating marketing content and synchronising data with Notion.
+
+## Pipeline Execution
+
+The `run_pipeline.py` orchestrates a sequence of scripts located in the `scripts/` directory.
+The current pipeline order is:
+
+1. `hook_generator.py` – generates marketing hooks using GPT.
+2. `retry_failed_uploads.py` – retries uploading failed hooks to Notion.
+3. `retry_dashboard_notifier.py` – updates KPI dashboards in Notion.
+
+Run the pipeline with:
+
+```bash
+python run_pipeline.py
+```

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,7 +1,9 @@
+"""Simple orchestrator for executing pipeline scripts in order."""
+
 import logging
+import os
 import subprocess
 import sys
-import os
 from datetime import datetime
 
 # ---------------------- 로깅 설정 ----------------------
@@ -13,34 +15,39 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    "retry_dashboard_notifier.py",
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
-def run_script(script):
+def run_script(script: str) -> bool:
+    """Execute a single script from the ``scripts`` directory."""
     full_path = os.path.join("scripts", script)
     if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+        logging.error("❌ 파일이 존재하지 않습니다: %s", full_path)
         return False
 
-    logging.info(f"🚀 실행 중: {script}")
-    result = subprocess.run([sys.executable, full_path], capture_output=True, text=True)
+    logging.info("🚀 실행 중: %s", script)
+    result = subprocess.run(
+        [sys.executable, full_path],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
 
     if result.returncode != 0:
-        logging.error(f"❌ 실패: {script}\n{result.stderr}")
+        logging.error("❌ 실패: %s\n%s", script, result.stderr)
         return False
-    else:
-        logging.info(f"✅ 완료: {script}")
-        if result.stdout.strip():
-            print(result.stdout)
-        return True
+
+    logging.info("✅ 완료: %s", script)
+    if result.stdout.strip():
+        print(result.stdout)
+    return True
 
 # ---------------------- 전체 파이프라인 실행 ----------------------
-def run_pipeline():
-    logging.info(f"🧩 파이프라인 시작: {datetime.now().strftime('%Y-%m-%d %H:%M')}")
+def run_pipeline() -> None:
+    """Run all scripts defined in :data:`PIPELINE_SEQUENCE` sequentially."""
+    logging.info("🧩 파이프라인 시작: %s", datetime.now().strftime("%Y-%m-%d %H:%M"))
     all_passed = True
 
     for script in PIPELINE_SEQUENCE:

--- a/scripts/hook_generator.py
+++ b/scripts/hook_generator.py
@@ -1,0 +1,11 @@
+"""Wrapper script to run :mod:`hook_generator` from the ``scripts`` directory."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # pylint: disable=wrong-import-position
+
+from hook_generator import generate_hooks  # type: ignore
+
+if __name__ == "__main__":
+    generate_hooks()

--- a/scripts/retry_dashboard_notifier.py
+++ b/scripts/retry_dashboard_notifier.py
@@ -1,0 +1,15 @@
+"""Wrapper to update KPI dashboards using :mod:`retry_dashboard_notifier`."""
+
+import os
+import sys
+import logging
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # pylint: disable=wrong-import-position
+
+from retry_dashboard_notifier import get_retry_stats, push_kpi_to_notion  # type: ignore
+
+if __name__ == "__main__":
+    kpi = get_retry_stats()
+    if kpi:
+        logging.info("📈 KPI 요약: %s", kpi)
+        push_kpi_to_notion(kpi)

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest import mock
+import run_pipeline
+
+class TestPipeline(unittest.TestCase):
+    def test_sequence(self):
+        self.assertEqual(
+            run_pipeline.PIPELINE_SEQUENCE,
+            [
+                "hook_generator.py",
+                "retry_failed_uploads.py",
+                "retry_dashboard_notifier.py",
+            ],
+        )
+
+    def test_run_pipeline_invokes_all_scripts(self):
+        calls = []
+
+        def fake_run_script(name):
+            calls.append(name)
+            return True
+
+        with mock.patch("run_pipeline.run_script", side_effect=fake_run_script):
+            run_pipeline.run_pipeline()
+        self.assertEqual(calls, run_pipeline.PIPELINE_SEQUENCE)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove missing stages from `PIPELINE_SEQUENCE`
- add wrapper scripts under `scripts/`
- document pipeline flow in README
- create unit tests covering pipeline order

## Testing
- `mypy run_pipeline.py scripts/hook_generator.py scripts/retry_dashboard_notifier.py`
- `pylint run_pipeline.py scripts/hook_generator.py scripts/retry_dashboard_notifier.py`
- `python -m unittest discover -v tests`

------
https://chatgpt.com/codex/tasks/task_e_684f49055194832e932891698898a96e