### PR TITLE
Add initial tests and CI pipeline

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,22 @@
+name: Python Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run tests
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 logs/
+__pycache__/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+openai
+python-dotenv
+notion-client
+pytrends
+snscrape
+pytest

--- a/tests/test_hook_generator.py
+++ b/tests/test_hook_generator.py
@@ -1,0 +1,25 @@
+import sys
+import types
+
+# Stub external dependencies before importing the module
+sys.modules['dotenv'] = types.ModuleType('dotenv')
+sys.modules['dotenv'].load_dotenv = lambda: None
+sys.modules['openai'] = types.ModuleType('openai')
+
+sys.path.insert(0, '.')
+sys.path.insert(0, 'Auto_Pipeline')
+
+import hook_generator
+
+
+def test_generate_hook_prompt():
+    prompt = hook_generator.generate_hook_prompt(
+        keyword='테스트 키워드',
+        topic='테스트',
+        source='GoogleTrends',
+        score=80,
+        growth=2.0,
+        mentions=100,
+    )
+    assert '테스트 키워드' in prompt
+    assert 'GoogleTrends' in prompt

--- a/tests/test_keyword_auto_pipeline.py
+++ b/tests/test_keyword_auto_pipeline.py
@@ -1,0 +1,54 @@
+import sys
+import types
+
+# Stub heavy external dependencies
+sys.modules['pytrends'] = types.ModuleType('pytrends')
+request_mod = types.ModuleType('pytrends.request')
+request_mod.TrendReq = object
+sys.modules['pytrends.request'] = request_mod
+
+sys.modules['snscrape'] = types.ModuleType('snscrape')
+mods = types.ModuleType('snscrape.modules')
+sys.modules['snscrape.modules'] = mods
+sys.modules['snscrape.modules.twitter'] = types.ModuleType('snscrape.modules.twitter')
+
+sys.path.insert(0, '.')
+sys.path.insert(0, 'Auto_Pipeline')
+
+import keyword_auto_pipeline as kap
+
+
+def test_filter_keywords():
+    entries = [
+        {
+            'keyword': 'g1',
+            'source': 'GoogleTrends',
+            'score': kap.GOOGLE_TRENDS_MIN_SCORE,
+            'growth': kap.GOOGLE_TRENDS_MIN_GROWTH,
+            'cpc': kap.MIN_CPC,
+        },
+        {
+            'keyword': 'g2',
+            'source': 'GoogleTrends',
+            'score': kap.GOOGLE_TRENDS_MIN_SCORE - 1,
+            'growth': kap.GOOGLE_TRENDS_MIN_GROWTH,
+            'cpc': kap.MIN_CPC,
+        },
+        {
+            'keyword': 't1',
+            'source': 'Twitter',
+            'mentions': kap.TWITTER_MIN_MENTIONS,
+            'top_retweet': kap.TWITTER_MIN_TOP_RETWEET,
+            'cpc': kap.MIN_CPC,
+        },
+        {
+            'keyword': 't2',
+            'source': 'Twitter',
+            'mentions': kap.TWITTER_MIN_MENTIONS - 1,
+            'top_retweet': kap.TWITTER_MIN_TOP_RETWEET,
+            'cpc': kap.MIN_CPC,
+        },
+    ]
+    filtered = kap.filter_keywords(entries)
+    names = {e['keyword'] for e in filtered}
+    assert names == {'g1', 't1'}


### PR DESCRIPTION
## Summary
- add Pytest-based unit tests with stubs
- define Python test workflow for GitHub Actions
- include project requirements
- ignore `__pycache__`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684f6ad987648322900ad29011439f93