### PR TITLE
Add content guideline validation

### DIFF
--- a/content_validator.py
+++ b/content_validator.py
@@ -1,0 +1,46 @@
+import re
+
+CONTENT_GUIDELINES = {
+    "notion": {
+        "banned_words": ["banned1", "banned2"],
+        "max_length": 2000,
+    },
+    "blog": {
+        "banned_words": ["spam", "clickbait"],
+        "max_length": 5000,
+        "no_urls": True,
+    },
+}
+
+
+def validate_text(text: str, platform: str = "notion"):
+    """Check text against platform guidelines.
+
+    Returns a tuple (is_valid, reason). is_valid is True if the text passes
+    all checks. Otherwise reason contains a short description of the rule that
+    was violated.
+    """
+    guidelines = CONTENT_GUIDELINES.get(platform, {})
+    if not text:
+        return True, None
+
+    lowered = text.lower()
+    for word in guidelines.get("banned_words", []):
+        if word.lower() in lowered:
+            return False, f"banned word '{word}'"
+
+    if guidelines.get("no_urls") and re.search(r"https?://", text):
+        return False, "contains url"
+
+    max_len = guidelines.get("max_length")
+    if max_len and len(text) > max_len:
+        return False, f"exceeds max length {max_len}"
+
+    return True, None
+
+
+def ensure_valid(text: str, platform: str = "notion"):
+    valid, reason = validate_text(text, platform)
+    if not valid:
+        raise ValueError(f"{platform} guideline violation: {reason}")
+

--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -4,6 +4,7 @@ import time
 import logging
 import re
 from datetime import datetime
+from content_validator import ensure_valid
 from notion_client import Client
 from dotenv import load_dotenv
 
@@ -60,6 +61,12 @@ def create_notion_page(item):
     keyword = item["keyword"]
     parsed = parse_generated_text(item.get("generated_text", ""))
     topic = keyword.split()[0] if " " in keyword else keyword
+
+    # Validate content against guidelines
+    for line in parsed["hook_lines"]:
+        ensure_valid(line, "notion")
+    for para in parsed["blog_paragraphs"]:
+        ensure_valid(para, "blog")
 
     notion.pages.create(
         parent={"database_id": NOTION_HOOK_DB_ID},

--- a/retry_failed_uploads.py
+++ b/retry_failed_uploads.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from content_validator import ensure_valid
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -46,6 +47,11 @@ def create_retry_page(item):
         "blog_paragraphs": item.get("blog_paragraphs", ["", "", ""]),
         "video_titles": item.get("video_titles", ["", ""])
     }
+
+    for line in parsed["hook_lines"]:
+        ensure_valid(line, "notion")
+    for para in parsed["blog_paragraphs"]:
+        ensure_valid(para, "blog")
 
     notion.pages.create(
         parent={"database_id": NOTION_HOOK_DB_ID},

--- a/scripts/retry_failed_uploads.py
+++ b/scripts/retry_failed_uploads.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from content_validator import ensure_valid
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -46,6 +47,11 @@ def create_retry_page(item):
         "blog_paragraphs": item.get("blog_paragraphs", ["", "", ""]),
         "video_titles": item.get("video_titles", ["", ""])
     }
+
+    for line in parsed["hook_lines"]:
+        ensure_valid(line, "notion")
+    for para in parsed["blog_paragraphs"]:
+        ensure_valid(para, "blog")
 
     notion.pages.create(
         parent={"database_id": NOTION_HOOK_DB_ID},


### PR DESCRIPTION
## Summary
- implement `content_validator` for simple banned word and formatting checks
- validate hook lines and blog paragraphs in Notion upload scripts
- check re-upload scripts before posting

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_684f6a5a83888322b61b184aee97c579