### PR TITLE
Fix missing directory for failed path

### DIFF
--- a/retry_failed_uploads.py
+++ b/retry_failed_uploads.py
@@ -88,6 +88,7 @@ def retry_failed_uploads():
 
     # 실패 파일 덮어쓰기
     if still_failed:
+        os.makedirs(os.path.dirname(FAILED_PATH), exist_ok=True)
         with open(FAILED_PATH, 'w', encoding='utf-8') as f:
             json.dump(still_failed, f, ensure_ascii=False, indent=2)
         logging.warning(f"🔁 여전히 실패한 항목 {len(still_failed)}개가 남아 있습니다.")

--- a/scripts/retry_failed_uploads.py
+++ b/scripts/retry_failed_uploads.py
@@ -88,6 +88,7 @@ def retry_failed_uploads():
 
     # 실패 파일 덮어쓰기
     if still_failed:
+        os.makedirs(os.path.dirname(FAILED_PATH), exist_ok=True)
         with open(FAILED_PATH, 'w', encoding='utf-8') as f:
             json.dump(still_failed, f, ensure_ascii=False, indent=2)
         logging.warning(f"🔁 여전히 실패한 항목 {len(still_failed)}개가 남아 있습니다.")


### PR DESCRIPTION
## Summary
- ensure the failed path's directories exist before writing retry failures

## Testing
- `python -m py_compile retry_failed_uploads.py scripts/retry_failed_uploads.py`


------
https://chatgpt.com/codex/tasks/task_b_684fbdd288508322af59e4ce312e8faa