### PR TITLE
Add missing scripts and document pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Auto Pipeline
+
+This project contains a set of scripts that run sequentially to generate hook content and upload it to Notion.
+
+## Pipeline Sequence
+
+`run_pipeline.py` executes the following scripts in order:
+
+1. **hook_generator.py** – generates hook text with GPT and saves the results.
+2. **parse_failed_gpt.py** – parses any failed GPT results so they can be retried.
+3. **retry_failed_uploads.py** – uploads the reparsed items to Notion.
+4. **notify_retry_result.py** – sends a Slack notification summarising the retry outcome.
+5. **retry_dashboard_notifier.py** – updates a KPI dashboard in Notion with the retry statistics.
+
+Each script resides in the `scripts/` directory and can be run individually, but `run_pipeline.py` provides a single entry point.

--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,47 @@
+import os
+import json
+import logging
+from dotenv import load_dotenv
+
+# ---------------------- 설정 로딩 ----------------------
+load_dotenv()
+WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+# ---------------------- 결과 요약 ----------------------
+def build_summary():
+    if not os.path.exists(SUMMARY_PATH):
+        return "재시도 결과 파일이 존재하지 않습니다."
+    with open(SUMMARY_PATH, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    total = len(data)
+    failed = len([d for d in data if d.get('retry_error')])
+    success = total - failed
+    return f"재업로드 결과: 총 {total}건 중 {success}건 성공, {failed}건 실패"
+
+# ---------------------- Slack 알림 ----------------------
+def send_slack(message):
+    if not WEBHOOK_URL:
+        logging.warning("SLACK_WEBHOOK_URL 미설정으로 알림을 건너뜁니다.")
+        return
+    try:
+        import requests
+    except Exception as e:
+        logging.error(f"requests 모듈 필요: {e}")
+        return
+    try:
+        resp = requests.post(WEBHOOK_URL, json={'text': message})
+        resp.raise_for_status()
+        logging.info("📣 Slack 알림 전송 완료")
+    except Exception as e:
+        logging.error(f"Slack 전송 실패: {e}")
+
+# ---------------------- 메인 ----------------------
+def main():
+    msg = build_summary()
+    send_slack(msg)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,46 @@
+import os
+import json
+import logging
+import re
+from dotenv import load_dotenv
+
+# ---------------------- 설정 로딩 ----------------------
+load_dotenv()
+FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_keywords.json")
+OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+# ---------------------- GPT 결과 파싱 ----------------------
+def parse_generated_text(text: str):
+    hook_lines = re.findall(r"후킹 ?문장[0-9]?[\s:：\-\)]*([^\n]+)", text)
+    blog_match = re.search(r"블로그(?:\s*초안)?[\s:：\-\)]*(.*?)\n+\s*(.*?\n+.*?\n+.*?)(?:\n|$)", text, re.DOTALL)
+    video_titles = re.findall(r"(?:영상 제목|YouTube 제목)[\s:：\-\)]*[^\n]*\n?-\s*(.+)", text)
+
+    blog_paragraphs = [p.strip() for p in blog_match[1].strip().split('\n')[:3]] if blog_match else ["", "", ""]
+    return {
+        "hook_lines": hook_lines[:2] if len(hook_lines) >= 2 else ["", ""],
+        "blog_paragraphs": blog_paragraphs,
+        "video_titles": video_titles[:2] if video_titles else ["", ""]
+    }
+
+# ---------------------- 메인 실행 ----------------------
+def main():
+    if not os.path.exists(FAILED_PATH):
+        logging.info(f"✅ 실패 데이터 파일이 없어 스킵합니다: {FAILED_PATH}")
+        return
+
+    with open(FAILED_PATH, 'r', encoding='utf-8') as f:
+        items = json.load(f)
+
+    for item in items:
+        text = item.get('generated_text', '')
+        item['parsed'] = parse_generated_text(text)
+
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        json.dump(items, f, ensure_ascii=False, indent=2)
+    logging.info(f"📦 파싱 결과 저장: {OUTPUT_PATH}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `scripts/parse_failed_gpt.py` to handle parsing of failed GPT results
- create `scripts/notify_retry_result.py` to send a Slack summary
- document the pipeline sequence in `README.md`

## Testing
- `python -m py_compile scripts/parse_failed_gpt.py scripts/notify_retry_result.py`
- `python -m py_compile run_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_b_684f6d9f6510832288cab6202a722b79