### PR TITLE
Add Flask dashboard

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,51 @@
+from flask import Flask, render_template, redirect, url_for
+import json
+import os
+import subprocess
+import sys
+
+app = Flask(__name__)
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(os.path.dirname(BASE_DIR), 'data')
+
+KEYWORD_PATH = os.path.join(DATA_DIR, 'keyword_output_with_cpc.json')
+HOOK_PATH = os.path.join(DATA_DIR, 'generated_hooks.json')
+
+
+def load_json(path):
+    if os.path.exists(path):
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except Exception:
+            return None
+    return None
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+@app.route('/keywords')
+def show_keywords():
+    data = load_json(KEYWORD_PATH) or {}
+    keywords = data.get('filtered_keywords', data if isinstance(data, list) else [])
+    return render_template('keywords.html', keywords=keywords)
+
+
+@app.route('/hooks')
+def show_hooks():
+    hooks = load_json(HOOK_PATH) or []
+    return render_template('hooks.html', hooks=hooks)
+
+
+@app.route('/run_pipeline', methods=['POST'])
+def run_pipeline():
+    subprocess.Popen([sys.executable, os.path.join(os.path.dirname(BASE_DIR), 'run_pipeline.py')])
+    return redirect(url_for('index'))
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/dashboard/templates/hooks.html
+++ b/dashboard/templates/hooks.html
@@ -1,0 +1,41 @@
+{% extends 'layout.html' %}
+
+{% block content %}
+  <h1 class="mb-4">Generated Hooks</h1>
+  <table class="table table-striped" aria-label="Generated hooks">
+    <thead>
+      <tr>
+        <th scope="col">Keyword</th>
+        <th scope="col">Hook Lines</th>
+        <th scope="col">Blog Draft</th>
+        <th scope="col">Video Titles</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for item in hooks %}
+      <tr>
+        <td>{{ item.keyword }}</td>
+        <td>
+          <ul>
+          {% for line in item.hook_lines %}
+            <li>{{ line }}</li>
+          {% endfor %}
+          </ul>
+        </td>
+        <td>
+          {% for para in item.blog_paragraphs %}
+            <p>{{ para }}</p>
+          {% endfor %}
+        </td>
+        <td>
+          <ul>
+          {% for t in item.video_titles %}
+            <li>{{ t }}</li>
+          {% endfor %}
+          </ul>
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}

--- a/dashboard/templates/index.html
+++ b/dashboard/templates/index.html
@@ -1,0 +1,10 @@
+{% extends 'layout.html' %}
+
+{% block content %}
+  <section>
+    <h1 class="mb-4">Pipeline Dashboard</h1>
+    <form method="post" action="{{ url_for('run_pipeline') }}" class="mb-3">
+      <button type="submit" class="btn btn-primary" aria-label="Run pipeline">Run Pipeline</button>
+    </form>
+  </section>
+{% endblock %}

--- a/dashboard/templates/keywords.html
+++ b/dashboard/templates/keywords.html
@@ -1,0 +1,31 @@
+{% extends 'layout.html' %}
+
+{% block content %}
+  <h1 class="mb-4">Keyword Results</h1>
+  <table class="table table-striped" aria-label="Keyword results">
+    <thead>
+      <tr>
+        <th scope="col">Keyword</th>
+        <th scope="col">Source</th>
+        <th scope="col">Score</th>
+        <th scope="col">Growth</th>
+        <th scope="col">Mentions</th>
+        <th scope="col">Top Retweet</th>
+        <th scope="col">CPC</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for item in keywords %}
+      <tr>
+        <td>{{ item.keyword }}</td>
+        <td>{{ item.source }}</td>
+        <td>{{ item.score }}</td>
+        <td>{{ item.growth }}</td>
+        <td>{{ item.mentions }}</td>
+        <td>{{ item.top_retweet }}</td>
+        <td>{{ item.cpc }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}

--- a/dashboard/templates/layout.html
+++ b/dashboard/templates/layout.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ title or 'Dashboard' }}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light" role="navigation" aria-label="Main navigation">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('index') }}">Dashboard</a>
+        <div>
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('show_keywords') }}">Keywords</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('show_hooks') }}">Hooks</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+    <main class="container mt-4" role="main">
+      {% block content %}{% endblock %}
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- create a dashboard using Flask
- show keyword and hook results
- allow triggering the existing pipeline via a web route
- build simple Bootstrap templates with ARIA labels

## Testing
- `python -m py_compile dashboard/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f6eb1edd48322b306345016b399c6