### PR TITLE
Add missing retry scripts

### DIFF
--- a/scripts/notify_retry_result.py
+++ b/scripts/notify_retry_result.py
@@ -1,0 +1,47 @@
+import os
+import json
+import logging
+from dotenv import load_dotenv
+
+load_dotenv()
+
+SUMMARY_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def load_summary():
+    if not os.path.exists(SUMMARY_PATH):
+        logging.error(f"❌ 요약 파일이 없습니다: {SUMMARY_PATH}")
+        return []
+    try:
+        with open(SUMMARY_PATH, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception as e:
+        logging.error(f"요약 파일 로딩 실패: {e}")
+        return []
+
+
+def send_slack_message(text: str):
+    if not SLACK_WEBHOOK_URL:
+        logging.info(text)
+        return
+    try:
+        import requests
+        response = requests.post(SLACK_WEBHOOK_URL, json={"text": text})
+        response.raise_for_status()
+        logging.info("Slack 알림 전송 완료")
+    except Exception as e:
+        logging.error(f"Slack 전송 실패: {e}")
+
+
+def main():
+    items = load_summary()
+    failed_count = len(items)
+    message = f"🔁 재시도 결과 보고 - 남은 실패 항목: {failed_count}개"
+    send_slack_message(message)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/parse_failed_gpt.py
+++ b/scripts/parse_failed_gpt.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import json
+import logging
+from dotenv import load_dotenv
+
+# Allow importing modules from project root
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from notion_hook_uploader import parse_generated_text
+
+load_dotenv()
+
+FAILED_INPUT_PATH = os.getenv("FAILED_HOOK_PATH", "logs/failed_hooks.json")
+OUTPUT_PATH = os.getenv("REPARSED_OUTPUT_PATH", "logs/failed_keywords_reparsed.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def load_failed_items():
+    if not os.path.exists(FAILED_INPUT_PATH):
+        logging.error(f"❌ 입력 파일이 존재하지 않습니다: {FAILED_INPUT_PATH}")
+        return []
+    with open(FAILED_INPUT_PATH, 'r', encoding='utf-8') as f:
+        try:
+            return json.load(f)
+        except Exception as e:
+            logging.error(f"JSON 로딩 실패: {e}")
+            return []
+
+
+def reparse_items(items):
+    output = []
+    for item in items:
+        text = item.get("generated_text")
+        if text:
+            try:
+                item["parsed"] = parse_generated_text(text)
+            except Exception as e:
+                logging.warning(f"파싱 실패: {item.get('keyword')} - {e}")
+        output.append(item)
+    return output
+
+
+def main():
+    items = load_failed_items()
+    if not items:
+        logging.info("재파싱할 항목이 없습니다.")
+        return
+    reparsed = reparse_items(items)
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
+        json.dump(reparsed, f, ensure_ascii=False, indent=2)
+    logging.info(f"✅ 재파싱 결과 저장: {OUTPUT_PATH} (총 {len(reparsed)}개)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `parse_failed_gpt.py` to reparse GPT outputs
- implement `notify_retry_result.py` for Slack notifications

## Testing
- `python -m py_compile scripts/parse_failed_gpt.py scripts/notify_retry_result.py`

------
https://chatgpt.com/codex/tasks/task_b_684f6ebf285083228f65160e017498c8