### PR TITLE
Fix pipeline script paths

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -12,18 +12,21 @@ logging.basicConfig(
 
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
+    "keyword_auto_pipeline.py",
     "hook_generator.py",
-    "parse_failed_gpt.py",
+    "notion_hook_uploader.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
     "retry_dashboard_notifier.py"
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    # 스크립트는 프로젝트 루트 혹은 scripts/ 하위에 존재할 수 있다.
+    candidates = [script, os.path.join("scripts", script)]
+    full_path = next((p for p in candidates if os.path.exists(p)), None)
+
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- fix run_pipeline script sequence
- allow running scripts from project root or scripts folder

## Testing
- `python -m py_compile run_pipeline.py`
- `python run_pipeline.py > /tmp/pipeline.log && tail -n 20 /tmp/pipeline.log`


------
https://chatgpt.com/codex/tasks/task_b_684fbace020c83228890c097f251306c