### PR TITLE
Fix pipeline script references

### DIFF
--- a/.github/workflows/daily-pipeline.yml.txt
+++ b/.github/workflows/daily-pipeline.yml.txt
@@ -32,7 +32,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: ▶️ Run full pipeline (single entrypoint)
-        run: python scripts/run_pipeline.py
+        run: python run_pipeline.py
 
       - name: 📋 Upload failed items (if any)
         if: always()

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -12,21 +12,25 @@ logging.basicConfig(
 
 # ---------------------- 실행할 스크립트 순서 정의 ----------------------
 PIPELINE_SEQUENCE = [
+    "keyword_auto_pipeline.py",
+    "notion_uploader.py",
     "hook_generator.py",
-    "parse_failed_gpt.py",
+    "notion_hook_uploader.py",
     "retry_failed_uploads.py",
-    "notify_retry_result.py",
-    "retry_dashboard_notifier.py"
+    "retry_dashboard_notifier.py",
 ]
 
 # ---------------------- 스크립트 실행 함수 ----------------------
-def run_script(script):
-    full_path = os.path.join("scripts", script)
-    if not os.path.exists(full_path):
-        logging.error(f"❌ 파일이 존재하지 않습니다: {full_path}")
+def run_script(script: str) -> bool:
+    """Execute a Python script located either at repo root or within scripts/"""
+    possible_paths = [script, os.path.join("scripts", script)]
+    full_path = next((p for p in possible_paths if os.path.exists(p)), None)
+
+    if not full_path:
+        logging.error(f"❌ 파일이 존재하지 않습니다: {script}")
         return False
 
-    logging.info(f"🚀 실행 중: {script}")
+    logging.info(f"🚀 실행 중: {full_path}")
     result = subprocess.run([sys.executable, full_path], capture_output=True, text=True)
 
     if result.returncode != 0:


### PR DESCRIPTION
## Summary
- correct the pipeline sequence to only include existing scripts
- resolve scripts from either repo root or `scripts/`
- run pipeline from the correct path in the workflow

## Testing
- `python -m py_compile run_pipeline.py keyword_auto_pipeline.py hook_generator.py notion_hook_uploader.py retry_failed_uploads.py retry_dashboard_notifier.py scripts/notion_uploader.py scripts/retry_failed_uploads.py`


------
https://chatgpt.com/codex/tasks/task_b_684fc211debc8322b6427b472d67bcd9