### PR TITLE
Add privacy management utility

### DIFF
--- a/hook_generator.py
+++ b/hook_generator.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from dotenv import load_dotenv
 import openai
+from privacy_manager import request_data_deletion
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -13,11 +14,17 @@ HOOK_OUTPUT_PATH = os.getenv("HOOK_OUTPUT_PATH", "data/generated_hooks.json")
 FAILED_HOOK_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 API_DELAY = float(os.getenv("API_DELAY", "1.0"))
+DELETE_USER_ID = os.getenv("DELETE_USER_ID")
 
 openai.api_key = OPENAI_API_KEY
 
 # ---------------------- 로깅 설정 ----------------------
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+# ---------------------- 개인정보 삭제 처리 ----------------------
+if DELETE_USER_ID:
+    request_data_deletion(DELETE_USER_ID, HOOK_OUTPUT_PATH)
+    request_data_deletion(DELETE_USER_ID, FAILED_HOOK_PATH)
 
 # ---------------------- GPT 프롬프트 생성 함수 ----------------------
 def generate_hook_prompt(keyword, topic, source, score, growth, mentions):

--- a/keyword_auto_pipeline.py
+++ b/keyword_auto_pipeline.py
@@ -7,6 +7,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pytrends.request import TrendReq
 import snscrape.modules.twitter as sntwitter
 import random  # CPC 더미 데이터용
+from privacy_manager import request_data_deletion
 
 # ---------------------- 설정 ----------------------
 CONFIG_PATH = os.getenv("TOPIC_CHANNELS_PATH", "config/topic_channels.json")
@@ -17,12 +18,17 @@ GOOGLE_TRENDS_MIN_GROWTH = 1.3
 TWITTER_MIN_MENTIONS = 30
 TWITTER_MIN_TOP_RETWEET = 50
 MIN_CPC = 1000  # 원 (더미 기준)
+DELETE_USER_ID = os.getenv("DELETE_USER_ID")
 
 # ---------------------- 로깅 설정 ----------------------
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s %(levelname)s:%(message)s'
 )
