### PR TITLE
Add EOF marker to retry_failed_uploads.py

### DIFF
--- a/retry_failed_uploads.py
+++ b/retry_failed_uploads.py
@@ -98,3 +98,4 @@ def retry_failed_uploads():
 
 if __name__ == "__main__":
     retry_failed_uploads()
+# EOF


### PR DESCRIPTION
## Summary
- ensure `retry_failed_uploads.py` ends with a non-empty line

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684fc007ae648322b2b94efb76e897a6