### PR TITLE
Update pipeline script paths

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,20 +13,20 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
+    "notion_hook_uploader.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
     "retry_dashboard_notifier.py"
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    potential_paths = [script, os.path.join("scripts", script)]
+    full_path = next((p for p in potential_paths if os.path.exists(p)), None)
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
-    logging.info(f"🚀 실행 중: {script}")
+    logging.info(f"🚀 실행 중: {full_path}")
     result = subprocess.run([sys.executable, full_path], capture_output=True, text=True)
 
     if result.returncode != 0:


### PR DESCRIPTION
## Summary
- update the pipeline sequence to only reference existing scripts
- allow `run_script()` to check both the repo root and `scripts/` when locating files

## Testing
- `python -m py_compile run_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_b_684fbe6fc8288322b7739e8f321d17ec