### PR TITLE
Add DB status tracking and tests

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -4,6 +4,10 @@ import sys
 import os
 from datetime import datetime
 
+from src.db_handler import update_db_status
+
+from src.db_handler import update_db_status
+
 # ---------------------- 로깅 설정 ----------------------
 logging.basicConfig(
     level=logging.INFO,
@@ -41,10 +45,12 @@ def run_script(script):
 # ---------------------- 전체 파이프라인 실행 ----------------------
 def run_pipeline():
     logging.info(f"🧩 파이프라인 시작: {datetime.now().strftime('%Y-%m-%d %H:%M')}")
+    update_db_status("Pipeline Start", "In Progress")
     all_passed = True
 
     for script in PIPELINE_SEQUENCE:
         success = run_script(script)
+        update_db_status(script, "Success" if success else "Failed")
         if not success:
             all_passed = False
             # 실패해도 계속 실행할 것인지 중단할 것인지 선택 가능
@@ -53,8 +59,10 @@ def run_pipeline():
     logging.info("🎯 파이프라인 전체 완료")
     if all_passed:
         logging.info("✅ 모든 단계 성공적으로 완료")
+        update_db_status("Pipeline End", "Completed")
     else:
         logging.warning("⚠️ 일부 단계에서 실패 발생")
+        update_db_status("Pipeline End", "Failed")
 
 # ---------------------- 진입점 ----------------------
 if __name__ == "__main__":

--- a/src/content_generator.py
+++ b/src/content_generator.py
@@ -1,0 +1,20 @@
+import logging
+from .db_handler import update_db_status
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+
+def generate_content(topic: str, language: str):
+    """Generate dummy content for a topic."""
+    try:
+        content = {
+            "title": f"Generated content for {topic}",
+            "body": f"Content generated in {language} language."
+        }
+        update_db_status("Content Generation", "Success")
+        return content
+    except Exception as exc:  # pragma: no cover - log-only path
+        update_db_status("Content Generation", "Failed", str(exc))
+        logger.error("Error generating content: %s", exc, exc_info=True)
+        return None

--- a/src/db_handler.py
+++ b/src/db_handler.py
@@ -1,0 +1,40 @@
+import os
+import logging
+import psycopg2
+from psycopg2 import sql
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+
+def get_db_connection():
+    """Create a database connection using environment variables."""
+    return psycopg2.connect(
+        dbname=os.getenv("DB_NAME", "your_db_name"),
+        user=os.getenv("DB_USER", "your_user"),
+        password=os.getenv("DB_PASSWORD", "your_password"),
+        host=os.getenv("DB_HOST", "your_host"),
+        port=os.getenv("DB_PORT", "your_port"),
+    )
+
+
+def update_db_status(step_name: str, status: str, error_details: str | None = None) -> None:
+    """Insert a pipeline status record into the database."""
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        query = sql.SQL(
+            """
+            INSERT INTO pipeline_status (step_name, status, error_details, timestamp)
+            VALUES (%s, %s, %s, NOW())
+            """
+        )
+        cursor.execute(query, (step_name, status, error_details))
+        conn.commit()
+        logger.info("DB status updated for %s with status %s", step_name, status)
+    except Exception as exc:  # pragma: no cover - log-only path
+        logger.error("Failed to update DB status for %s: %s", step_name, exc, exc_info=True)
+    finally:
+        cursor.close()
+        conn.close()
+

--- a/tests/test_content_generator.py
+++ b/tests/test_content_generator.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch, call
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src import content_generator
+
+
+@patch('src.content_generator.update_db_status')
+def test_generate_content_success(mock_update):
+    result = content_generator.generate_content('AI', 'English')
+    assert result['title'] == 'Generated content for AI'
+    mock_update.assert_called_with('Content Generation', 'Success')
+
+
+@patch('src.content_generator.logger')
+@patch('src.content_generator.update_db_status')
+def test_generate_content_error(mock_update, mock_logger):
+    mock_update.side_effect = [Exception('boom'), None]
+    result = content_generator.generate_content('AI', 'English')
+    assert result is None
+    mock_update.assert_has_calls([
+        call('Content Generation', 'Success'),
+        call('Content Generation', 'Failed', 'boom'),
+    ])
+    mock_logger.error.assert_called()

--- a/tests/test_db_handler.py
+++ b/tests/test_db_handler.py
@@ -1,0 +1,22 @@
+from unittest.mock import MagicMock, patch
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src import db_handler
+
+
+@patch('src.db_handler.psycopg2.connect')
+def test_update_db_status(mock_connect):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_connect.return_value = mock_conn
+    mock_conn.cursor.return_value = mock_cursor
+
+    db_handler.update_db_status('step', 'Success')
+
+    mock_cursor.execute.assert_called_once()
+    mock_conn.commit.assert_called_once()
+    mock_cursor.close.assert_called_once()
+    mock_conn.close.assert_called_once()


### PR DESCRIPTION
## Summary
- implement `db_handler` with DB status update helper
- implement `content_generator` and integrate DB status updates
- update `run_pipeline` to log status of each step into DB
- add unit tests for new modules

## Testing
- `pylint src/db_handler.py src/content_generator.py run_pipeline.py`
- `mypy src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f57add334832e915d2410c0e532ff