### PR TITLE
Add pytest tests for keyword and Notion utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Auto Pipeline
+
+This repository contains scripts for collecting trending keywords, generating marketing hooks, and uploading them to Notion.
+
+## Running Tests
+
+Tests use `pytest` and are located in the `tests/` directory. To run all tests:
+
+```bash
+pytest
+```
+
+Ensure required dependencies are installed (e.g. `pytest`). Dummy modules are used so tests do not require external services.

--- a/tests/test_keyword_auto_pipeline.py
+++ b/tests/test_keyword_auto_pipeline.py
@@ -1,0 +1,58 @@
+import sys
+import types
+
+# Stub external dependencies used during module import
+pytrends_request = types.ModuleType('pytrends.request')
+pytrends_request.TrendReq = lambda *a, **k: None
+pytrends = types.ModuleType('pytrends')
+pytrends.request = pytrends_request
+sys.modules['pytrends'] = pytrends
+sys.modules['pytrends.request'] = pytrends_request
+sys.modules['snscrape'] = types.ModuleType('snscrape')
+sys.modules['snscrape.modules'] = types.ModuleType('snscrape.modules')
+sys.modules['snscrape.modules.twitter'] = types.ModuleType('snscrape.modules.twitter')
+
+import keyword_auto_pipeline as kap
+
+
+def test_generate_keyword_pairs():
+    topic_details = {'A': ['x', 'y'], 'B': ['z']}
+    pairs = kap.generate_keyword_pairs(topic_details)
+    assert set(pairs) == {'A x', 'A y', 'B z'}
+    assert len(pairs) == 3
+
+
+def test_filter_keywords():
+    entries = [
+        {
+            'keyword': 'g1',
+            'source': 'GoogleTrends',
+            'score': kap.GOOGLE_TRENDS_MIN_SCORE + 1,
+            'growth': kap.GOOGLE_TRENDS_MIN_GROWTH + 0.1,
+            'cpc': kap.MIN_CPC + 10,
+        },
+        {
+            'keyword': 'g2',
+            'source': 'GoogleTrends',
+            'score': kap.GOOGLE_TRENDS_MIN_SCORE - 1,
+            'growth': kap.GOOGLE_TRENDS_MIN_GROWTH + 0.1,
+            'cpc': kap.MIN_CPC + 10,
+        },
+        {
+            'keyword': 't1',
+            'source': 'Twitter',
+            'mentions': kap.TWITTER_MIN_MENTIONS + 1,
+            'top_retweet': kap.TWITTER_MIN_TOP_RETWEET + 1,
+            'cpc': kap.MIN_CPC + 10,
+        },
+        {
+            'keyword': 't2',
+            'source': 'Twitter',
+            'mentions': kap.TWITTER_MIN_MENTIONS - 1,
+            'top_retweet': kap.TWITTER_MIN_TOP_RETWEET + 1,
+            'cpc': kap.MIN_CPC + 10,
+        },
+    ]
+    filtered = kap.filter_keywords(entries)
+    keywords = {item['keyword'] for item in filtered}
+    assert keywords == {'g1', 't1'}

--- a/tests/test_notion_hook_uploader.py
+++ b/tests/test_notion_hook_uploader.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import types
+import importlib
+
+# create required directories and dummy modules before import
+os.makedirs('logs', exist_ok=True)
+sys.modules['dotenv'] = types.SimpleNamespace(load_dotenv=lambda: None)
+sys.modules['notion_client'] = types.SimpleNamespace(Client=lambda *a, **k: None)
+
+nhu = importlib.import_module('notion_hook_uploader')
+
+
+def test_parse_generated_text():
+    text = """후킹 문장1: 훅1
+후킹 문장2: 훅2
+블로그 초안: 첫 문단
+둘째 문단
+셋째 문단
+영상 제목: - 타이틀1
+YouTube 제목 - 타이틀2
+"""
+    parsed = nhu.parse_generated_text(text)
+    assert parsed['hook_lines'] == ['훅1', '훅2']
+    assert parsed['blog_paragraphs'] == ['첫 문단']
+    assert parsed['video_titles'] == ['타이틀1', '타이틀2']


### PR DESCRIPTION
## Summary
- add pytest test suite covering core functions
- stub external deps in tests so no network required
- document running tests in new README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f6da1dfe883229f64c1d648ef6b6d