### PR TITLE
Add MAX_WORKERS env var support

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -16,6 +16,7 @@ jobs:
       NOTION_KPI_DB_ID: ${{ secrets.NOTION_KPI_DB_ID }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       REPARSED_OUTPUT_PATH: logs/failed_keywords_reparsed.json
+      MAX_WORKERS: 10
 
     steps:
       - name: 📂 Checkout repository

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Auto Pipeline
+
+자동화된 키워드 수집과 Notion 업로드를 위한 스크립트 모음입니다.
+
+## 주요 환경 변수
+
+| 이름 | 기본값 | 설명 |
+| ---- | ------ | ---- |
+| `TOPIC_CHANNELS_PATH` | `config/topic_channels.json` | 토픽 및 채널 설정 파일 경로 |
+| `KEYWORD_OUTPUT_PATH` | `data/keyword_output_with_cpc.json` | 키워드 파이프라인 결과 저장 경로 |
+| `MAX_WORKERS` | `10` | `keyword_auto_pipeline.py`에서 사용할 스레드 수 |
+
+기타 Notion 업로드 및 GPT 호출과 관련된 토큰은 GitHub Secrets를 통해 전달됩니다.

--- a/keyword_auto_pipeline.py
+++ b/keyword_auto_pipeline.py
@@ -152,7 +152,8 @@ def run_pipeline():
     pytrends = TrendReq(hl='ko', tz=540)
     all_results = []
 
-    with ThreadPoolExecutor(max_workers=10) as executor:
+    max_workers = int(os.getenv("MAX_WORKERS", 10))
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = {executor.submit(collect_data_for_keyword, kw, pytrends): kw for kw in keywords}
 
         for future in as_completed(futures):


### PR DESCRIPTION
## Summary
- use `MAX_WORKERS` env var in `keyword_auto_pipeline.py`
- expose new variable in workflow
- document environment variables in README

## Testing
- `python -m py_compile keyword_auto_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_b_684f6eafc52c8322a667270560365955