### PR TITLE
Fix workflow script path

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()


### PR DESCRIPTION
## Summary
- run the pipeline directly in GitHub Actions instead of referencing a non-existent scripts folder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f684da8c48322b190177f8143e476