### PR TITLE
Fix pipeline script path in daily workflow

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()


### PR DESCRIPTION
## Summary
- correct pipeline script location in workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f57644998832eb5eddf4e1a812021