### PR TITLE
Add env example and setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+# Example environment configuration
+# Copy this file to `.env` and fill in your secrets and paths
+
+# API keys
+OPENAI_API_KEY=your-openai-api-key
+NOTION_API_TOKEN=your-notion-token
+
+# Notion database IDs
+NOTION_HOOK_DB_ID=your-hook-db-id
+NOTION_KPI_DB_ID=your-kpi-db-id
+NOTION_DB_ID=your-keyword-db-id
+
+# Optional webhook
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/your/webhook/url
+
+# Paths (modify as needed)
+KEYWORD_OUTPUT_PATH=data/keyword_output_with_cpc.json
+HOOK_OUTPUT_PATH=data/generated_hooks.json
+FAILED_HOOK_PATH=logs/failed_hooks.json
+FAILED_UPLOADS_PATH=logs/failed_uploads.json
+UPLOADED_CACHE_PATH=data/uploaded_keywords_cache.json
+REPARSED_OUTPUT_PATH=logs/failed_keywords_reparsed.json
+TOPIC_CHANNELS_PATH=config/topic_channels.json
+
+# Delays
+API_DELAY=1.0
+UPLOAD_DELAY=0.5
+RETRY_DELAY=0.5

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Auto Pipeline
+
+This project contains scripts to generate marketing hooks and upload them to Notion.  
+Environment variables are required for API keys and database IDs.
+
+## Setup
+1. Copy `.env.example` to `.env`.
+2. Fill in your API keys, Notion database IDs and other settings in the `.env` file.
+3. Install Python dependencies listed in `requirements.txt` (if provided).
+4. Run the scripts as needed, for example:
+   ```bash
+   python hook_generator.py
+   ```
+
+The `.env` file is ignored by Git, so your secrets will stay local.


### PR DESCRIPTION
## Summary
- provide `.env.example` with expected environment variables
- document environment setup in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_684fba9c6dd4832299c0ff697cbf52fb