### PR TITLE
Fix daily pipeline YAML workflow

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -1,6 +1,7 @@
+---
 name: Daily Notion Hook Pipeline
 
-on:
+'on':
   schedule:
     - cron: '0 0 * * *'  # 매일 오전 9시 (KST 기준)
   workflow_dispatch:
@@ -46,4 +47,4 @@ jobs:
         run: |
           echo "## 🌐 Notion Hook 파이프라인 실행 완료" >> $GITHUB_STEP_SUMMARY
           echo "- 실행 시각: $(date '+%Y-%m-%d %H:%M:%S')" >> $GITHUB_STEP_SUMMARY
-          echo "- 실패 항목 JSON: logs/failed_keywords_reparsed.json" >> $GITHUB_STEP_SUMMARY
+          echo "- 실패 항목 JSON: ${REPARSED_OUTPUT_PATH}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- rename `daily-pipeline.yml.txt` -> `daily-pipeline.yml`
- add YAML document marker and quote reserved word
- use existing env var for artifact path
- verify workflow YAML with `yamllint`

## Testing
- `yamllint .github/workflows/daily-pipeline.yml`
- `curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" -d '{"ref":"main"}' https://api.github.com/repos/owner/repo/actions/workflows/daily-pipeline.yml/dispatches` *(fails: Bad credentials)*

------
https://chatgpt.com/codex/tasks/task_e_684f53f7688c832e8b12a8874bf7e912