### PR TITLE
Add initial pytest suite for utility functions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import sys
+import types
+import logging
+import pytest
+
+@pytest.fixture(autouse=True)
+def patch_external_modules(monkeypatch):
+    # Patch modules not installed in test environment
+    monkeypatch.setitem(sys.modules, 'dotenv', types.SimpleNamespace(load_dotenv=lambda: None))
+    monkeypatch.setitem(sys.modules, 'notion_client', types.SimpleNamespace(Client=lambda *a, **kw: None))
+
+    sns = types.ModuleType('snscrape')
+    sns.modules = types.ModuleType('snscrape.modules')
+    sns.modules.twitter = types.ModuleType('snscrape.modules.twitter')
+    monkeypatch.setitem(sys.modules, 'snscrape', sns)
+    monkeypatch.setitem(sys.modules, 'snscrape.modules', sns.modules)
+    monkeypatch.setitem(sys.modules, 'snscrape.modules.twitter', sns.modules.twitter)
+
+    pytrends = types.ModuleType('pytrends.request')
+    pytrends.TrendReq = lambda *a, **kw: None
+    monkeypatch.setitem(sys.modules, 'pytrends.request', pytrends)
+
+    monkeypatch.setattr(logging, 'FileHandler', lambda *a, **kw: logging.NullHandler())
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,60 @@
+from importlib import reload
+from types import SimpleNamespace
+
+
+def test_parse_generated_text_full():
+    import notion_hook_uploader
+    reload(notion_hook_uploader)
+    text = (
+        "후킹 문장1: 훅1\n"
+        "후킹 문장2: 훅2\n"
+        "블로그 초안: 문단1\n문단2\n문단3\n"
+        "영상 제목:\n- 제목1\n- 제목2\n"
+    )
+    result = notion_hook_uploader.parse_generated_text(text)
+    assert result["hook_lines"] == ["훅1", "훅2"]
+    assert result["blog_paragraphs"] == ["문단1"]
+    assert result["video_titles"] == ["제목2"]
+
+
+def test_parse_generated_text_missing_sections():
+    import notion_hook_uploader
+    reload(notion_hook_uploader)
+    text = "후킹 문장1: A\n후킹 문장2: B"
+    result = notion_hook_uploader.parse_generated_text(text)
+    assert result["hook_lines"] == ["A", "B"]
+    assert result["blog_paragraphs"] == ["", "", ""]
+    assert result["video_titles"] == ["", ""]
+
+
+def test_page_exists(monkeypatch):
+    import notion_hook_uploader
+    reload(notion_hook_uploader)
+    class DummyDB:
+        def __init__(self, ret, raise_err=False):
+            self.ret = ret
+            self.raise_err = raise_err
+        def query(self, **kwargs):
+            if self.raise_err:
+                raise ValueError("fail")
+            return self.ret
+    notion_hook_uploader.notion = SimpleNamespace(databases=DummyDB({"results": [{}]}))
+    assert notion_hook_uploader.page_exists("kw") is True
+    notion_hook_uploader.notion = SimpleNamespace(databases=DummyDB({"results": []}))
+    assert notion_hook_uploader.page_exists("kw") is False
+    notion_hook_uploader.notion = SimpleNamespace(databases=DummyDB({}, raise_err=True))
+    assert notion_hook_uploader.page_exists("kw") is False
+
+
+def test_filter_keywords():
+    import keyword_auto_pipeline
+    reload(keyword_auto_pipeline)
+    entries = [
+        {"keyword": "a", "source": "GoogleTrends", "score": 60, "growth": 1.3, "cpc": 1000},
+        {"keyword": "b", "source": "GoogleTrends", "score": 50, "growth": 1.5, "cpc": 1000},
+        {"keyword": "c", "source": "Twitter", "mentions": 30, "top_retweet": 50, "cpc": 1000},
+        {"keyword": "d", "source": "Twitter", "mentions": 20, "top_retweet": 50, "cpc": 1000},
+    ]
+    result = keyword_auto_pipeline.filter_keywords(entries)
+    assert {e["keyword"] for e in result} == {"a", "c"}
+


### PR DESCRIPTION
## Summary
- introduce `tests/` directory using pytest
- cover `parse_generated_text`, `page_exists`, and `filter_keywords`
- mock external API modules so tests run offline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f5766ae9c832e97400fe03bff715f