### PR TITLE
Add channel ROI analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Auto Pipeline
+
+본 저장소는 키워드 기반 콘텐츠 제작을 자동화하기 위한 스크립트를 포함합니다. 
+새롭게 `channel_roi_analysis.py`와 `config/channel_specs.json` 파일이 추가되어 
+플랫폼별 수익 지표와 콘텐츠 규격을 확인하고 ROI 우선순위를 계산할 수 있습니다.
+
+## ROI 분석 사용법
+```bash
+python channel_roi_analysis.py
+```
+해당 명령을 실행하면 각 채널의 ROI 점수와 권장 규격이 출력됩니다.

--- a/channel_roi_analysis.py
+++ b/channel_roi_analysis.py
@@ -1,0 +1,42 @@
+import json
+import os
+import logging
+
+CONFIG_PATH = os.getenv("CHANNEL_SPECS_PATH", "config/channel_specs.json")
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
+
+
+def load_channels(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+        return data.get("channels", [])
+
+
+def calc_roi(ch):
+    cpm = ch.get("cpm", 0)
+    cpc = ch.get("cpc", 0)
+    cpa = ch.get("cpa", 0)
+    return round(cpm * 0.5 + cpc * 0.3 + cpa * 0.2, 2)
+
+
+def main():
+    channels = load_channels(CONFIG_PATH)
+    for ch in channels:
+        ch["roi_score"] = calc_roi(ch)
+    channels.sort(key=lambda x: x["roi_score"], reverse=True)
+
+    print("채널 ROI 우선순위")
+    for idx, ch in enumerate(channels, start=1):
+        spec = ch.get("content_spec", {})
+        print(f"{idx}. {ch['name']} - ROI {ch['roi_score']}")
+        print(
+            f"   규격: 텍스트 {spec.get('text_length', 'N/A')}, "
+            f"이미지 {spec.get('image_size', 'N/A')}, "
+            f"영상 {spec.get('video_size', 'N/A')}, "
+            f"해시태그 {spec.get('hashtags', 'N/A')}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/config/channel_specs.json
+++ b/config/channel_specs.json
@@ -1,0 +1,69 @@
+{
+  "channels": [
+    {
+      "name": "유튜브",
+      "revenue_models": ["광고 수익", "제휴 마케팅"],
+      "cpm": 2000,
+      "cpa": 10000,
+      "cpc": 300,
+      "content_spec": {
+        "text_length": "제목 100자 이내, 설명 5000자 이내",
+        "image_size": "썸네일 1280x720",
+        "video_size": "최대 12시간 / 128GB",
+        "hashtags": 15
+      }
+    },
+    {
+      "name": "블로그",
+      "revenue_models": ["디스플레이 광고", "제휴 링크"],
+      "cpm": 1500,
+      "cpa": 7000,
+      "cpc": 200,
+      "content_spec": {
+        "text_length": "본문 3000자 이상 권장",
+        "image_size": "본문 너비 1200px",
+        "video_size": "임베드 가능",
+        "hashtags": 10
+      }
+    },
+    {
+      "name": "인스타그램",
+      "revenue_models": ["브랜드 광고", "제품 판매"],
+      "cpm": 2500,
+      "cpa": 9000,
+      "cpc": 250,
+      "content_spec": {
+        "text_length": "캡션 최대 2200자",
+        "image_size": "1080x1080",
+        "video_size": "Reels 최대 60초",
+        "hashtags": 30
+      }
+    },
+    {
+      "name": "트위터",
+      "revenue_models": ["프로모션 트윗", "어필리에이트 링크"],
+      "cpm": 1800,
+      "cpa": 8000,
+      "cpc": 220,
+      "content_spec": {
+        "text_length": "280자",
+        "image_size": "1600x900",
+        "video_size": "2분 20초",
+        "hashtags": 2
+      }
+    },
+    {
+      "name": "이메일 마케팅",
+      "revenue_models": ["구독 기반", "제품 판매"],
+      "cpm": 1000,
+      "cpa": 12000,
+      "cpc": 180,
+      "content_spec": {
+        "text_length": "본문 1500자 이내",
+        "image_size": "가로 600px 권장",
+        "video_size": "링크 형태",
+        "hashtags": 0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add channel specifications with monetization metrics
- implement `channel_roi_analysis.py` to compute ROI scores
- document usage in new README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684fbc9c09608322b19b64681bc344f3