### PR TITLE
Add IDS setup script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Auto Pipeline
+
+This repository contains scripts for generating and uploading content to Notion using various automation steps.
+
+## Security
+
+An optional intrusion detection system (IDS) can be configured to monitor this environment. See `security/ids_setup.sh` for a simple Snort installation script. Logs are stored in `/var/log/snort` by default.
+
+### Enabling and Monitoring IDS Logs
+
+Run the setup script with root privileges:
+
+```bash
+sudo bash security/ids_setup.sh
+```
+
+After installation, review `/var/log/snort/` (or your configured directory) to monitor alerts and other IDS output. Rotate or archive these logs regularly to maintain disk space.
+

--- a/security/ids_setup.sh
+++ b/security/ids_setup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Basic Snort IDS installation script
+# Run this script with root or sudo privileges.
+
+set -e
+
+LOG_DIR="/var/log/snort"  # dedicated directory for IDS logs
+
+# Install Snort
+apt-get update
+apt-get install -y snort  # or replace with suricata
+
+# Ensure log directory exists
+mkdir -p "$LOG_DIR"
+chown snort:snort "$LOG_DIR"
+# Inform about configuration and logging
+echo "Edit /etc/snort/snort.conf to specify HOME_NET and other options." >&2
+
+echo "Logs will be written to $LOG_DIR" >&2
+
+systemctl enable snort
+systemctl restart snort
+
+


### PR DESCRIPTION
## Summary
- add `security/ids_setup.sh` with Snort installation steps
- create README with section on enabling and monitoring IDS logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f700717c08322afc13cb2c5cda575