### PR TITLE
Add channel specs and ROI analyzer

### DIFF
--- a/channel_roi_analyzer.py
+++ b/channel_roi_analyzer.py
@@ -1,0 +1,51 @@
+import os
+import json
+import logging
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+CHANNEL_SPECS_PATH = os.getenv('CHANNEL_SPECS_PATH', 'config/channel_specs.json')
+ROI_RANKING_PATH = os.getenv('ROI_RANKING_PATH', 'data/channel_roi_ranking.json')
+
+# ---------------------- ROI 계산 ----------------------
+
+def load_specs(path: str) -> dict:
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def compute_roi(spec: dict) -> float:
+    cpm = spec.get('cpm', 0)
+    cpa = spec.get('cpa', 0)
+    cpc = spec.get('cpc', 0)
+    return cpm * 0.5 + cpa * 0.3 + cpc * 0.2
+
+
+def rank_channels(specs: dict) -> list:
+    ranking = []
+    for channel, spec in specs.items():
+        score = compute_roi(spec)
+        ranking.append({'channel': channel, 'roi_score': round(score, 2)})
+    ranking.sort(key=lambda x: x['roi_score'], reverse=True)
+    return ranking
+
+
+def main() -> None:
+    if not os.path.exists(CHANNEL_SPECS_PATH):
+        logging.error(f"Spec file not found: {CHANNEL_SPECS_PATH}")
+        return
+    specs = load_specs(CHANNEL_SPECS_PATH)
+    ranking = rank_channels(specs)
+
+    os.makedirs(os.path.dirname(ROI_RANKING_PATH), exist_ok=True)
+    with open(ROI_RANKING_PATH, 'w', encoding='utf-8') as f:
+        json.dump(ranking, f, ensure_ascii=False, indent=2)
+    logging.info(f"ROI ranking saved to {ROI_RANKING_PATH}")
+
+    print("ROI Ranking:")
+    for idx, entry in enumerate(ranking, 1):
+        print(f"{idx}. {entry['channel']} - score {entry['roi_score']}")
+
+
+if __name__ == '__main__':
+    main()

--- a/config/channel_specs.json
+++ b/config/channel_specs.json
@@ -1,0 +1,43 @@
+{
+  "YouTube": {
+    "max_title_length": 100,
+    "max_description_length": 5000,
+    "video_resolution": "1920x1080",
+    "hashtag_limit": 15,
+    "cpm": 5.0,
+    "cpa": 1.2,
+    "cpc": 0.2
+  },
+  "Blog": {
+    "max_title_length": 60,
+    "max_content_length": 10000,
+    "image_size": "1200x630",
+    "hashtag_limit": 10,
+    "cpm": 3.0,
+    "cpa": 0.8,
+    "cpc": 0.1
+  },
+  "Instagram": {
+    "caption_length": 2200,
+    "image_size": "1080x1080",
+    "hashtag_limit": 30,
+    "cpm": 4.5,
+    "cpa": 1.0,
+    "cpc": 0.15
+  },
+  "Twitter": {
+    "tweet_length": 280,
+    "image_size": "1200x675",
+    "hashtag_limit": 3,
+    "cpm": 2.5,
+    "cpa": 0.5,
+    "cpc": 0.05
+  },
+  "Email": {
+    "subject_length": 78,
+    "body_length": 5000,
+    "cpm": 6.0,
+    "cpa": 2.0,
+    "cpc": 0.25
+  }
+}

--- a/data/channel_roi_ranking.json
+++ b/data/channel_roi_ranking.json
@@ -1,0 +1,22 @@
+[
+  {
+    "channel": "Email",
+    "roi_score": 3.65
+  },
+  {
+    "channel": "YouTube",
+    "roi_score": 2.9
+  },
+  {
+    "channel": "Instagram",
+    "roi_score": 2.58
+  },
+  {
+    "channel": "Blog",
+    "roi_score": 1.76
+  },
+  {
+    "channel": "Twitter",
+    "roi_score": 1.41
+  }
+]


### PR DESCRIPTION
## Summary
- define content specs and ad metrics per channel in `channel_specs.json`
- add `channel_roi_analyzer.py` to rank channels by ROI
- include example ROI ranking output

## Testing
- `python channel_roi_analyzer.py`

------
https://chatgpt.com/codex/tasks/task_b_684fb9feadf08322a9ade93db270be7a