### PR TITLE
Fix workflow file name and pipeline path

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()


### PR DESCRIPTION
## Summary
- rename daily pipeline workflow file to `daily-pipeline.yml`
- fix the script path used to run the pipeline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684fc210fcc0832292d21c19ffcb02a4