### PR TITLE
Add basic test framework and A/B variant manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pylint
+      - name: Lint
+        run: pylint $(git ls-files '*.py')
+      - name: Test
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 logs/
+__pycache__/

--- a/src/ab_variant_manager/__init__.py
+++ b/src/ab_variant_manager/__init__.py
@@ -1,0 +1,30 @@
+"""A/B variant selection utilities."""
+
+from hashlib import sha256
+from typing import Iterable, Sequence
+
+
+def choose_variant(user_id: str, variants: Sequence[str]) -> str:
+    """Deterministically choose a variant based on ``user_id``.
+
+    Parameters
+    ----------
+    user_id:
+        Identifier used to select the variant.
+    variants:
+        Non-empty sequence of variant names.
+
+    Returns
+    -------
+    str
+        Selected variant from ``variants``.
+
+    Raises
+    ------
+    ValueError
+        If ``variants`` is empty.
+    """
+    if not variants:
+        raise ValueError("variants sequence cannot be empty")
+    index = int(sha256(user_id.encode()).hexdigest(), 16) % len(variants)
+    return variants[index]

--- a/tests/test_ab_variant_manager.py
+++ b/tests/test_ab_variant_manager.py
@@ -1,0 +1,27 @@
+"""Tests for the A/B variant manager utilities."""
+
+from src.ab_variant_manager import choose_variant
+
+
+def test_choose_variant_returns_variant():
+    """Selected variant should be one of the provided options."""
+    variants = ["A", "B", "C"]
+    user_id = "user123"
+    assert choose_variant(user_id, variants) in variants
+
+
+def test_choose_variant_deterministic():
+    """The function should return the same variant for the same user."""
+    variants = ["A", "B"]
+    uid = "alpha"
+    assert choose_variant(uid, variants) == choose_variant(uid, variants)
+
+
+def test_choose_variant_empty_list():
+    """An empty variant list should raise ``ValueError``."""
+    try:
+        choose_variant("x", [])
+    except ValueError:
+        assert True
+    else:
+        assert False


### PR DESCRIPTION
## Summary
- set up CI workflow
- create A/B variant manager module under `src`
- add pytest skeleton covering the new module
- ignore `__pycache__` files

## Testing
- `PYTHONPATH=. pytest -q`
- `PYTHONPATH=. pylint src tests`


------
https://chatgpt.com/codex/tasks/task_e_684f48bc6078832eaf7566ebb75cc12d