### PR TITLE
Ensure directory exists when writing failed uploads

### DIFF
--- a/retry_failed_uploads.py
+++ b/retry_failed_uploads.py
@@ -88,6 +88,7 @@ def retry_failed_uploads():
 
     # 실패 파일 덮어쓰기
     if still_failed:
+        os.makedirs(os.path.dirname(FAILED_PATH), exist_ok=True)
         with open(FAILED_PATH, 'w', encoding='utf-8') as f:
             json.dump(still_failed, f, ensure_ascii=False, indent=2)
         logging.warning(f"🔁 여전히 실패한 항목 {len(still_failed)}개가 남아 있습니다.")

--- a/scripts/retry_failed_uploads.py
+++ b/scripts/retry_failed_uploads.py
@@ -88,6 +88,7 @@ def retry_failed_uploads():
 
     # 실패 파일 덮어쓰기
     if still_failed:
+        os.makedirs(os.path.dirname(FAILED_PATH), exist_ok=True)
         with open(FAILED_PATH, 'w', encoding='utf-8') as f:
             json.dump(still_failed, f, ensure_ascii=False, indent=2)
         logging.warning(f"🔁 여전히 실패한 항목 {len(still_failed)}개가 남아 있습니다.")


### PR DESCRIPTION
## Summary
- make sure logs folder exists before writing failed uploads in retry scripts

## Testing
- `python -m py_compile retry_failed_uploads.py scripts/retry_failed_uploads.py`


------
https://chatgpt.com/codex/tasks/task_b_684fbcb14c44832285e0e9f2f2988100