### PR TITLE
Add pytest tests and CI step

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -31,6 +31,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: 🧪 Run unit tests
+        run: pytest -q
+
       - name: ▶️ Run full pipeline (single entrypoint)
         run: python scripts/run_pipeline.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 logs/
+__pycache__/

--- a/tests/test_data_fetching.py
+++ b/tests/test_data_fetching.py
@@ -1,0 +1,82 @@
+import types
+import sys
+import os
+import importlib
+
+# Ensure repository root is in sys.path
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+# Stub modules required for import
+pytrends_mod = types.ModuleType('pytrends')
+request_mod = types.ModuleType('pytrends.request')
+class DummyTrendReq:
+    pass
+request_mod.TrendReq = DummyTrendReq
+pytrends_mod.request = request_mod
+sys.modules['pytrends'] = pytrends_mod
+sys.modules['pytrends.request'] = request_mod
+
+sns_pkg = types.ModuleType('snscrape')
+modules_pkg = types.ModuleType('snscrape.modules')
+sns_mod = types.ModuleType('snscrape.modules.twitter')
+modules_pkg.twitter = sns_mod
+sns_pkg.modules = modules_pkg
+sys.modules['snscrape'] = sns_pkg
+sys.modules['snscrape.modules'] = modules_pkg
+sys.modules['snscrape.modules.twitter'] = sns_mod
+
+import keyword_auto_pipeline as kap
+
+class DummySeries:
+    def __init__(self, data):
+        self.data = list(data)
+    def __getitem__(self, item):
+        if isinstance(item, slice):
+            return DummySeries(self.data[item])
+        return self.data[item]
+    def mean(self):
+        return sum(self.data) / len(self.data)
+
+class DummyDataFrame:
+    def __init__(self, keyword, data):
+        self.keyword = keyword
+        self.data = DummySeries(data)
+        self.empty = False
+    def __contains__(self, item):
+        return item == self.keyword
+    def __getitem__(self, item):
+        return self.data
+
+class DummyTrends:
+    def build_payload(self, *args, **kwargs):
+        pass
+    def interest_over_time(self):
+        return DummyDataFrame('test', [10, 20, 30, 40, 50, 60, 70])
+
+def test_fetch_google_trends(monkeypatch):
+    monkeypatch.setattr(kap, 'fetch_cpc_dummy', lambda kw: 999)
+    result = kap.fetch_google_trends('test', DummyTrends())
+    assert result['keyword'] == 'test'
+    assert result['source'] == 'GoogleTrends'
+    assert result['score'] == int((50 + 60 + 70) / 3)
+    assert result['cpc'] == 999
+
+def test_fetch_twitter_metrics(monkeypatch):
+    class DummyTweet:
+        def __init__(self, count):
+            self.retweetCount = count
+    class DummyScraper:
+        def __init__(self, query):
+            self.query = query
+        def get_items(self):
+            return iter([DummyTweet(1), DummyTweet(5), DummyTweet(10)])
+    sns_mod.TwitterSearchScraper = DummyScraper
+    import importlib
+    importlib.reload(kap)
+    monkeypatch.setattr(kap, 'fetch_cpc_dummy', lambda kw: 123)
+    result = kap.fetch_twitter_metrics('kw', max_tweets=3)
+    assert result['keyword'] == 'kw'
+    assert result['source'] == 'Twitter'
+    assert result['mentions'] == 3
+    assert result['top_retweet'] == 10
+    assert result['cpc'] == 123

--- a/tests/test_notion_upload.py
+++ b/tests/test_notion_upload.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import types
+import importlib
+
+# Ensure repository root is in sys.path
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+# Prepare stubs before module import
+dotenv_mod = types.ModuleType('dotenv')
+dotenv_mod.load_dotenv = lambda: None
+sys.modules['dotenv'] = dotenv_mod
+
+class DummyPages:
+    def __init__(self):
+        self.created = []
+    def create(self, **kwargs):
+        self.created.append(kwargs)
+
+class DummyClient:
+    def __init__(self, auth=None):
+        self.pages = DummyPages()
+        self.databases = types.SimpleNamespace(query=lambda **kw: {'results': []})
+
+notion_mod = types.ModuleType('notion_client')
+notion_mod.Client = DummyClient
+sys.modules['notion_client'] = notion_mod
+
+os.environ['NOTION_API_TOKEN'] = 'token'
+os.environ['NOTION_HOOK_DB_ID'] = 'db123'
+
+# Ensure logs directory exists to avoid FileHandler error
+os.makedirs('logs', exist_ok=True)
+
+import notion_hook_uploader as nup
+
+def test_create_notion_page(monkeypatch):
+    monkeypatch.setattr(nup, 'parse_generated_text', lambda text: {
+        'hook_lines': ['a', 'b'],
+        'blog_paragraphs': ['p1', 'p2', 'p3'],
+        'video_titles': ['v1', 'v2']
+    })
+    item = {'keyword': 'kw', 'generated_text': 'dummy'}
+    nup.create_notion_page(item)
+    assert nup.notion.pages.created
+    call = nup.notion.pages.created[0]
+    assert call['parent']['database_id'] == 'db123'
+    assert call['properties']['키워드']['title'][0]['text']['content'] == 'kw'

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,0 +1,27 @@
+import importlib
+import types
+import sys
+import os
+
+# Ensure repository root is in sys.path
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+# Stub missing openai module to avoid import errors
+sys.modules['openai'] = types.ModuleType('openai')
+
+import hook_generator as hg
+
+def test_generate_hook_prompt():
+    prompt = hg.generate_hook_prompt(
+        keyword="테스트 키워드",
+        topic="테스트",
+        source="Twitter",
+        score=80,
+        growth=1.5,
+        mentions=100
+    )
+    assert "테스트 키워드" in prompt
+    assert "Twitter" in prompt
+    assert "80" in prompt
+    assert "1.5" in prompt
+    assert "100" in prompt


### PR DESCRIPTION
## Summary
- add pytest-based tests for prompt generation, data fetching and Notion upload logic
- ignore `__pycache__`
- run unit tests in the workflow before executing the pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f6c384afc83228677da7bea079707