### PR TITLE
Fix workflow filename and dependencies

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+openai
+notion-client
+python-dotenv
+pytrends
+snscrape


### PR DESCRIPTION
## Summary
- rename workflow file so GitHub picks it up
- define required Python dependencies
- run the main pipeline entry point in the workflow

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_684fbe7dd1288322b8d38f957ae82fa7