### PR TITLE
Add test suite and CI pytest step

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -1,0 +1,52 @@
+name: Daily Notion Hook Pipeline
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # 매일 오전 9시 (KST 기준)
+  workflow_dispatch:
+
+jobs:
+  run-pipeline:
+    runs-on: ubuntu-latest
+
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      NOTION_API_TOKEN: ${{ secrets.NOTION_API_TOKEN }}
+      NOTION_HOOK_DB_ID: ${{ secrets.NOTION_HOOK_DB_ID }}
+      NOTION_KPI_DB_ID: ${{ secrets.NOTION_KPI_DB_ID }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      REPARSED_OUTPUT_PATH: logs/failed_keywords_reparsed.json
+
+    steps:
+      - name: 📂 Checkout repository
+        uses: actions/checkout@v3
+
+      - name: ⚖️ Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: 🛠️ Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: 🧪 Run tests
+        run: pytest -q
+
+      - name: ▶️ Run full pipeline (single entrypoint)
+        run: python scripts/run_pipeline.py
+
+      - name: 📋 Upload failed items (if any)
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: failed-keywords
+          path: logs/failed_keywords_reparsed.json
+
+      - name: ✍️ Append workflow summary
+        if: always()
+        run: |
+          echo "## 🌐 Notion Hook 파이프라인 실행 완료" >> $GITHUB_STEP_SUMMARY
+          echo "- 실행 시각: $(date '+%Y-%m-%d %H:%M:%S')" >> $GITHUB_STEP_SUMMARY
+          echo "- 실패 항목 JSON: logs/failed_keywords_reparsed.json" >> $GITHUB_STEP_SUMMARY

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+openai
+python-dotenv
+notion-client
+pytrends
+snscrape
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+import sys
+import types
+
+# Stub external modules at import time so tests can import project modules
+if 'dotenv' not in sys.modules:
+    dotenv = types.ModuleType('dotenv')
+    def load_dotenv(*args, **kwargs):
+        return None
+    dotenv.load_dotenv = load_dotenv
+    sys.modules['dotenv'] = dotenv
+
+if 'openai' not in sys.modules:
+    openai = types.ModuleType('openai')
+    class ChatCompletion:
+        @staticmethod
+        def create(*args, **kwargs):
+            raise NotImplementedError
+    openai.ChatCompletion = ChatCompletion
+    openai.api_key = None
+    sys.modules['openai'] = openai
+
+if 'notion_client' not in sys.modules:
+    notion_client = types.ModuleType('notion_client')
+    class DummyPages:
+        def create(self, *args, **kwargs):
+            return None
+    class Client:
+        def __init__(self, auth=None):
+            self.pages = DummyPages()
+            self.databases = types.SimpleNamespace(query=lambda **kw: {'results': []})
+    notion_client.Client = Client
+    sys.modules['notion_client'] = notion_client
+
+import pytest
+
+@pytest.fixture(autouse=True)
+def stub_external_modules(monkeypatch):
+    """Ensure stubs remain during tests."""
+    yield

--- a/tests/test_hook_generator.py
+++ b/tests/test_hook_generator.py
@@ -1,0 +1,68 @@
+import types
+import sys
+import time
+
+import pytest
+
+import hook_generator
+
+
+def test_generate_hook_prompt():
+    prompt = hook_generator.generate_hook_prompt(
+        keyword="keyword1",
+        topic="topic1",
+        source="Twitter",
+        score=10,
+        growth=1.5,
+        mentions=100,
+    )
+    assert "주제: keyword1" in prompt
+    assert "출처: Twitter" in prompt
+    assert "트렌드 점수: 10" in prompt
+    assert "성장률: 1.5" in prompt
+    assert "트윗 수: 100" in prompt
+
+
+def test_get_gpt_response(monkeypatch):
+    class MockChoice:
+        def __init__(self, content):
+            self.message = {"content": content}
+
+    class MockResponse:
+        def __init__(self, content):
+            self.choices = [MockChoice(content)]
+
+    calls = []
+
+    def mock_create(**kwargs):
+        calls.append(kwargs)
+        return MockResponse("hello")
+
+    monkeypatch.setattr(hook_generator.openai.ChatCompletion, "create", mock_create)
+    result = hook_generator.get_gpt_response("hi")
+    assert result == "hello"
+    assert len(calls) == 1
+
+
+def test_get_gpt_response_retries(monkeypatch):
+    class MockChoice:
+        def __init__(self, content):
+            self.message = {"content": content}
+
+    class MockResponse:
+        def __init__(self, content):
+            self.choices = [MockChoice(content)]
+
+    attempts = {"count": 0}
+
+    def mock_create(**kwargs):
+        attempts["count"] += 1
+        if attempts["count"] < 2:
+            raise Exception("fail")
+        return MockResponse("ok")
+
+    monkeypatch.setattr(hook_generator.openai.ChatCompletion, "create", mock_create)
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    result = hook_generator.get_gpt_response("hi", retries=2)
+    assert result == "ok"
+    assert attempts["count"] == 2

--- a/tests/test_notion_hook_uploader.py
+++ b/tests/test_notion_hook_uploader.py
@@ -1,0 +1,21 @@
+import os
+os.makedirs('logs', exist_ok=True)
+import notion_hook_uploader as nhu
+
+
+def test_parse_generated_text():
+    sample = (
+        "후킹 문장1: 첫번째 문장\n"
+        "후킹 문장2: 두번째 문장\n"
+        "블로그 초안: 서론\n"
+        "첫 문단 내용\n"
+        "둘째 문단 내용\n"
+        "셋째 문단 내용\n"
+        "영상 제목:\n"
+        "- 비디오제목1\n"
+        "- 비디오제목2\n"
+    )
+    parsed = nhu.parse_generated_text(sample)
+    assert parsed["hook_lines"] == ["첫번째 문장", "두번째 문장"]
+    assert parsed["blog_paragraphs"] == ["서론"]
+    assert parsed["video_titles"] == ["비디오제목2"]

--- a/tests/test_retry_failed_uploads.py
+++ b/tests/test_retry_failed_uploads.py
@@ -1,0 +1,57 @@
+import importlib
+import json
+import types
+import sys
+import time
+
+import pytest
+
+
+def setup_module(module):
+    # create dummy notion_client before import
+    dummy = types.ModuleType('notion_client')
+    class DummyPages:
+        def create(self, *args, **kwargs):
+            pass
+    class DummyClient:
+        def __init__(self, auth=None):
+            self.pages = DummyPages()
+    dummy.Client = DummyClient
+    sys.modules['notion_client'] = dummy
+    sys.modules.setdefault('dotenv', types.SimpleNamespace(load_dotenv=lambda: None))
+
+
+def import_module(monkeypatch, tmp_path):
+    monkeypatch.setenv('NOTION_API_TOKEN', 'x')
+    monkeypatch.setenv('NOTION_HOOK_DB_ID', 'y')
+    failed_path = tmp_path / 'failed.json'
+    monkeypatch.setenv('REPARSED_OUTPUT_PATH', str(failed_path))
+    module = importlib.reload(importlib.import_module('retry_failed_uploads'))
+    return module, failed_path
+
+
+def test_retry_failed_uploads(monkeypatch, tmp_path):
+    module, path = import_module(monkeypatch, tmp_path)
+
+    items = [
+        {'keyword': 'a'},
+        {'keyword': 'b'},
+    ]
+    def mock_load():
+        return items
+    calls = []
+    def mock_create(item):
+        calls.append(item['keyword'])
+        if item['keyword'] == 'a':
+            raise Exception('boom')
+    monkeypatch.setattr(module, 'load_failed_items', mock_load)
+    monkeypatch.setattr(module, 'create_retry_page', mock_create)
+    monkeypatch.setattr(time, 'sleep', lambda x: None)
+
+    module.retry_failed_uploads()
+
+    with open(path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    assert data[0]['keyword'] == 'a'
+    assert 'retry_error' in data[0]
+    assert calls == ['a', 'b']


### PR DESCRIPTION
## Summary
- create pytest suite for hook generator, notion parser, and retry logic
- stub external modules for tests
- add package requirements
- update GitHub Actions workflow to run tests

## Testing
- `pylint $(git ls-files '*.py')` *(fails: Module 'openai' has no 'ChatCompletion' member)*
- `mypy $(git ls-files '*.py')` *(fails: Duplicate module named "retry_failed_uploads")*
- `sqlfluff lint`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f53f8ffa0832eb747720fb713a2e1