### PR TITLE
Add pytest suite with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/tests/test_hook_generator.py
+++ b/tests/test_hook_generator.py
@@ -1,0 +1,39 @@
+import sys
+from types import SimpleNamespace
+import importlib
+import pytest
+
+# helper to import hook_generator with mocked modules
+
+def import_hook_generator(openai_create):
+    sys.modules['dotenv'] = SimpleNamespace(load_dotenv=lambda: None)
+    sys.modules['openai'] = SimpleNamespace(ChatCompletion=SimpleNamespace(create=openai_create))
+    if 'hook_generator' in sys.modules:
+        del sys.modules['hook_generator']
+    import hook_generator
+    return hook_generator
+
+
+def test_generate_hook_prompt():
+    hg = import_hook_generator(lambda **k: None)
+    prompt = hg.generate_hook_prompt('키워드', '키', 'Google', 10, 1.2, 5)
+    assert '키워드' in prompt
+    assert 'Google' in prompt
+    assert '10' in prompt
+    assert '1.2' in prompt
+    assert '5' in prompt
+
+
+def test_get_gpt_response_retry(monkeypatch):
+    calls = {'n': 0}
+    def fake_create(**kwargs):
+        calls['n'] += 1
+        if calls['n'] < 2:
+            raise Exception('fail')
+        return SimpleNamespace(choices=[SimpleNamespace(message={'content': 'done'})])
+
+    hg = import_hook_generator(fake_create)
+    monkeypatch.setattr(hg.time, 'sleep', lambda x: None)
+    result = hg.get_gpt_response('prompt', retries=2)
+    assert result == 'done'
+    assert calls['n'] == 2

--- a/tests/test_notion_hook_uploader.py
+++ b/tests/test_notion_hook_uploader.py
@@ -1,0 +1,19 @@
+import sys
+import logging
+from types import SimpleNamespace
+import importlib
+
+sys.modules['dotenv'] = SimpleNamespace(load_dotenv=lambda: None)
+sys.modules['notion_client'] = SimpleNamespace(Client=lambda **k: 'client')
+logging.FileHandler = lambda *a, **kw: logging.NullHandler()
+if 'notion_hook_uploader' in sys.modules:
+    del sys.modules['notion_hook_uploader']
+import notion_hook_uploader
+
+
+def test_parse_generated_text():
+    text = """후킹 문장1: Hook1\n후킹 문장2: Hook2\n블로그 초안: Para1\nPara2\nPara3\n영상 제목:\n- Video1\n- Video2"""
+    parsed = notion_hook_uploader.parse_generated_text(text)
+    assert parsed['hook_lines'] == ['Hook1', 'Hook2']
+    assert parsed['blog_paragraphs'][0] == 'Para1'
+    assert parsed['video_titles'][0] == 'Video2'

--- a/tests/test_retry_failed_uploads.py
+++ b/tests/test_retry_failed_uploads.py
@@ -1,0 +1,41 @@
+import sys
+import os
+import json
+from pathlib import Path
+from types import SimpleNamespace
+import importlib
+
+sys.modules['dotenv'] = SimpleNamespace(load_dotenv=lambda: None)
+sys.modules['notion_client'] = SimpleNamespace(Client=lambda **k: 'client')
+
+os.environ['NOTION_API_TOKEN'] = 'x'
+os.environ['NOTION_HOOK_DB_ID'] = 'y'
+
+
+def import_retry_module(tmp_path):
+    os.environ['REPARSED_OUTPUT_PATH'] = str(tmp_path / 'failed.json')
+    if 'retry_failed_uploads' in sys.modules:
+        del sys.modules['retry_failed_uploads']
+    import retry_failed_uploads
+    return retry_failed_uploads
+
+
+def test_retry_logic(tmp_path, monkeypatch):
+    module = import_retry_module(tmp_path)
+    items = [{'keyword': 'k1'}, {'keyword': 'k2'}]
+    monkeypatch.setattr(module, 'load_failed_items', lambda: items)
+
+    calls = []
+    def mock_create(item):
+        calls.append(item)
+        if item['keyword'] == 'k1':
+            raise Exception('fail')
+    monkeypatch.setattr(module, 'create_retry_page', mock_create)
+    monkeypatch.setattr(module.time, 'sleep', lambda x: None)
+
+    module.retry_failed_uploads()
+
+    out = json.loads(Path(module.FAILED_PATH).read_text())
+    assert out[0]['keyword'] == 'k1'
+    assert out[0]['retry_error'] == 'fail'
+    assert len(calls) == 2


### PR DESCRIPTION
## Summary
- add pytest tests for hook generation, Notion hook parsing, and retry logic
- create GitHub Actions workflow to run pytest automatically

## Testing
- `pytest -q`
- `pylint hook_generator.py notion_hook_uploader.py retry_failed_uploads.py >/tmp/pylint.log || true`
- `mypy hook_generator.py notion_hook_uploader.py retry_failed_uploads.py >/tmp/mypy.log || true`


------
https://chatgpt.com/codex/tasks/task_e_684f4909f8d4832eb0cb4a3b309e0868