### PR TITLE
Add AWS cost monitor script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Auto Pipeline
+
+## AWS 비용 모니터링
+
+`scripts/aws_cost_monitor.py` 스크립트는 AWS Cost Explorer API를 사용하여 현재 달의 비용을 조회합니다. 실행 전에 다음 환경 변수를 설정하거나 `.env` 파일에 추가하세요.
+
+```bash
+AWS_ACCESS_KEY_ID=YOUR_KEY
+AWS_SECRET_ACCESS_KEY=YOUR_SECRET
+AWS_SESSION_TOKEN=YOUR_TOKEN  # 선택 사항
+AWS_REGION=us-east-1          # 기본값
+```
+
+설정 후 아래 명령어로 비용을 확인할 수 있습니다.
+
+```bash
+python scripts/aws_cost_monitor.py
+```

--- a/scripts/aws_cost_monitor.py
+++ b/scripts/aws_cost_monitor.py
@@ -1,0 +1,54 @@
+import os
+import logging
+from datetime import datetime
+
+import boto3
+from dotenv import load_dotenv
+
+# ---------------------- 환경 변수 로딩 ----------------------
+load_dotenv()
+AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID")
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")
+AWS_SESSION_TOKEN = os.getenv("AWS_SESSION_TOKEN")
+AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
+
+# ---------------------- 로깅 설정 ----------------------
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+# ---------------------- AWS Cost Explorer 클라이언트 ----------------------
+if not AWS_ACCESS_KEY_ID or not AWS_SECRET_ACCESS_KEY:
+    logging.error("❗ AWS 인증 정보(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)가 누락되었습니다.")
+    exit(1)
+
+ce = boto3.client(
+    "ce",
+    region_name=AWS_REGION,
+    aws_access_key_id=AWS_ACCESS_KEY_ID,
+    aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+    aws_session_token=AWS_SESSION_TOKEN,
+)
+
+# ---------------------- 월별 비용 조회 ----------------------
+def log_current_month_cost():
+    today = datetime.utcnow().date()
+    start = today.replace(day=1)
+    # 다음 달 첫 날 계산
+    if start.month == 12:
+        next_month = start.replace(year=start.year + 1, month=1)
+    else:
+        next_month = start.replace(month=start.month + 1)
+
+    resp = ce.get_cost_and_usage(
+        TimePeriod={"Start": start.strftime("%Y-%m-%d"), "End": next_month.strftime("%Y-%m-%d")},
+        Granularity="MONTHLY",
+        Metrics=["UnblendedCost"],
+    )
+
+    total = resp["ResultsByTime"][0]["Total"]["UnblendedCost"]
+    amount = total.get("Amount")
+    unit = total.get("Unit")
+    logging.info(f"💰 AWS 비용 {start.strftime('%Y-%m')}: {amount} {unit}")
+
+
+if __name__ == "__main__":
+    log_current_month_cost()


### PR DESCRIPTION
## Summary
- add `aws_cost_monitor.py` to query AWS monthly cost via Cost Explorer
- manage AWS credentials via environment variables
- document usage in README

## Testing
- `python -m py_compile scripts/aws_cost_monitor.py`

------
https://chatgpt.com/codex/tasks/task_b_684f6ead9bd88322bb1d2c486ef9c705