### PR TITLE
Implement basic privacy manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Auto_Pipeline
+
+This repository contains automation scripts for generating and uploading content.
+
+## Privacy Management
+
+The `privacy` module implements utilities to comply with GDPR and CCPA "right to be forgotten" requirements. Use the `PrivacyManager` class to remove a user's data from local storage.
+
+### Deleting a User's Data
+
+```bash
+python privacy/privacy_manager.py --delete <USER_ID>
+```
+
+This command deletes all records associated with `USER_ID` from `data/user_data.json`. Removing these records ensures we honor user requests for deletion in accordance with GDPR and CCPA regulations.
+

--- a/privacy/privacy_manager.py
+++ b/privacy/privacy_manager.py
@@ -1,0 +1,50 @@
+import argparse
+import json
+import logging
+import os
+
+
+class PrivacyManager:
+    """Utility class to manage user data in local storage."""
+
+    def __init__(self, storage_path: str = "data/user_data.json") -> None:
+        self.storage_path = storage_path
+
+    def request_data_deletion(self, user_id: str) -> bool:
+        """Remove records for ``user_id`` from the local storage file."""
+        if not os.path.exists(self.storage_path):
+            logging.warning("Storage file not found: %s", self.storage_path)
+            return False
+
+        try:
+            with open(self.storage_path, "r", encoding="utf-8") as f:
+                records = json.load(f)
+        except json.JSONDecodeError:
+            logging.error("Invalid JSON in %s", self.storage_path)
+            return False
+
+        original_len = len(records)
+        records = [r for r in records if r.get("user_id") != user_id]
+
+        if len(records) == original_len:
+            logging.info("No records found for user %s", user_id)
+        else:
+            with open(self.storage_path, "w", encoding="utf-8") as f:
+                json.dump(records, f, ensure_ascii=False, indent=2)
+            logging.info("Deleted data for user %s", user_id)
+        return True
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Manage privacy operations")
+    parser.add_argument("--delete", metavar="USER_ID", help="Delete a user's data")
+    args = parser.parse_args()
+
+    if args.delete:
+        manager = PrivacyManager()
+        success = manager.request_data_deletion(args.delete)
+        if success:
+            print(f"User {args.delete} data deleted.")
+        else:
+            print(f"No data deleted for user {args.delete}.")
+


### PR DESCRIPTION
## Summary
- add `privacy/privacy_manager.py` with a `PrivacyManager` class
- provide CLI interface to delete local user data
- document privacy deletion under GDPR/CCPA

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f7005ffe88322a6b75d0ff3a22083