### PR TITLE
Fix workflow path

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()


### PR DESCRIPTION
## Summary
- rename daily pipeline workflow to use `.yml`
- call the correct entrypoint in CI

## Testing
- `python -m py_compile run_pipeline.py`
- `python -m py_compile keyword_auto_pipeline.py notion_hook_uploader.py retry_dashboard_notifier.py retry_failed_uploads.py scripts/notion_uploader.py scripts/retry_failed_uploads.py hook_generator.py`


------
https://chatgpt.com/codex/tasks/task_b_684fba9762508322b981a9d4fd20f1ab