### PR TITLE
Add env template and setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# Copy this file to .env and fill in your credentials
+
+# API keys
+OPENAI_API_KEY=
+NOTION_API_TOKEN=
+
+# Notion database IDs
+NOTION_HOOK_DB_ID=
+NOTION_KPI_DB_ID=
+NOTION_DB_ID=
+
+# Optional integrations
+SLACK_WEBHOOK_URL=
+
+# File paths
+TOPIC_CHANNELS_PATH=config/topic_channels.json
+KEYWORD_OUTPUT_PATH=data/keyword_output_with_cpc.json
+HOOK_OUTPUT_PATH=data/generated_hooks.json
+FAILED_HOOK_PATH=logs/failed_hooks.json
+REPARSED_OUTPUT_PATH=logs/failed_keywords_reparsed.json
+UPLOADED_CACHE_PATH=data/uploaded_keywords_cache.json
+FAILED_UPLOADS_PATH=logs/failed_uploads.json
+
+# Misc settings
+UPLOAD_DELAY=0.5
+RETRY_DELAY=0.5
+API_DELAY=1.0

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Auto Pipeline
+
+This repository contains scripts to generate marketing hooks, upload them to Notion, and track metrics.
+
+## Setup
+1. Copy `.env.example` to `.env` in the project root.
+2. Fill in the API keys, database IDs and any other credentials in `.env`.
+3. Install the required Python packages.
+
+## Running
+Execute the scripts or `run_pipeline.py` depending on your workflow.


### PR DESCRIPTION
## Summary
- add `.env.example` with OpenAI, Notion and Slack variables
- add minimal README with instructions to copy the template to `.env`

## Testing
- `python -m py_compile hook_generator.py notion_hook_uploader.py retry_dashboard_notifier.py retry_failed_uploads.py keyword_auto_pipeline.py scripts/notion_uploader.py scripts/retry_failed_uploads.py run_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_b_684fbcbebc7483228598019cc38f3463