### PR TITLE
Fix workflow file name and script path

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()


### PR DESCRIPTION
## Summary
- rename workflow to `daily-pipeline.yml`
- call `run_pipeline.py` from repository root

## Testing
- `python -m py_compile *.py scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_b_684fbf4818b483229cc4ca39c4d6f2e2