### PR TITLE
Add ROI analyzer tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Auto Pipeline
+
+This repository contains utility scripts for various automation tasks.
+
+## Running Tests
+
+Tests are written using `pytest`. After installing dependencies, you can run all
+tests from the project root:
+
+```bash
+pytest
+```
+
+`pytest` will automatically discover tests in the `tests/` directory.

--- a/roi_analyzer.py
+++ b/roi_analyzer.py
@@ -1,0 +1,35 @@
+import json
+
+
+def load_specs(path):
+    """Load channel specifications from a JSON file."""
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def compute_roi(spec):
+    """Compute ROI for a single channel spec.
+
+    ROI is defined as (revenue - cost) / cost. If cost is zero, return
+    infinity when revenue is positive, otherwise 0.
+    """
+    cost = spec.get("cost", 0)
+    revenue = spec.get("revenue", 0)
+    if cost == 0:
+        return float("inf") if revenue > 0 else 0
+    return (revenue - cost) / cost
+
+
+def rank_channels(specs):
+    """Rank channels by ROI in descending order.
+
+    Returns a new list of specs including the computed ROI for each
+    channel, sorted from highest ROI to lowest.
+    """
+    specs_with_roi = []
+    for spec in specs:
+        roi = compute_roi(spec)
+        item = spec.copy()
+        item["roi"] = roi
+        specs_with_roi.append(item)
+    return sorted(specs_with_roi, key=lambda x: x["roi"], reverse=True)

--- a/tests/channel_specs.json
+++ b/tests/channel_specs.json
@@ -1,0 +1,5 @@
+[
+  {"channel": "A", "cost": 1000, "revenue": 2000},
+  {"channel": "B", "cost": 2000, "revenue": 3000},
+  {"channel": "C", "cost": 1500, "revenue": 4000}
+]

--- a/tests/test_roi_analyzer.py
+++ b/tests/test_roi_analyzer.py
@@ -1,0 +1,37 @@
+import os
+import json
+import sys
+import pytest
+
+# Ensure the project root is on the import path so tests can find the module
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from roi_analyzer import load_specs, compute_roi, rank_channels
+
+
+def test_load_specs():
+    path = os.path.join(os.path.dirname(__file__), 'channel_specs.json')
+    specs = load_specs(path)
+    assert isinstance(specs, list)
+    assert len(specs) == 3
+    assert specs[0]['channel'] == 'A'
+
+
+def test_compute_roi():
+    spec = {'channel': 'X', 'cost': 100, 'revenue': 250}
+    roi = compute_roi(spec)
+    assert roi == pytest.approx(1.5)
+
+    zero_cost = {'channel': 'Free', 'cost': 0, 'revenue': 10}
+    assert compute_roi(zero_cost) == float('inf')
+
+
+def test_rank_channels():
+    path = os.path.join(os.path.dirname(__file__), 'channel_specs.json')
+    specs = load_specs(path)
+    ranked = rank_channels(specs)
+    # Expect channel C with highest ROI, then A, then B
+    assert [c['channel'] for c in ranked] == ['C', 'A', 'B']
+    # Each item should include computed ROI
+    assert 'roi' in ranked[0]
+


### PR DESCRIPTION
## Summary
- add ROI analyzer module for computing ROI and ranking channels
- create sample specs and unit tests
- document how to run tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684fc1720f008322bad8e571fb6e64f7