### PR TITLE
Fix pipeline path references

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -21,7 +21,7 @@ PIPELINE_SEQUENCE = [
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
+    full_path = os.path.join(".", script)
     if not os.path.exists(full_path):
         logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
         return False


### PR DESCRIPTION
## Summary
- update `run_script` to use current directory paths
- fix GitHub workflow to call `run_pipeline.py` from project root

## Testing
- `python run_pipeline.py` *(fails: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_684f6ebd6dc48322b14b4d5e0fe97a9e