### PR TITLE
Add content validation for Notion uploads

### DIFF
--- a/content_validator.py
+++ b/content_validator.py
@@ -1,0 +1,41 @@
+import logging
+import re
+
+# List of banned terms or phrases that violate platform policies
+BANNED_TERMS = [
+    "guaranteed",
+    "make money fast",
+    "성인",
+    "도박",
+]
+
+
+def contains_banned_term(text: str):
+    """Check if the text contains any banned term.
+
+    Returns a tuple of (is_valid, offending_term).
+    """
+    for term in BANNED_TERMS:
+        if re.search(term, text, re.IGNORECASE):
+            return False, term
+    return True, None
+
+
+def validate_content(parsed: dict) -> bool:
+    """Validate parsed hook content.
+
+    The parsed dictionary should contain lists under the keys 'hook_lines',
+    'blog_paragraphs' and 'video_titles'. If any banned term is found in the
+    text fields this function returns False.
+    """
+    texts = []
+    texts.extend(parsed.get("hook_lines", []))
+    texts.extend(parsed.get("blog_paragraphs", []))
+    texts.extend(parsed.get("video_titles", []))
+
+    for text in texts:
+        valid, term = contains_banned_term(text)
+        if not valid:
+            logging.error(f"❌ 금지어 발견: '{term}' in '{text}'")
+            return False
+    return True

--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -6,6 +6,7 @@ import re
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from content_validator import validate_content
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -59,6 +60,8 @@ def parse_generated_text(text):
 def create_notion_page(item):
     keyword = item["keyword"]
     parsed = parse_generated_text(item.get("generated_text", ""))
+    if not validate_content(parsed):
+        raise ValueError("Generated content contains banned terms")
     topic = keyword.split()[0] if " " in keyword else keyword
 
     notion.pages.create(

--- a/retry_failed_uploads.py
+++ b/retry_failed_uploads.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from content_validator import validate_content
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -46,6 +47,9 @@ def create_retry_page(item):
         "blog_paragraphs": item.get("blog_paragraphs", ["", "", ""]),
         "video_titles": item.get("video_titles", ["", ""])
     }
+
+    if not validate_content(parsed):
+        raise ValueError("Generated content contains banned terms")
 
     notion.pages.create(
         parent={"database_id": NOTION_HOOK_DB_ID},

--- a/scripts/retry_failed_uploads.py
+++ b/scripts/retry_failed_uploads.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from content_validator import validate_content
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -46,6 +47,9 @@ def create_retry_page(item):
         "blog_paragraphs": item.get("blog_paragraphs", ["", "", ""]),
         "video_titles": item.get("video_titles", ["", ""])
     }
+
+    if not validate_content(parsed):
+        raise ValueError("Generated content contains banned terms")
 
     notion.pages.create(
         parent={"database_id": NOTION_HOOK_DB_ID},


### PR DESCRIPTION
## Summary
- implement `content_validator` module with banned-term detection
- validate parsed hook content before uploading to Notion
- apply validation in normal and retry upload scripts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_684f69c65a908322933fbb1e463f85c6