### PR TITLE
Add README and env template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Copy to .env and fill in your own credentials
+OPENAI_API_KEY=
+NOTION_API_TOKEN=
+NOTION_HOOK_DB_ID=
+NOTION_DB_ID=
+NOTION_KPI_DB_ID=
+
+# Optional paths and settings
+KEYWORD_OUTPUT_PATH=data/keyword_output_with_cpc.json
+HOOK_OUTPUT_PATH=data/generated_hooks.json
+FAILED_HOOK_PATH=logs/failed_hooks.json
+FAILED_UPLOADS_PATH=logs/failed_uploads.json
+UPLOADED_CACHE_PATH=data/uploaded_keywords_cache.json
+REPARSED_OUTPUT_PATH=logs/failed_keywords_reparsed.json
+TOPIC_CHANNELS_PATH=config/topic_channels.json
+UPLOAD_DELAY=0.5
+API_DELAY=1.0
+RETRY_DELAY=0.5

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Auto Pipeline
+
+This repository contains automation scripts for generating marketing hooks and uploading them to Notion databases. The project relies on several external APIs and requires a few environment variables to run.
+
+## Setup
+
+1. **Clone the repository** and create a Python virtual environment (optional but recommended):
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   ```
+2. **Install dependencies**:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. **Prepare environment variables**:
+   - Copy `.env.example` to `.env`.
+   - Fill in the API keys and other values in the new `.env` file.
+4. **Run the pipeline**:
+   ```bash
+   python run_pipeline.py
+   ```
+
+## Security Reminders
+
+- `.env` is excluded from version control via `.gitignore`. **Never commit your real secrets**.
+- Rotate API keys on a regular basis and update the values in your `.env` file when you do.
+- If you suspect that a key was committed accidentally, rotate it immediately and review the commit history and CI logs for exposure.
+
+## Logs
+
+Execution logs are saved under the `logs/` directory. Regularly review these logs to ensure that no sensitive information is written there by mistake.
+


### PR DESCRIPTION
## Summary
- add project setup instructions in README
- include an `.env.example` template with required variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684fc0122d7883228efa851d4415dd19