### PR TITLE
Fix pipeline script path

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()


### PR DESCRIPTION
## Summary
- ensure the daily pipeline workflow calls `python run_pipeline.py` instead of looking for it in `scripts/`

## Testing
- `python -m py_compile run_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_b_684fc021b37c83229a9062ab276793f3