### PR TITLE
Add policy validation for content uploads

### DIFF
--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -3,6 +3,7 @@ import json
 import time
 import logging
 import re
+from policy_checker import validate_hook_item
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
@@ -100,6 +101,14 @@ def upload_all_hooks():
         if page_exists(keyword):
             logging.info(f"⏭️ 중복 스킵: {keyword}")
             skipped += 1
+            continue
+
+        valid, reason = validate_hook_item(item)
+        if not valid:
+            logging.error(f"🚫 정책 위반: {keyword} - {reason}")
+            item["upload_error"] = f"policy violation: {reason}"
+            failed_items.append(item)
+            failed += 1
             continue
 
         for attempt in range(3):

--- a/policy_checker.py
+++ b/policy_checker.py
@@ -1,0 +1,47 @@
+import re
+
+# ---------------------- 기본 정책 ----------------------
+# 금지어와 금지 패턴은 실제 운영 가이드라인을 반영해 업데이트한다.
+BANNED_WORDS = [
+    "욕설",
+    "비속어",
+    "불법",
+    "성인",
+    "음란",
+]
+
+BANNED_PATTERNS = [
+    r"(?:http|https)://[^\s]+",  # 외부 링크 금지 예시
+]
+
+
+def validate_text(text: str):
+    """텍스트가 정책을 준수하는지 검사한다."""
+    if not text:
+        return True, None
+    lower = text.lower()
+    for word in BANNED_WORDS:
+        if word.lower() in lower:
+            return False, f"금지어 포함: {word}"
+    for pattern in BANNED_PATTERNS:
+        if re.search(pattern, text, re.IGNORECASE):
+            return False, f"금지 표현 발견: {pattern}"
+    return True, None
+
+
+def validate_hook_item(item: dict):
+    """후킹 생성 결과 전체를 점검한다."""
+    fields = []
+    if "keyword" in item:
+        fields.append(item["keyword"])
+    if "generated_text" in item:
+        fields.append(item["generated_text"])
+    for key in ["hook_lines", "blog_paragraphs", "video_titles"]:
+        value = item.get(key)
+        if isinstance(value, list):
+            fields.extend(value)
+    for text in fields:
+        ok, reason = validate_text(text)
+        if not ok:
+            return False, reason
+    return True, None

--- a/retry_failed_uploads.py
+++ b/retry_failed_uploads.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from policy_checker import validate_hook_item
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -74,6 +75,13 @@ def retry_failed_uploads():
         keyword = item.get("keyword")
         if not keyword:
             logging.warning("⛔ keyword 누락 항목 건너뜀")
+            continue
+        valid, reason = validate_hook_item(item)
+        if not valid:
+            logging.error(f"🚫 정책 위반: {keyword} - {reason}")
+            item["retry_error"] = f"policy violation: {reason}"
+            still_failed.append(item)
+            failed += 1
             continue
         try:
             create_retry_page(item)


### PR DESCRIPTION
## Summary
- implement `policy_checker.py` with banned word check logic
- enforce policy checks in `notion_hook_uploader.py`
- check policy compliance when retrying failed uploads

## Testing
- `python -m py_compile policy_checker.py notion_hook_uploader.py retry_failed_uploads.py`

------
https://chatgpt.com/codex/tasks/task_b_684f6bd201588322957eea9b9b9fcbd0