### PR TITLE
Add content checks for uploads

### DIFF
--- a/content_checker.py
+++ b/content_checker.py
@@ -1,0 +1,43 @@
+import re
+
+# Simple platform guidelines with example banned terms and formatting rules
+GUIDELINES = {
+    "notion": {
+        "banned_terms": ["spam", "subscribe", "buy now"],
+        # Example forbidden pattern: raw URLs are not allowed in Notion text
+        "forbidden_patterns": [r"https?://[^\s]+"],
+    },
+    "youtube": {
+        "banned_terms": ["subscribe", "like and share"],
+        "forbidden_patterns": [],
+    },
+    "blog": {
+        "banned_terms": ["click here", "buy now"],
+        "forbidden_patterns": [],
+    },
+}
+
+
+def detect_violation(text: str, platform: str = "notion"):
+    """Return a string describing the violation if the text violates rules."""
+    rules = GUIDELINES.get(platform, {})
+    lower_text = text.lower()
+    for term in rules.get("banned_terms", []):
+        if term.lower() in lower_text:
+            return f"banned term '{term}'"
+    for pattern in rules.get("forbidden_patterns", []):
+        if re.search(pattern, text):
+            return f"forbidden pattern '{pattern}'"
+    return None
+
+
+def check_parsed_content(parsed: dict, platform: str = "notion"):
+    """Check parsed content sections for violations."""
+    for section in ("hook_lines", "blog_paragraphs", "video_titles"):
+        for text in parsed.get(section, []):
+            if not text:
+                continue
+            violation = detect_violation(text, platform=platform)
+            if violation:
+                return violation, text
+    return None, None

--- a/retry_failed_uploads.py
+++ b/retry_failed_uploads.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from content_checker import check_parsed_content
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -46,6 +47,10 @@ def create_retry_page(item):
         "blog_paragraphs": item.get("blog_paragraphs", ["", "", ""]),
         "video_titles": item.get("video_titles", ["", ""])
     }
+
+    violation, bad_text = check_parsed_content(parsed)
+    if violation:
+        raise ValueError(f"content violation {violation} in '{bad_text}'")
 
     notion.pages.create(
         parent={"database_id": NOTION_HOOK_DB_ID},

--- a/scripts/notion_uploader.py
+++ b/scripts/notion_uploader.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from content_checker import detect_violation
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -90,6 +91,13 @@ def upload_all_keywords():
         if page_exists(keyword):
             logging.info(f"⏭️ 중복 스킵: {keyword}")
             skipped += 1
+            continue
+
+        violation = detect_violation(keyword, platform="notion")
+        if violation:
+            logging.error(f"⛔ 업로드 차단: {keyword} - {violation}")
+            failed_uploads.append(item)
+            failed += 1
             continue
 
         for attempt in range(3):

--- a/scripts/retry_failed_uploads.py
+++ b/scripts/retry_failed_uploads.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from content_checker import check_parsed_content
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -46,6 +47,10 @@ def create_retry_page(item):
         "blog_paragraphs": item.get("blog_paragraphs", ["", "", ""]),
         "video_titles": item.get("video_titles", ["", ""])
     }
+
+    violation, bad_text = check_parsed_content(parsed)
+    if violation:
+        raise ValueError(f"content violation {violation} in '{bad_text}'")
 
     notion.pages.create(
         parent={"database_id": NOTION_HOOK_DB_ID},


### PR DESCRIPTION
## Summary
- create `content_checker` module defining banned terms per platform
- detect content violations in `notion_hook_uploader` before creating Notion pages
- apply the same checks when retrying failed uploads
- block invalid keywords when uploading generic notion content

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_684f6b54c3ec83229e1f39ff299ba181