### PR TITLE
Add resource monitoring module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Auto Pipeline
+
+This repository contains scripts used to run the automated pipeline.
+
+## Resource Monitoring
+
+Resource usage (CPU and memory) can be captured during pipeline execution.
+Set the environment variable `ENABLE_MONITORING=true` before running
+`run_pipeline.py` to enable monitoring. Metrics will be written to
+`logs/resource_monitor.log`.
+
+Monitoring is disabled by default if the variable is unset or set to any
+other value.

--- a/monitoring/resource_monitor.py
+++ b/monitoring/resource_monitor.py
@@ -1,0 +1,57 @@
+import os
+import threading
+import time
+from datetime import datetime
+
+import psutil
+
+
+class ResourceMonitor:
+    """Background monitor that logs CPU and memory usage."""
+
+    def __init__(self, interval: float = 1.0, log_file: str = "logs/resource_monitor.log"):
+        self.interval = interval
+        self.log_file = log_file
+        self._thread = None
+        self._stop_event = threading.Event()
+
+    def _ensure_log_dir(self):
+        directory = os.path.dirname(self.log_file)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+
+    def _monitor(self):
+        self._ensure_log_dir()
+        with open(self.log_file, "a") as f:
+            while not self._stop_event.is_set():
+                cpu = psutil.cpu_percent(interval=None)
+                mem = psutil.virtual_memory().percent
+                timestamp = datetime.now().isoformat()
+                f.write(f"{timestamp}, cpu={cpu}, mem={mem}\n")
+                f.flush()
+                time.sleep(self.interval)
+
+    def start(self):
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._monitor, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join()
+
+
+_default_monitor = ResourceMonitor()
+
+
+def start_monitoring():
+    """Start the default resource monitor."""
+    _default_monitor.start()
+
+
+def stop_monitoring():
+    """Stop the default resource monitor."""
+    _default_monitor.stop()

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -4,6 +4,16 @@ import sys
 import os
 from datetime import datetime
 
+ENABLE_MONITORING = os.getenv("ENABLE_MONITORING", "false").lower() == "true"
+if ENABLE_MONITORING:
+    from monitoring.resource_monitor import start_monitoring, stop_monitoring
+else:
+    def start_monitoring():
+        pass
+
+    def stop_monitoring():
+        pass
+
 # ---------------------- 로깅 설정 ----------------------
 logging.basicConfig(
     level=logging.INFO,
@@ -41,6 +51,10 @@ def run_script(script):
 # ---------------------- 전체 파이프라인 실행 ----------------------
 def run_pipeline():
     logging.info(f"🧩 파이프라인 시작: {datetime.now().strftime('%Y-%m-%d %H:%M')}")
+    if ENABLE_MONITORING:
+        logging.info("📈 Resource monitoring enabled")
+    start_monitoring()
+
     all_passed = True
 
     for script in PIPELINE_SEQUENCE:
@@ -55,6 +69,10 @@ def run_pipeline():
         logging.info("✅ 모든 단계 성공적으로 완료")
     else:
         logging.warning("⚠️ 일부 단계에서 실패 발생")
+
+    stop_monitoring()
+    if ENABLE_MONITORING:
+        logging.info("📉 Resource monitoring stopped")
 
 # ---------------------- 진입점 ----------------------
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a resource monitor that logs CPU/memory usage
- start/stop monitor in the pipeline based on `ENABLE_MONITORING`
- document monitoring in README

## Testing
- `python -m py_compile run_pipeline.py monitoring/resource_monitor.py`
- `ENABLE_MONITORING=true python run_pipeline.py` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_b_684f6ff59b088322a45881366f67ee84