### PR TITLE
Improve parsing robustness

### DIFF
--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -45,14 +45,37 @@ def page_exists(keyword):
 # ---------------------- GPT 결과 파싱 함수 ----------------------
 def parse_generated_text(text):
     hook_lines = re.findall(r"후킹 ?문장[0-9]?[\s:：\-\)]*([^\n]+)", text)
-    blog_match = re.search(r"블로그(?:\s*초안)?[\s:：\-\)]*(.*?)\n+\s*(.*?\n+.*?\n+.*?)(?:\n|$)", text, re.DOTALL)
-    video_titles = re.findall(r"(?:영상 제목|YouTube 제목)[\s:：\-\)]*[^\n]*\n?-\s*(.+)", text)
+    blog_match = re.search(
+        r"블로그(?:\s*초안)?[\s:：\-\)]*(.*?)\n+\s*(.*?\n+.*?\n+.*?)(?:\n|$)",
+        text,
+        re.DOTALL,
+    )
+    video_titles = re.findall(
+        r"(?:영상 제목|YouTube 제목)[\s:：\-\)]*[^\n]*\n?-\s*(.+)", text
+    )
 
-    blog_paragraphs = [p.strip() for p in blog_match[1].strip().split('\n')[:3]] if blog_match else ["", "", ""]
+    hooks = [
+        hook_lines[0].strip() if len(hook_lines) > 0 else "",
+        hook_lines[1].strip() if len(hook_lines) > 1 else "",
+    ]
+
+    if blog_match:
+        blog_text = f"{blog_match.group(1)}\n{blog_match.group(2)}".strip()
+        blog_paragraphs = [p.strip() for p in blog_text.split("\n")[:3]]
+        while len(blog_paragraphs) < 3:
+            blog_paragraphs.append("")
+    else:
+        blog_paragraphs = ["", "", ""]
+
+    titles = [
+        video_titles[0].strip() if len(video_titles) > 0 else "",
+        video_titles[1].strip() if len(video_titles) > 1 else "",
+    ]
+
     return {
-        "hook_lines": hook_lines[:2] if len(hook_lines) >= 2 else ["", ""],
+        "hook_lines": hooks,
         "blog_paragraphs": blog_paragraphs,
-        "video_titles": video_titles[:2] if video_titles else ["", ""]
+        "video_titles": titles,
     }
 
 # ---------------------- Notion 페이지 생성 함수 ----------------------

--- a/tests/test_parse_generated_text.py
+++ b/tests/test_parse_generated_text.py
@@ -1,0 +1,54 @@
+import sys
+import types
+import os
+import importlib
+from pathlib import Path
+
+# ensure repository root is on sys.path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# provide stub modules to satisfy imports in notion_hook_uploader
+sys.modules['notion_client'] = types.SimpleNamespace(Client=lambda *a, **k: None)
+sys.modules['dotenv'] = types.SimpleNamespace(load_dotenv=lambda: None)
+
+# ensure log directory exists to avoid logging.FileHandler errors
+os.makedirs('logs', exist_ok=True)
+
+notion_hook_uploader = importlib.import_module('notion_hook_uploader')
+parse_generated_text = notion_hook_uploader.parse_generated_text
+
+
+def test_parse_typical_output():
+    text = (
+        "후킹 문장1: 당신의 미래를 바꿀 비밀을 알려드립니다!\n"
+        "후킹 문장2: 지금 바로 시작하세요!\n"
+        "블로그 초안:\n"
+        "첫 번째 문단입니다.\n"
+        "두 번째 문단입니다.\n"
+        "세 번째 문단입니다.\n"
+        "영상 제목: - 첫 번째 영상 제목\n"
+        "YouTube 제목: - 두 번째 영상 제목\n"
+    )
+    parsed = parse_generated_text(text)
+    assert parsed['hook_lines'] == [
+        '당신의 미래를 바꿀 비밀을 알려드립니다!',
+        '지금 바로 시작하세요!'
+    ]
+    assert parsed['blog_paragraphs'] == [
+        '첫 번째 문단입니다.',
+        '두 번째 문단입니다.',
+        '세 번째 문단입니다.'
+    ]
+    assert parsed['video_titles'] == ['첫 번째 영상 제목', '두 번째 영상 제목']
+
+
+def test_parse_malformed_output():
+    text = (
+        "후킹 문장1: 하나만 있습니다.\n"
+        "영상 제목: - 유일한 영상 제목\n"
+    )
+    parsed = parse_generated_text(text)
+    assert parsed['hook_lines'] == ['하나만 있습니다.', '']
+    assert parsed['blog_paragraphs'] == ['', '', '']
+    assert parsed['video_titles'] == ['유일한 영상 제목', '']


### PR DESCRIPTION
## Summary
- handle missing regex matches in `parse_generated_text`
- pad hooks, blog paragraphs and titles with empty strings when absent
- add unit tests for typical and malformed GPT output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f6da1daf48322b2c7ac33c88bfd55