### PR TITLE
Fix pipeline paths and workflow

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -12,16 +12,17 @@ logging.basicConfig(
 
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
+    "keyword_auto_pipeline.py",
     "hook_generator.py",
-    "parse_failed_gpt.py",
+    "notion_hook_uploader.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    "retry_dashboard_notifier.py",
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    full_path = os.path.join(base_dir, script)
     if not os.path.exists(full_path):
         logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
         return False

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -1,0 +1,22 @@
+import os
+from pathlib import Path
+import sys
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+from run_pipeline import run_script
+
+
+def test_run_script_missing():
+    assert not run_script('no_such_script.py')
+
+
+def test_run_script_success(tmp_path):
+    script_name = 'temp_test_script.py'
+    root_dir = Path(__file__).resolve().parents[1]
+    temp_script = root_dir / script_name
+    temp_script.write_text('print("ok")')
+    try:
+        assert run_script(script_name)
+    finally:
+        temp_script.unlink()
+


### PR DESCRIPTION
## Summary
- keep scripts at repo root and update `run_pipeline.py`
- correct `PIPELINE_SEQUENCE` to real scripts
- update workflow to call root `run_pipeline.py`
- add tests for `run_script`

## Testing
- `pytest -q`
- `pylint run_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684f53f464d4832ea101658aa8a34e44