### PR TITLE
Implement retry utilities and tests

### DIFF
--- a/notify_retry_result.py
+++ b/notify_retry_result.py
@@ -1,0 +1,44 @@
+import json
+import logging
+import os
+import urllib.request
+from typing import List, Dict, Optional
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def _send_slack(message: str, webhook_url: Optional[str]) -> None:
+    if not webhook_url:
+        logging.warning("⚠️ SLACK_WEBHOOK_URL 미설정")
+        return
+    data = json.dumps({"text": message}).encode("utf-8")
+    req = urllib.request.Request(webhook_url, data=data, headers={"Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req) as resp:
+            logging.info(f"✅ Slack 전송 완료 (status={resp.status})")
+    except Exception as exc:
+        logging.error(f"❌ Slack 전송 실패: {exc}")
+
+
+def notify(summary_path: Optional[str] = None, webhook_url: Optional[str] = None) -> None:
+    summary_path = summary_path or os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+    webhook_url = webhook_url or os.getenv("SLACK_WEBHOOK_URL")
+    assert summary_path is not None
+
+    if not os.path.exists(summary_path):
+        logging.info(f"❗ 요약 파일이 존재하지 않습니다: {summary_path}")
+        return
+
+    with open(summary_path, "r", encoding="utf-8") as f:
+        items: List[Dict] = json.load(f)
+
+    total = len(items)
+    failed = len([i for i in items if i.get("retry_error")])
+    success = total - failed
+    message = f"Retry Upload Result - Success: {success}, Failed: {failed}"
+    logging.info(message)
+    _send_slack(message, webhook_url)
+
+
+if __name__ == "__main__":
+    notify()

--- a/parse_failed_gpt.py
+++ b/parse_failed_gpt.py
@@ -1,0 +1,42 @@
+import json
+import logging
+import os
+from typing import List, Dict, Optional
+
+from notion_hook_uploader import parse_generated_text
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def parse_failed(input_path: Optional[str] = None, output_path: Optional[str] = None) -> None:
+    """Parse failed GPT results and save them for retry."""
+    input_path = input_path or os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+    output_path = output_path or os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+    assert input_path is not None
+    assert output_path is not None
+
+    if not os.path.exists(input_path):
+        logging.info(f"❗ 실패 로그 파일이 존재하지 않습니다: {input_path}")
+        return
+
+    with open(input_path, "r", encoding="utf-8") as f:
+        items: List[Dict] = json.load(f)
+
+    reparsed: List[Dict] = []
+    for item in items:
+        text = item.get("generated_text")
+        keyword = item.get("keyword")
+        if text:
+            item["parsed"] = parse_generated_text(text)
+        else:
+            logging.warning(f"✅ 재시도 필요: '{keyword}' 는 generated_text가 없습니다")
+        reparsed.append(item)
+
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(reparsed, f, ensure_ascii=False, indent=2)
+    logging.info(f"📄 재파싱 결과 저장: {output_path}")
+
+
+if __name__ == "__main__":
+    parse_failed()

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -20,8 +20,9 @@ PIPELINE_SEQUENCE = [
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
-def run_script(script):
-    full_path = os.path.join("scripts", script)
+def run_script(script: str) -> bool:
+    """Execute a single pipeline script."""
+    full_path = script if os.path.exists(script) else os.path.join("scripts", script)
     if not os.path.exists(full_path):
         logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
         return False

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,67 @@
+import json
+import os
+import json
+import urllib.request
+from pathlib import Path
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import importlib
+import types
+
+run_pipeline = importlib.import_module("run_pipeline")
+
+# Prepare dummy notion_hook_uploader before importing parse_failed_gpt
+dummy_module = types.ModuleType("notion_hook_uploader")
+def _dummy_parse(text: str):
+    return {"dummy": text}
+dummy_module.parse_generated_text = _dummy_parse
+sys.modules["notion_hook_uploader"] = dummy_module
+
+parse_failed_gpt = importlib.import_module("parse_failed_gpt")
+notify_retry_result = importlib.import_module("notify_retry_result")
+
+
+def test_parse_failed_creates_output(tmp_path: Path):
+    input_file = tmp_path / "failed.json"
+    output_file = tmp_path / "out.json"
+    sample = [{"keyword": "test", "generated_text": "후킹문장1: a\n후킹문장2: b"}]
+    input_file.write_text(json.dumps(sample, ensure_ascii=False))
+    parse_failed_gpt.parse_failed(str(input_file), str(output_file))
+    assert output_file.exists()
+    data = json.loads(output_file.read_text())
+    assert data[0]["keyword"] == "test"
+    assert "parsed" in data[0]
+
+
+def test_notify_retry_result_sends_message(monkeypatch, tmp_path: Path):
+    summary = tmp_path / "summary.json"
+    summary.write_text(json.dumps([{"keyword": "k", "retry_error": "x"}, {}], ensure_ascii=False))
+    messages = []
+
+    def fake_urlopen(req):
+        messages.append(json.loads(req.data.decode("utf-8"))["text"])
+        class Resp:
+            status = 200
+            def __enter__(self):
+                return self
+            def __exit__(self, exc_type, exc, tb):
+                pass
+        return Resp()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    notify_retry_result.notify(str(summary), "http://example.com")
+    assert messages and "Success: 1" in messages[0]
+
+
+def test_run_pipeline_executes_all(monkeypatch, tmp_path: Path):
+    scripts = []
+    for i in range(3):
+        path = tmp_path / f"s{i}.py"
+        path.write_text("print('x')")
+        scripts.append(str(path))
+
+    monkeypatch.setattr(run_pipeline, "PIPELINE_SEQUENCE", scripts)
+    run_pipeline.run_pipeline()


### PR DESCRIPTION
## Summary
- support running scripts from root or `scripts/`
- add `parse_failed_gpt.py` for post-processing failed GPT outputs
- add `notify_retry_result.py` for Slack reporting
- test pipeline utilities

## Testing
- `pylint parse_failed_gpt.py notify_retry_result.py run_pipeline.py tests/test_pipeline.py`
- `mypy --ignore-missing-imports parse_failed_gpt.py notify_retry_result.py run_pipeline.py tests/test_pipeline.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f53f4ee94832e9c18b9a86229c353