### PR TITLE
Fix run_pipeline path and clean sequence

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,15 +13,16 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    "retry_dashboard_notifier.py",
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
 def run_script(script):
-    full_path = os.path.join("scripts", script)
+    full_path = os.path.join(BASE_DIR, script)
     if not os.path.exists(full_path):
         logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
         return False


### PR DESCRIPTION
## Summary
- remove missing scripts from pipeline sequence
- run scripts from the repository root instead of the `scripts/` folder

## Testing
- `python -m py_compile run_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_b_684fbcc01bec832287d23edfac72d5e4