### PR TITLE
Add social platform trend collection

### DIFF
--- a/keyword_auto_pipeline.py
+++ b/keyword_auto_pipeline.py
@@ -6,6 +6,7 @@ from itertools import islice
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pytrends.request import TrendReq
 import snscrape.modules.twitter as sntwitter
+import requests
 import random  # CPC 더미 데이터용
 
 # ---------------------- 설정 ----------------------
@@ -17,6 +18,9 @@ GOOGLE_TRENDS_MIN_GROWTH = 1.3
 TWITTER_MIN_MENTIONS = 30
 TWITTER_MIN_TOP_RETWEET = 50
 MIN_CPC = 1000  # 원 (더미 기준)
+YOUTUBE_MIN_AVG_VIEWS = 5000
+INSTAGRAM_MIN_AVG_LIKES = 300
+TIKTOK_MIN_AVG_VIEWS = 5000
 
 # ---------------------- 로깅 설정 ----------------------
 logging.basicConfig(
@@ -105,6 +109,132 @@ def fetch_twitter_metrics(keyword, max_tweets=100):
         logging.error(f"Twitter 에러 '{keyword}': {e}")
         return None
 
+def fetch_youtube_trends(keyword, max_results=20):
+    api_key = os.getenv("YOUTUBE_API_KEY")
+    if not api_key:
+        logging.warning("YouTube API 키가 설정되지 않았습니다.")
+        return None
+    try:
+        search_url = "https://www.googleapis.com/youtube/v3/search"
+        search_params = {
+            "part": "snippet",
+            "q": keyword,
+            "type": "video",
+            "order": "viewCount",
+            "maxResults": max_results,
+            "key": api_key
+        }
+        resp = requests.get(search_url, params=search_params, timeout=10)
+        resp.raise_for_status()
+        items = resp.json().get("items", [])
+        if not items:
+            logging.warning(f"YouTube: '{keyword}' 검색 결과 없음")
+            return None
+        video_ids = ",".join([
+            item.get("id", {}).get("videoId")
+            for item in items
+            if item.get("id", {}).get("videoId")
+        ])
+        if not video_ids:
+            return None
+        stats_url = "https://www.googleapis.com/youtube/v3/videos"
+        stats_params = {
+            "part": "statistics",
+            "id": video_ids,
+            "key": api_key
+        }
+        stats_resp = requests.get(stats_url, params=stats_params, timeout=10)
+        stats_resp.raise_for_status()
+        views = [
+            int(v.get("statistics", {}).get("viewCount", 0))
+            for v in stats_resp.json().get("items", [])
+        ]
+        avg_views = sum(views) / len(views) if views else 0
+        result = {
+            "keyword": keyword,
+            "source": "YouTube",
+            "avg_views": int(avg_views),
+            "cpc": fetch_cpc_dummy(keyword)
+        }
+        logging.info(
+            f"YouTube 수집 완료: {keyword} avg_views={result['avg_views']} cpc={result['cpc']}"
+        )
+        return result
+    except Exception as e:
+        logging.error(f"YouTube 에러 '{keyword}': {e}")
+        return None
+
+
+def fetch_instagram_metrics(keyword):
+    access_token = os.getenv("INSTAGRAM_ACCESS_TOKEN")
+    user_id = os.getenv("INSTAGRAM_USER_ID")
+    if not access_token or not user_id:
+        logging.warning("Instagram API 자격 증명이 설정되지 않았습니다.")
+        return None
+    try:
+        search_url = "https://graph.facebook.com/v17.0/ig_hashtag_search"
+        params = {"user_id": user_id, "q": keyword, "access_token": access_token}
+        resp = requests.get(search_url, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json().get("data")
+        if not data:
+            logging.warning(f"Instagram: '{keyword}' 해시태그 없음")
+            return None
+        tag_id = data[0]["id"]
+        top_url = f"https://graph.facebook.com/v17.0/{tag_id}/top_media"
+        top_params = {
+            "user_id": user_id,
+            "fields": "like_count,comments_count",
+            "access_token": access_token,
+        }
+        top_resp = requests.get(top_url, params=top_params, timeout=10)
+        top_resp.raise_for_status()
+        posts = top_resp.json().get("data", [])
+        likes = [p.get("like_count", 0) for p in posts]
+        avg_likes = sum(likes) / len(likes) if likes else 0
+        result = {
+            "keyword": keyword,
+            "source": "Instagram",
+            "avg_likes": int(avg_likes),
+            "cpc": fetch_cpc_dummy(keyword),
+        }
+        logging.info(
+            f"Instagram 수집 완료: {keyword} avg_likes={result['avg_likes']} cpc={result['cpc']}"
+        )
+        return result
+    except Exception as e:
+        logging.error(f"Instagram 에러 '{keyword}': {e}")
+        return None
+
+
+def fetch_tiktok_metrics(keyword):
+    token = os.getenv("TIKTOK_API_TOKEN")
+    if not token:
+        logging.warning("TikTok API 토큰이 설정되지 않았습니다.")
+        return None
+    try:
+        # 예시용 엔드포인트. 실제 API 스펙에 맞게 수정 필요
+        url = "https://open.tiktokapis.com/v2/post/published-list/"
+        params = {"keyword": keyword, "access_token": token}
+        resp = requests.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json().get("data", [])
+        views = [int(v.get("play_count", 0)) for v in data]
+        avg_views = sum(views) / len(views) if views else 0
+        result = {
+            "keyword": keyword,
+            "source": "TikTok",
+            "avg_views": int(avg_views),
+            "cpc": fetch_cpc_dummy(keyword),
+        }
+        logging.info(
+            f"TikTok 수집 완료: {keyword} avg_views={result['avg_views']} cpc={result['cpc']}"
+        )
+        return result
+    except Exception as e:
+        logging.error(f"TikTok 에러 '{keyword}': {e}")
+        return None
+
 # ---------------------- 필터링 함수 ----------------------
 def filter_keywords(entries):
     filtered = []
@@ -122,6 +252,18 @@ def filter_keywords(entries):
             if (item.get("mentions", 0) >= TWITTER_MIN_MENTIONS and
                 item.get("top_retweet", 0) >= TWITTER_MIN_TOP_RETWEET and
                 cpc >= MIN_CPC):
+                filtered.append(item)
+
+        elif source == "YouTube":
+            if item.get("avg_views", 0) >= YOUTUBE_MIN_AVG_VIEWS and cpc >= MIN_CPC:
+                filtered.append(item)
+
+        elif source == "Instagram":
+            if item.get("avg_likes", 0) >= INSTAGRAM_MIN_AVG_LIKES and cpc >= MIN_CPC:
+                filtered.append(item)
+
+        elif source == "TikTok":
+            if item.get("avg_views", 0) >= TIKTOK_MIN_AVG_VIEWS and cpc >= MIN_CPC:
                 filtered.append(item)
 
     logging.info(f"필터링된 키워드 개수: {len(filtered)}")
@@ -143,6 +285,27 @@ def collect_data_for_keyword(keyword, pytrends):
             results.append(twitter)
     except Exception as e:
         logging.error(f"Twitter 처리 실패: {keyword} - {e}")
+
+    try:
+        youtube = fetch_youtube_trends(keyword)
+        if youtube:
+            results.append(youtube)
+    except Exception as e:
+        logging.error(f"YouTube 처리 실패: {keyword} - {e}")
+
+    try:
+        insta = fetch_instagram_metrics(keyword)
+        if insta:
+            results.append(insta)
+    except Exception as e:
+        logging.error(f"Instagram 처리 실패: {keyword} - {e}")
+
+    try:
+        tiktok = fetch_tiktok_metrics(keyword)
+        if tiktok:
+            results.append(tiktok)
+    except Exception as e:
+        logging.error(f"TikTok 처리 실패: {keyword} - {e}")
 
     return results
 


### PR DESCRIPTION
## Summary
- pull trending data from YouTube, Instagram and TikTok via API placeholders
- add constants for metrics thresholds
- integrate new sources into filtering logic
- update collection pipeline to gather these metrics alongside Google Trends and Twitter data

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_684f6bd29f748322be49c60cd6636c97