### PR TITLE
Add platform templates and conversion tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 logs/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Auto_Pipeline
+
+이 프로젝트는 여러 플랫폼에 맞게 콘텐츠를 변환하는 도구를 제공합니다.
+
+## 사용 방법
+1. `content_converter.py` 모듈에서 `convert_content` 함수를 불러옵니다.
+2. 원본 텍스트와 변환할 플랫폼 이름을 인자로 전달합니다.
+3. 지원 플랫폼: `youtube`, `instagram`, `tiktok`, `facebook`, `linkedin`.
+
+```python
+from content_converter import convert_content
+
+text = "원소스 멀티유스 전략으로 수익을 극대화하는 방법\n..."
+yt_script = convert_content(text, "youtube")
+print(yt_script)
+```
+
+새로운 플랫폼 템플릿을 추가하려면 `TEMPLATES` 딕셔너리에 항목을 추가하고 `convert_content`에서 분기 처리를 구현하면 됩니다.

--- a/content_converter.py
+++ b/content_converter.py
@@ -1,0 +1,37 @@
+"""Content conversion utilities for various platforms."""
+
+from datetime import datetime
+
+# 기본 플랫폼 템플릿
+TEMPLATES = {
+    "youtube": "제목: {title}\n\n스크립트:\n안녕하세요, 오늘은 {summary}...\n(영상 요소: {elements})",
+    "instagram": "{summary}\n\n#해시태그: {hashtags}\n(이미지 설명: {image_desc})",
+    "tiktok": "{hook}\n{summary}\n\n{call_to_action}",
+    "facebook": "{summary}\n\n자세히 보기: {link}",
+    "linkedin": "제목: {title}\n{summary}\n\n전문 읽기: {link}",
+}
+
+def convert_content(original_text: str, platform: str) -> str:
+    """Convert original content to a specific platform format."""
+    title = original_text.split('\n')[0]
+    summary = original_text[:100] + "..."
+
+    if platform == "youtube":
+        elements = "시각자료 큐, BGM 큐 등"
+        return TEMPLATES[platform].format(title=title, summary=summary, elements=elements)
+    elif platform == "instagram":
+        hashtags = "#자동화 #콘텐츠 #OSMU"
+        image_desc = "포스트와 관련된 시각 자료 설명"
+        return TEMPLATES[platform].format(summary=summary, hashtags=hashtags, image_desc=image_desc)
+    elif platform == "tiktok":
+        hook = "📣 " + title + " 📣\n"
+        call_to_action = "👉 더 알고 싶다면 댓글을 확인하세요!"
+        return TEMPLATES[platform].format(hook=hook, summary=summary, call_to_action=call_to_action)
+    elif platform == "facebook":
+        link = "https://example.com/full-post"
+        return TEMPLATES[platform].format(summary=summary, link=link)
+    elif platform == "linkedin":
+        link = "https://example.com/full-post"
+        return TEMPLATES[platform].format(title=title, summary=summary, link=link)
+    else:
+        return original_text

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1,0 +1,21 @@
+import unittest
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+from content_converter import convert_content
+
+class TestConversion(unittest.TestCase):
+    def setUp(self):
+        self.text = "테스트 글 제목\n본문 내용이 이어집니다."
+
+    def test_facebook_template(self):
+        result = convert_content(self.text, "facebook")
+        self.assertIn("자세히 보기:", result)
+
+    def test_linkedin_template(self):
+        result = convert_content(self.text, "linkedin")
+        self.assertIn("전문 읽기:", result)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement content conversion module for multiple platforms
- add Facebook and LinkedIn templates
- document converter usage in README
- add tests for new templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684fc27b5a4c832282357140f5111f85