### PR TITLE
Fix pipeline runner path

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,17 +13,29 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
+    "notion_hook_uploader.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    "retry_dashboard_notifier.py",
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    """Execute an individual pipeline script.
+
+    The function looks for the script in the repository root first and
+    then inside the ``scripts`` directory. This allows ``PIPELINE_SEQUENCE``
+    to list scripts regardless of their actual location.
+    """
+    repo_root = os.path.dirname(os.path.abspath(__file__))
+    root_path = os.path.join(repo_root, script)
+    scripts_path = os.path.join(repo_root, "scripts", script)
+
+    if os.path.exists(root_path):
+        full_path = root_path
+    elif os.path.exists(scripts_path):
+        full_path = scripts_path
+    else:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- update pipeline order
- locate scripts in root or `scripts/`
- fix workflow to invoke `run_pipeline.py`

## Testing
- `python -m py_compile run_pipeline.py`
- `python -m py_compile hook_generator.py notion_hook_uploader.py retry_failed_uploads.py retry_dashboard_notifier.py`
- `python -m py_compile scripts/notion_uploader.py scripts/retry_failed_uploads.py`


------
https://chatgpt.com/codex/tasks/task_b_684fbe8a3ff883229d983e0052273a70