### PR TITLE
Add YouTube/Instagram/TikTok metrics to keyword pipeline

### DIFF
--- a/keyword_auto_pipeline.py
+++ b/keyword_auto_pipeline.py
@@ -7,6 +7,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pytrends.request import TrendReq
 import snscrape.modules.twitter as sntwitter
 import random  # CPC 더미 데이터용
+import requests
 
 # ---------------------- 설정 ----------------------
 CONFIG_PATH = os.getenv("TOPIC_CHANNELS_PATH", "config/topic_channels.json")
@@ -17,6 +18,9 @@ GOOGLE_TRENDS_MIN_GROWTH = 1.3
 TWITTER_MIN_MENTIONS = 30
 TWITTER_MIN_TOP_RETWEET = 50
 MIN_CPC = 1000  # 원 (더미 기준)
+YOUTUBE_MIN_VIEWS = 10000
+INSTAGRAM_MIN_POSTS = 20
+TIKTOK_MIN_VIEWS = 50000
 
 # ---------------------- 로깅 설정 ----------------------
 logging.basicConfig(
@@ -105,6 +109,60 @@ def fetch_twitter_metrics(keyword, max_tweets=100):
         logging.error(f"Twitter 에러 '{keyword}': {e}")
         return None
 
+def fetch_youtube_trends(keyword):
+    try:
+        # TODO: 실제 YouTube API 연동으로 대체
+        views = random.randint(0, 200000)
+        result = {
+            "keyword": keyword,
+            "source": "YouTube",
+            "views": views,
+            "cpc": fetch_cpc_dummy(keyword),
+        }
+        logging.info(
+            f"YouTube 수집 완료: {keyword} views={views} cpc={result['cpc']}"
+        )
+        return result
+    except Exception as e:
+        logging.error(f"YouTube 에러 '{keyword}': {e}")
+        return None
+
+def fetch_instagram_metrics(keyword):
+    try:
+        # TODO: 실제 Instagram API 연동으로 대체
+        posts = random.randint(0, 100)
+        result = {
+            "keyword": keyword,
+            "source": "Instagram",
+            "posts": posts,
+            "cpc": fetch_cpc_dummy(keyword),
+        }
+        logging.info(
+            f"Instagram 수집 완료: {keyword} posts={posts} cpc={result['cpc']}"
+        )
+        return result
+    except Exception as e:
+        logging.error(f"Instagram 에러 '{keyword}': {e}")
+        return None
+
+def fetch_tiktok_metrics(keyword):
+    try:
+        # TODO: 실제 TikTok API 연동으로 대체
+        views = random.randint(0, 300000)
+        result = {
+            "keyword": keyword,
+            "source": "TikTok",
+            "views": views,
+            "cpc": fetch_cpc_dummy(keyword),
+        }
+        logging.info(
+            f"TikTok 수집 완료: {keyword} views={views} cpc={result['cpc']}"
+        )
+        return result
+    except Exception as e:
+        logging.error(f"TikTok 에러 '{keyword}': {e}")
+        return None
+
 # ---------------------- 필터링 함수 ----------------------
 def filter_keywords(entries):
     filtered = []
@@ -122,6 +180,18 @@ def filter_keywords(entries):
             if (item.get("mentions", 0) >= TWITTER_MIN_MENTIONS and
                 item.get("top_retweet", 0) >= TWITTER_MIN_TOP_RETWEET and
                 cpc >= MIN_CPC):
+                filtered.append(item)
+
+        elif source == "YouTube":
+            if item.get("views", 0) >= YOUTUBE_MIN_VIEWS and cpc >= MIN_CPC:
+                filtered.append(item)
+
+        elif source == "Instagram":
+            if item.get("posts", 0) >= INSTAGRAM_MIN_POSTS and cpc >= MIN_CPC:
+                filtered.append(item)
+
+        elif source == "TikTok":
+            if item.get("views", 0) >= TIKTOK_MIN_VIEWS and cpc >= MIN_CPC:
                 filtered.append(item)
 
     logging.info(f"필터링된 키워드 개수: {len(filtered)}")
@@ -143,6 +213,27 @@ def collect_data_for_keyword(keyword, pytrends):
             results.append(twitter)
     except Exception as e:
         logging.error(f"Twitter 처리 실패: {keyword} - {e}")
+
+    try:
+        youtube = fetch_youtube_trends(keyword)
+        if youtube:
+            results.append(youtube)
+    except Exception as e:
+        logging.error(f"YouTube 처리 실패: {keyword} - {e}")
+
+    try:
+        instagram = fetch_instagram_metrics(keyword)
+        if instagram:
+            results.append(instagram)
+    except Exception as e:
+        logging.error(f"Instagram 처리 실패: {keyword} - {e}")
+
+    try:
+        tiktok = fetch_tiktok_metrics(keyword)
+        if tiktok:
+            results.append(tiktok)
+    except Exception as e:
+        logging.error(f"TikTok 처리 실패: {keyword} - {e}")
 
     return results
 


### PR DESCRIPTION
## Summary
- extend keyword pipeline with placeholders for YouTube, Instagram and TikTok
- add thresholds for the new platforms and handle them in filtering

## Testing
- `python -m py_compile keyword_auto_pipeline.py`
- `python keyword_auto_pipeline.py` *(fails: ModuleNotFoundError: No module named 'pytrends')*

------
https://chatgpt.com/codex/tasks/task_b_684f6ac7199c8322b8f8bc875922da20