### PR TITLE
Fix pipeline script lookup

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,17 +13,22 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
     "retry_dashboard_notifier.py"
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    # Look for the script inside the scripts directory first,
+    # then fall back to the repository root
+    candidate_paths = [os.path.join("scripts", script), script]
+    full_path = None
+    for path in candidate_paths:
+        if os.path.exists(path):
+            full_path = path
+            break
+    if full_path is None:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- run scripts from root or scripts directory
- drop missing scripts from `PIPELINE_SEQUENCE`

## Testing
- `python -m py_compile *.py scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_b_684fbf41167083228d0f5731f0db5e6c