### PR TITLE
Fix daily pipeline workflow

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()


### PR DESCRIPTION
## Summary
- rename the daily pipeline workflow to use the `.yml` extension
- call the top-level `run_pipeline.py` script in the workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684fbe70386083229f9e231674683db9