### PR TITLE
Fix script path search and pipeline sequence

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,17 +13,26 @@ logging.basicConfig(
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
     "hook_generator.py",
-    "parse_failed_gpt.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
     "retry_dashboard_notifier.py"
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    candidate_paths = [
+        os.path.join(base_dir, "scripts", script),
+        os.path.join(base_dir, script),
+    ]
+
+    full_path = None
+    for path in candidate_paths:
+        if os.path.exists(path):
+            full_path = path
+            break
+
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
     logging.info(f"🚀 실행 중: {script}")


### PR DESCRIPTION
## Summary
- update run_script path search order to look in project root
- drop unused scripts from pipeline sequence

## Testing
- `python -m py_compile run_pipeline.py hook_generator.py retry_failed_uploads.py retry_dashboard_notifier.py notion_hook_uploader.py keyword_auto_pipeline.py scripts/retry_failed_uploads.py scripts/notion_uploader.py`

------
https://chatgpt.com/codex/tasks/task_b_684fc0118568832291f45b17eda218ce