+
+# ---------------------- 개인정보 삭제 처리 ----------------------
+if DELETE_USER_ID:
+    request_data_deletion(DELETE_USER_ID, OUTPUT_PATH)
 
 # ---------------------- 토픽별 세부 키워드 쌍 ----------------------
 TOPIC_DETAILS = {

--- a/notion_hook_uploader.py
+++ b/notion_hook_uploader.py
@@ -6,6 +6,7 @@ import re
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from privacy_manager import request_data_deletion
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -14,6 +15,7 @@ NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
 HOOK_JSON_PATH = os.getenv("HOOK_OUTPUT_PATH", "data/generated_hooks.json")
 FAILED_OUTPUT_PATH = "data/upload_failed_hooks.json"
 UPLOAD_DELAY = float(os.getenv("UPLOAD_DELAY", "0.5"))
+DELETE_USER_ID = os.getenv("DELETE_USER_ID")
 
 notion = Client(auth=NOTION_TOKEN)
 logging.basicConfig(
@@ -24,6 +26,11 @@ logging.basicConfig(
         logging.StreamHandler()
     ]
 )
+
+# ---------------------- 개인정보 삭제 처리 ----------------------
+if DELETE_USER_ID:
+    request_data_deletion(DELETE_USER_ID, HOOK_JSON_PATH)
+    request_data_deletion(DELETE_USER_ID, FAILED_OUTPUT_PATH)
 
 # ---------------------- 유틸: Notion rich_text 제한 처리 ----------------------
 def truncate_text(text, max_length=2000):

--- a/privacy_manager.py
+++ b/privacy_manager.py
@@ -1,0 +1,80 @@
+import os
+import json
+import logging
+
+
+def request_data_deletion(user_id: str, storage_path: str) -> int:
+    """Remove records associated with ``user_id`` from a JSON file.
+
+    Parameters
+    ----------
+    user_id : str
+        Identifier of the user whose data should be removed.
+    storage_path : str
+        Path to the JSON file storing the data.
+
+    Returns
+    -------
+    int
+        Number of records removed.
+    """
+    if not os.path.exists(storage_path):
+        logging.info("Storage file not found: %s", storage_path)
+        return 0
+
+    try:
+        with open(storage_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception as e:
+        logging.warning("Failed reading %s: %s", storage_path, e)
+        return 0
+
+    removed = 0
+    modified = False
+
+    if isinstance(data, list):
+        new_data = []
+        for entry in data:
+            if isinstance(entry, dict) and (
+                entry.get("user_id") == user_id
+                or entry.get("user") == user_id
+                or entry.get("id") == user_id
+            ):
+                removed += 1
+                modified = True
+                logging.info("Removed entry for user %s from %s", user_id, storage_path)
+            else:
+                new_data.append(entry)
+        data = new_data
+    elif isinstance(data, dict):
+        if user_id in data:
+            removed += 1
+            modified = True
+            data.pop(user_id)
+            logging.info("Removed key %s from %s", user_id, storage_path)
+        elif "records" in data and isinstance(data["records"], list):
+            new_records = []
+            for entry in data["records"]:
+                if isinstance(entry, dict) and entry.get("user_id") == user_id:
+                    removed += 1
+                    modified = True
+                    logging.info(
+                        "Removed record for user %s from %s", user_id, storage_path
+                    )
+                else:
+                    new_records.append(entry)
+            data["records"] = new_records
+    else:
+        logging.warning("Unsupported JSON format in %s", storage_path)
+        return 0
+
+    if modified:
+        try:
+            with open(storage_path, "w", encoding="utf-8") as f:
+                json.dump(data, f, ensure_ascii=False, indent=2)
+        except Exception as e:
+            logging.error("Failed writing %s: %s", storage_path, e)
+            return 0
+
+    return removed
+

--- a/retry_dashboard_notifier.py
+++ b/retry_dashboard_notifier.py
@@ -4,14 +4,20 @@ import logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from privacy_manager import request_data_deletion
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
 NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_KPI_DB_ID = os.getenv("NOTION_KPI_DB_ID")
 SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+DELETE_USER_ID = os.getenv("DELETE_USER_ID")
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+# ---------------------- 개인정보 삭제 처리 ----------------------
+if DELETE_USER_ID:
+    request_data_deletion(DELETE_USER_ID, SUMMARY_PATH)
 
 # ---------------------- Notion 클라이언트 ----------------------
 if not NOTION_TOKEN or not NOTION_KPI_DB_ID:

--- a/retry_failed_uploads.py
+++ b/retry_failed_uploads.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from privacy_manager import request_data_deletion
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -12,8 +13,13 @@ NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
 FAILED_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
 RETRY_DELAY = float(os.getenv("RETRY_DELAY", "0.5"))
+DELETE_USER_ID = os.getenv("DELETE_USER_ID")
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+# ---------------------- 개인정보 삭제 처리 ----------------------
+if DELETE_USER_ID:
+    request_data_deletion(DELETE_USER_ID, FAILED_PATH)
 
 # ---------------------- Notion 클라이언트 ----------------------
 if not NOTION_TOKEN or not NOTION_HOOK_DB_ID:

--- a/scripts/notion_uploader.py
+++ b/scripts/notion_uploader.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from privacy_manager import request_data_deletion
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -14,9 +15,15 @@ KEYWORD_JSON_PATH = os.getenv("KEYWORD_OUTPUT_PATH", "data/keyword_output_with_c
 UPLOAD_DELAY = float(os.getenv("UPLOAD_DELAY", "0.5"))
 CACHE_PATH = os.getenv("UPLOADED_CACHE_PATH", "data/uploaded_keywords_cache.json")
 FAILED_PATH = os.getenv("FAILED_UPLOADS_PATH", "logs/failed_uploads.json")
+DELETE_USER_ID = os.getenv("DELETE_USER_ID")
 
 # ---------------------- 로깅 설정 ----------------------
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+# ---------------------- 개인정보 삭제 처리 ----------------------
+if DELETE_USER_ID:
+    request_data_deletion(DELETE_USER_ID, CACHE_PATH)
+    request_data_deletion(DELETE_USER_ID, FAILED_PATH)
 
 # ---------------------- Notion 클라이언트 ----------------------
 notion = Client(auth=NOTION_TOKEN)

--- a/scripts/retry_failed_uploads.py
+++ b/scripts/retry_failed_uploads.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from notion_client import Client
 from dotenv import load_dotenv
+from privacy_manager import request_data_deletion
 
 # ---------------------- 설정 로딩 ----------------------
 load_dotenv()
@@ -12,8 +13,13 @@ NOTION_TOKEN = os.getenv("NOTION_API_TOKEN")
 NOTION_HOOK_DB_ID = os.getenv("NOTION_HOOK_DB_ID")
 FAILED_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_keywords.json")
 RETRY_DELAY = float(os.getenv("RETRY_DELAY", "0.5"))
+DELETE_USER_ID = os.getenv("DELETE_USER_ID")
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+# ---------------------- 개인정보 삭제 처리 ----------------------
+if DELETE_USER_ID:
+    request_data_deletion(DELETE_USER_ID, FAILED_PATH)
 
 # ---------------------- Notion 클라이언트 ----------------------
 if not NOTION_TOKEN or not NOTION_HOOK_DB_ID:


### PR DESCRIPTION
## Summary
- add `privacy_manager.py` with `request_data_deletion`
- support optional deletion of user data via `DELETE_USER_ID` in keyword and hook generators
- integrate deletion checks in Notion upload scripts and retry helpers

## Testing
- `python -m py_compile privacy_manager.py hook_generator.py keyword_auto_pipeline.py notion_hook_uploader.py retry_dashboard_notifier.py retry_failed_uploads.py scripts/notion_uploader.py scripts/retry_failed_uploads.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f6ebbdb108322b0f7cdef3f249286