### PR TITLE
Add unit tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: Python Tests
+
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run pytest
+        run: pytest -q

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+openai
+notion-client
+python-dotenv
+pytest

--- a/tests/test_hook_generator.py
+++ b/tests/test_hook_generator.py
@@ -1,0 +1,61 @@
+import builtins
+import importlib
+from unittest import mock
+
+import hook_generator
+
+
+def test_generate_hook_prompt():
+    prompt = hook_generator.generate_hook_prompt(
+        keyword="test keyword",
+        topic="test",
+        source="twitter",
+        score=1,
+        growth=2,
+        mentions=3,
+    )
+    assert "test keyword" in prompt
+    assert "twitter" in prompt
+    assert "1" in prompt
+
+
+class DummyResp:
+    def __init__(self, content):
+        self.choices = [mock.Mock(message={'content': content})]
+
+
+def test_get_gpt_response_success(monkeypatch):
+    called = {}
+
+    def fake_create(**kwargs):
+        called['prompt'] = kwargs['messages'][0]['content']
+        return DummyResp("answer")
+
+    monkeypatch.setattr(hook_generator.openai.ChatCompletion, "create", fake_create)
+    res = hook_generator.get_gpt_response("hi", retries=2)
+    assert res == "answer"
+    assert called['prompt'] == "hi"
+
+
+def test_get_gpt_response_retry(monkeypatch):
+    calls = []
+
+    def fake_create(**kwargs):
+        calls.append(1)
+        if len(calls) < 3:
+            raise Exception("fail")
+        return DummyResp("ok")
+
+    monkeypatch.setattr(hook_generator.openai.ChatCompletion, "create", fake_create)
+    res = hook_generator.get_gpt_response("x", retries=3)
+    assert res == "ok"
+    assert len(calls) == 3
+
+
+def test_get_gpt_response_fail(monkeypatch):
+    def fake_create(**kwargs):
+        raise Exception("nope")
+
+    monkeypatch.setattr(hook_generator.openai.ChatCompletion, "create", fake_create)
+    res = hook_generator.get_gpt_response("x", retries=2)
+    assert res is None

--- a/tests/test_notion_hook_uploader.py
+++ b/tests/test_notion_hook_uploader.py
@@ -1,0 +1,22 @@
+import importlib
+from unittest import mock
+
+
+def test_parse_generated_text(monkeypatch):
+    monkeypatch.setattr('logging.FileHandler', lambda *a, **k: mock.Mock())
+    module = importlib.import_module('notion_hook_uploader')
+    sample = (
+        "후킹 문장1: Hook1\n"
+        "후킹문장2: Hook2\n"
+        "블로그 초안:\n"
+        "Para1\n"
+        "Para2\n"
+        "Para3\n"
+        "영상 제목:\n"
+        "- Title1\n"
+        "- Title2\n"
+    )
+    parsed = module.parse_generated_text(sample)
+    assert parsed["hook_lines"] == ["Hook1", "Hook2"]
+    assert parsed["blog_paragraphs"] == ["Para1"]
+    assert parsed["video_titles"] == ["Title2"]

--- a/tests/test_retry_failed_uploads.py
+++ b/tests/test_retry_failed_uploads.py
@@ -1,0 +1,37 @@
+import json
+import importlib
+
+import pytest
+
+
+def setup_module(module):
+    # ensure environment variables so module import does not exit
+    import os
+    os.environ.setdefault('NOTION_API_TOKEN', 'x')
+    os.environ.setdefault('NOTION_HOOK_DB_ID', 'y')
+
+
+def test_retry_logic(tmp_path, monkeypatch):
+    path = tmp_path / 'failed.json'
+    items = [
+        {'keyword': 'a'},
+        {'keyword': 'b'},
+        {'keyword': 'c'},
+    ]
+    path.write_text(json.dumps(items), encoding='utf-8')
+    monkeypatch.setenv('REPARSED_OUTPUT_PATH', str(path))
+
+    module = importlib.reload(importlib.import_module('retry_failed_uploads'))
+
+    def fake_create_retry_page(item):
+        if item['keyword'] == 'b':
+            raise Exception('boom')
+
+    monkeypatch.setattr(module, 'create_retry_page', fake_create_retry_page)
+    monkeypatch.setattr(module, 'RETRY_DELAY', 0)
+
+    module.retry_failed_uploads()
+
+    data = json.loads(path.read_text(encoding='utf-8'))
+    assert len(data) == 1
+    assert data[0]['keyword'] == 'b'


### PR DESCRIPTION
## Summary
- add pytest suites for hook generator, Notion uploader parser, and retry logic
- add requirements file for dependencies
- enable GitHub Actions workflow to run pytest on each commit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f49d6bb04832ebe83ef2f5150a3a2