### PR TITLE
Add sustainable content strategy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Auto_Pipeline
+
+This repository contains automation scripts for uploading content and retry logic for failed tasks. For a long-term approach to maximizing content performance and adapting to platform changes, see [SUSTAINABLE_CONTENT_STRATEGY.md](docs/SUSTAINABLE_CONTENT_STRATEGY.md).

--- a/docs/SUSTAINABLE_CONTENT_STRATEGY.md
+++ b/docs/SUSTAINABLE_CONTENT_STRATEGY.md
@@ -1,0 +1,100 @@
+# 지속 가능한 콘텐츠 최적화 및 개선 전략
+
+이 문서는 Auto_Pipeline 프로젝트가 장기적으로 다양한 플랫폼의 알고리즘 변화에 적응하고, 콘텐츠 성과를 극대화할 수 있도록 돕기 위한 전략을 정리합니다. 또한 프로젝트를 확장 가능한 구조로 설계하고 팀이나 사용자가 손쉽게 유지보수할 수 있도록 하는 방법을 포함합니다.
+
+## 1. 지속적인 데이터 수집 및 분석 시스템
+- 플랫폼별 데이터를 주기적으로 수집하여 저장합니다.
+- 수집된 데이터를 기반으로 성과를 분석해 향후 전략을 수립합니다.
+
+### 예시 코드
+```python
+class DataCollector:
+    def __init__(self, platforms: list):
+        self.platforms = platforms
+    def collect_data(self, platform_name: str):
+        if platform_name == "YouTube":
+            return self.collect_youtube_data()
+        elif platform_name == "Instagram":
+            return self.collect_instagram_data()
+        else:
+            return f"Data collection for {platform_name} is not supported"
+    def collect_youtube_data(self):
+        return {"views": 1500, "likes": 250, "shares": 45}
+    def collect_instagram_data(self):
+        return {"likes": 350, "comments": 75, "shares": 20}
+```
+
+## 2. AI 기반 성과 예측 시스템
+- 과거 데이터를 활용하여 새로운 콘텐츠의 성과를 예측합니다.
+- 최신 트렌드를 분석하여 향후 인기 있을 주제를 파악합니다.
+
+### 예시 코드
+```python
+class AIPredictor:
+    def __init__(self, historical_data):
+        self.historical_data = historical_data
+    def predict_performance(self, new_content):
+        predicted_views = sum(self.historical_data["views"]) / len(self.historical_data["views"])
+        predicted_likes = sum(self.historical_data["likes"]) / len(self.historical_data["likes"])
+        predicted_shares = sum(self.historical_data["shares"]) / len(self.historical_data["shares"])
+        return {
+            "predicted_views": predicted_views,
+            "predicted_likes": predicted_likes,
+            "predicted_shares": predicted_shares,
+        }
+    def predict_trends(self):
+        return "Trending topics: AI, Automation, 2025 Technology"
+```
+
+## 3. 플랫폼별 알고리즘 변동 모니터링 및 대응
+- 알고리즘 변화를 주기적으로 확인하고 이에 맞춰 전략을 수정합니다.
+- 플랫폼 정책 변경 사항을 자동으로 반영합니다.
+
+### 예시 코드
+```python
+class AlgorithmMonitor:
+    def __init__(self, platforms):
+        self.platforms = platforms
+    def monitor_algorithm_changes(self):
+        algorithm_updates = {
+            "YouTube": "YouTube algorithm now favors longer videos over shorter videos",
+            "Instagram": "Instagram Reels now supports up to 90 seconds",
+        }
+        return algorithm_updates
+    def update_strategy(self, algorithm_changes):
+        if "YouTube" in algorithm_changes:
+            return "Switch focus to longer-form YouTube videos."
+        if "Instagram" in algorithm_changes:
+            return "Adapt to new Instagram Reels length limit."
+        return "No changes needed."
+```
+
+## 4. 사용자 피드백 시스템
+- 댓글과 반응을 수집하여 긍정적/부정적 피드백을 분석합니다.
+- 부정적인 피드백이 많은 경우 개선 계획을 수립합니다.
+
+### 예시 코드
+```python
+class UserFeedback:
+    def __init__(self, user_comments):
+        self.user_comments = user_comments
+    def analyze_feedback(self):
+        positive_comments = [c for c in self.user_comments if "good" in c or "great" in c]
+        negative_comments = [c for c in self.user_comments if "bad" in c or "poor" in c]
+        return {
+            "positive": len(positive_comments),
+            "negative": len(negative_comments),
+        }
+    def generate_improvement_plan(self, feedback_analysis):
+        if feedback_analysis["negative"] > feedback_analysis["positive"]:
+            return "Consider improving content quality or changing posting time."
+        return "No significant changes needed."
+```
+
+## 실행 전략 요약
+1. 데이터 수집 및 분석을 통해 성과 예측과 트렌드 예측을 수행합니다.
+2. AI 모델을 활용하여 콘텐츠 성과를 미리 예측하고 실시간 피드백을 반영합니다.
+3. 플랫폼 알고리즘 변화를 모니터링하고 즉각 대응합니다.
+4. 사용자 피드백을 활용해 콘텐츠 품질을 지속적으로 개선합니다.
+
+이 문서를 기반으로 Auto_Pipeline 프로젝트의 확장성과 유지보수성을 높일 수 있습니다.


### PR DESCRIPTION
## Summary
- document sustainable content strategy in new `docs/SUSTAINABLE_CONTENT_STRATEGY.md`
- add a short `README.md` linking to the strategy doc

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684f69ec06108322a39021447ca738bd