### PR TITLE
Add pytest tests and CI step

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -31,6 +31,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: 🧪 Run tests
+        run: pytest -q
+
       - name: ▶️ Run full pipeline (single entrypoint)
         run: python scripts/run_pipeline.py
 

--- a/tests/test_hook_generator.py
+++ b/tests/test_hook_generator.py
@@ -1,0 +1,32 @@
+import sys
+import types
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+# Mock modules to avoid missing dependencies
+sys.modules['dotenv'] = types.ModuleType('dotenv')
+sys.modules['dotenv'].load_dotenv = lambda: None
+sys.modules['openai'] = types.ModuleType('openai')
+sys.modules['openai'].api_key = None
+
+from hook_generator import generate_hook_prompt
+
+
+def test_generate_hook_prompt_contents():
+    prompt = generate_hook_prompt(
+        keyword="테스트키워드",
+        topic="테스트주제",
+        source="출처",
+        score=1,
+        growth=2,
+        mentions=3,
+    )
+
+    assert "테스트키워드" in prompt
+    assert "출처" in prompt
+    assert "1" in prompt
+    assert "2" in prompt
+    assert "3" in prompt
+
+

--- a/tests/test_notion_hook_uploader.py
+++ b/tests/test_notion_hook_uploader.py
@@ -1,0 +1,41 @@
+import sys
+import types
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+# Ensure logs directory exists for FileHandler
+os.makedirs('logs', exist_ok=True)
+
+# Mock external modules
+notion_client = types.ModuleType('notion_client')
+class DummyClient:
+    def __init__(self, *args, **kwargs):
+        pass
+notion_client.Client = DummyClient
+sys.modules['notion_client'] = notion_client
+
+sys.modules['dotenv'] = types.ModuleType('dotenv')
+sys.modules['dotenv'].load_dotenv = lambda: None
+
+from notion_hook_uploader import parse_generated_text
+
+
+def test_parse_generated_text_basic():
+    sample = (
+        "후킹 문장1: 첫번째 후킹\n"
+        "후킹문장2: 두번째 후킹\n"
+        "블로그 초안:\n"
+        "첫 문단\n"
+        "둘째 문단\n"
+        "셋째 문단\n"
+        "영상 제목:\n"
+        "- 제목A\n"
+        "- 제목B\n"
+    )
+
+    result = parse_generated_text(sample)
+    assert result["hook_lines"] == ["첫번째 후킹", "두번째 후킹"]
+    assert result["blog_paragraphs"] == ["첫 문단"]
+    assert result["video_titles"] == ["제목B"]
+


### PR DESCRIPTION
## Summary
- add basic pytest tests for hook prompt and generated text parsing
- run pytest in GitHub Actions workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684fbf4a9c3483228a4ccf766d048518