### PR TITLE
Centralize environment loading

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,45 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+class ConfigError(Exception):
+    """Raised when a required environment variable is missing or invalid."""
+    pass
+
+
+def get_env(name: str, default=None, *, cast=None):
+    value = os.getenv(name, default)
+    if cast and value is not None:
+        try:
+            value = cast(value)
+        except (ValueError, TypeError):
+            raise ConfigError(f"Invalid value for environment variable '{name}': {value}")
+    return value
+
+# File paths and tokens
+TOPIC_CHANNELS_PATH = get_env("TOPIC_CHANNELS_PATH", "config/topic_channels.json")
+KEYWORD_OUTPUT_PATH = get_env("KEYWORD_OUTPUT_PATH", "data/keyword_output_with_cpc.json")
+HOOK_OUTPUT_PATH = get_env("HOOK_OUTPUT_PATH", "data/generated_hooks.json")
+FAILED_HOOK_PATH = get_env("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+REPARSED_OUTPUT_PATH = get_env("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+UPLOADED_CACHE_PATH = get_env("UPLOADED_CACHE_PATH", "data/uploaded_keywords_cache.json")
+FAILED_UPLOADS_PATH = get_env("FAILED_UPLOADS_PATH", "logs/failed_uploads.json")
+
+OPENAI_API_KEY = get_env("OPENAI_API_KEY")
+NOTION_API_TOKEN = get_env("NOTION_API_TOKEN")
+NOTION_DB_ID = get_env("NOTION_DB_ID")
+NOTION_HOOK_DB_ID = get_env("NOTION_HOOK_DB_ID")
+NOTION_KPI_DB_ID = get_env("NOTION_KPI_DB_ID")
+
+# Numeric settings
+UPLOAD_DELAY = get_env("UPLOAD_DELAY", 0.5, cast=float)
+RETRY_DELAY = get_env("RETRY_DELAY", 0.5, cast=float)
+API_DELAY = get_env("API_DELAY", 1.0, cast=float)
+
+
+def require(*names: str) -> None:
+    """Ensure the given env vars are present and not empty."""
+    missing = [n for n in names if globals().get(n) in (None, "")]
+    if missing:
+        raise ConfigError("Missing required environment variables: " + ", ".join(missing))

--- a/hook_generator.py
+++ b/hook_generator.py
@@ -3,16 +3,16 @@ import json
 import time
 import logging
 from datetime import datetime
-from dotenv import load_dotenv
 import openai
+import config
 
 # ---------------------- 설정 로딩 ----------------------
-load_dotenv()
-KEYWORD_JSON_PATH = os.getenv("KEYWORD_OUTPUT_PATH", "data/keyword_output_with_cpc.json")
-HOOK_OUTPUT_PATH = os.getenv("HOOK_OUTPUT_PATH", "data/generated_hooks.json")
-FAILED_HOOK_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-API_DELAY = float(os.getenv("API_DELAY", "1.0"))
+KEYWORD_JSON_PATH = config.KEYWORD_OUTPUT_PATH
+HOOK_OUTPUT_PATH = config.HOOK_OUTPUT_PATH
+FAILED_HOOK_PATH = config.FAILED_HOOK_PATH
+OPENAI_API_KEY = config.OPENAI_API_KEY
+API_DELAY = config.API_DELAY
+config.require("OPENAI_API_KEY")
 
 openai.api_key = OPENAI_API_KEY
 

--- a/keyword_auto_pipeline.py
+++ b/keyword_auto_pipeline.py
@@ -7,10 +7,11 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pytrends.request import TrendReq
 import snscrape.modules.twitter as sntwitter
 import random  # CPC 더미 데이터용
+import config
 
 # ---------------------- 설정 ----------------------
-CONFIG_PATH = os.getenv("TOPIC_CHANNELS_PATH", "config/topic_channels.json")
-OUTPUT_PATH = os.getenv("KEYWORD_OUTPUT_PATH", "data/keyword_output_with_cpc.json")
+CONFIG_PATH = config.TOPIC_CHANNELS_PATH
+OUTPUT_PATH = config.KEYWORD_OUTPUT_PATH
 
 GOOGLE_TRENDS_MIN_SCORE = 60
 GOOGLE_TRENDS_MIN_GROWTH = 1.3

--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -5,15 +5,15 @@ import logging
 import re
 from datetime import datetime
 from notion_client import Client
-from dotenv import load_dotenv
+import config
 
 # ---------------------- 설정 로딩 ----------------------
-load_dotenv()
-NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
-NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
-HOOK_JSON_PATH = os.getenv("HOOK_OUTPUT_PATH", "data/generated_hooks.json")
+NOTION_TOKEN = config.NOTION_API_TOKEN
+NOTION_HOOK_DB_ID = config.NOTION_HOOK_DB_ID
+HOOK_JSON_PATH = config.HOOK_OUTPUT_PATH
 FAILED_OUTPUT_PATH = "data/upload_failed_hooks.json"
-UPLOAD_DELAY = float(os.getenv("UPLOAD_DELAY", "0.5"))
+UPLOAD_DELAY = config.UPLOAD_DELAY
+config.require("NOTION_API_TOKEN", "NOTION_HOOK_DB_ID")
 
 notion = Client(auth=NOTION_TOKEN)
 logging.basicConfig(

--- a/retry_dashboard_notifier.py
+++ b/retry_dashboard_notifier.py
@@ -3,20 +3,17 @@ import json
 import logging
 from datetime import datetime
 from notion_client import Client
-from dotenv import load_dotenv
+import config
 
 # ---------------------- 설정 로딩 ----------------------
-load_dotenv()
-NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
-NOTION_KPI_DB_ID = os.getenv("NOTION_KPI_DB_ID")
-SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+NOTION_TOKEN = config.NOTION_API_TOKEN
+NOTION_KPI_DB_ID = config.NOTION_KPI_DB_ID
+SUMMARY_PATH = config.REPARSED_OUTPUT_PATH
+config.require("NOTION_API_TOKEN", "NOTION_KPI_DB_ID")
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
 
 # ---------------------- Notion 클라이언트 ----------------------
-if not NOTION_TOKEN or not NOTION_KPI_DB_ID:
-    logging.error("❗ 환경 변수(NOTION_API_TOKEN, NOTION_KPI_DB_ID)가 누락되었습니다.")
-    exit(1)
 notion = Client(auth=NOTION_TOKEN)
 
 # ---------------------- KPI 데이터 수집 ----------------------

--- a/retry_failed_uploads.py
+++ b/retry_failed_uploads.py
@@ -4,21 +4,18 @@ import time
 import logging
 from datetime import datetime
 from notion_client import Client
-from dotenv import load_dotenv
+import config
 
 # ---------------------- 설정 로딩 ----------------------
-load_dotenv()
-NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
-NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
-FAILED_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
-RETRY_DELAY = float(os.getenv("RETRY_DELAY", "0.5"))
+NOTION_TOKEN = config.NOTION_API_TOKEN
+NOTION_HOOK_DB_ID = config.NOTION_HOOK_DB_ID
+FAILED_PATH = config.REPARSED_OUTPUT_PATH
+RETRY_DELAY = config.RETRY_DELAY
+config.require("NOTION_API_TOKEN", "NOTION_HOOK_DB_ID")
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
 
 # ---------------------- Notion 클라이언트 ----------------------
-if not NOTION_TOKEN or not NOTION_HOOK_DB_ID:
-    logging.error("❗ 환경 변수(NOTION_API_TOKEN, NOTION_HOOK_DB_ID)가 누락되었습니다.")
-    exit(1)
 notion = Client(auth=NOTION_TOKEN)
 
 # ---------------------- 유틸: rich_text 길이 제한 ----------------------

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import os
 from datetime import datetime
+import config  # noqa: F401
 
 # ---------------------- 로깅 설정 ----------------------
 logging.basicConfig(

--- a/scripts/notion_uploader.py
+++ b/scripts/notion_uploader.py
@@ -4,16 +4,16 @@ import time
 import logging
 from datetime import datetime
 from notion_client import Client
-from dotenv import load_dotenv
+import config
 
 # ---------------------- 설정 로딩 ----------------------
-load_dotenv()
-NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
-NOTION_DB_ID = os.getenv("NOTION_DB_ID")
-KEYWORD_JSON_PATH = os.getenv("KEYWORD_OUTPUT_PATH", "data/keyword_output_with_cpc.json")
-UPLOAD_DELAY = float(os.getenv("UPLOAD_DELAY", "0.5"))
-CACHE_PATH = os.getenv("UPLOADED_CACHE_PATH", "data/uploaded_keywords_cache.json")
-FAILED_PATH = os.getenv("FAILED_UPLOADS_PATH", "logs/failed_uploads.json")
+NOTION_TOKEN = config.NOTION_API_TOKEN
+NOTION_DB_ID = config.NOTION_DB_ID
+KEYWORD_JSON_PATH = config.KEYWORD_OUTPUT_PATH
+UPLOAD_DELAY = config.UPLOAD_DELAY
+CACHE_PATH = config.UPLOADED_CACHE_PATH
+FAILED_PATH = config.FAILED_UPLOADS_PATH
+config.require("NOTION_API_TOKEN", "NOTION_DB_ID")
 
 # ---------------------- 로깅 설정 ----------------------
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
@@ -66,9 +66,6 @@ def create_notion_page(item):
 
 # ---------------------- 업로드 메인 함수 ----------------------
 def upload_all_keywords():
-    if not NOTION_TOKEN or not NOTION_DB_ID:
-        logging.error("❗ 환경 변수(NOTION_API_TOKEN, NOTION_DB_ID)가 누락되었습니다.")
-        return
 
     try:
         with open(KEYWORD_JSON_PATH, 'r', encoding='utf-8') as f:

--- a/scripts/retry_failed_uploads.py
+++ b/scripts/retry_failed_uploads.py
@@ -4,21 +4,18 @@ import time
 import logging
 from datetime import datetime
 from notion_client import Client
-from dotenv import load_dotenv
+import config
 
 # ---------------------- 설정 로딩 ----------------------
-load_dotenv()
-NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
-NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
-FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_keywords.json")
-RETRY_DELAY = float(os.getenv("RETRY_DELAY", "0.5"))
+NOTION_TOKEN = config.NOTION_API_TOKEN
+NOTION_HOOK_DB_ID = config.NOTION_HOOK_DB_ID
+FAILED_PATH = config.FAILED_HOOK_PATH
+RETRY_DELAY = config.RETRY_DELAY
+config.require("NOTION_API_TOKEN", "NOTION_HOOK_DB_ID")
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
 
 # ---------------------- Notion 클라이언트 ----------------------
-if not NOTION_TOKEN or not NOTION_HOOK_DB_ID:
-    logging.error("❗ 환경 변수(NOTION_API_TOKEN, NOTION_HOOK_DB_ID)가 누락되었습니다.")
-    exit(1)
 notion = Client(auth=NOTION_TOKEN)
 
 # ---------------------- 유틸: rich_text 길이 제한 ----------------------


### PR DESCRIPTION
## Summary
- validate environment variables in new `config.py`
- use the centralized config in all pipeline scripts

## Testing
- `pytest -q`
- `pylint *.py scripts/*.py`
- `mypy *.py scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684f57681df0832ea71606a34058ab06