### PR TITLE
Update pipeline script list and path lookup

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -12,21 +12,26 @@ logging.basicConfig(
 
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
+    "keyword_auto_pipeline.py",
     "hook_generator.py",
-    "parse_failed_gpt.py",
+    "notion_hook_uploader.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    "retry_dashboard_notifier.py",
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
 def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+    """Run a Python script located either in the repo root or the scripts folder."""
+    possible_paths = [script]
+    if not os.path.isabs(script):
+        possible_paths.append(os.path.join("scripts", script))
+
+    full_path = next((p for p in possible_paths if os.path.exists(p)), None)
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {possible_paths[-1]}")
         return False
 
-    logging.info(f"🚀 실행 중: {script}")
+    logging.info(f"🚀 실행 중: {full_path}")
     result = subprocess.run([sys.executable, full_path], capture_output=True, text=True)
 
     if result.returncode != 0:


### PR DESCRIPTION
## Summary
- clean up pipeline script names to only include existing scripts
- make `run_script` resolve scripts from repo root or `scripts/` folder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684fc163342883228aec0b49bbdbb263